### PR TITLE
feat(e2e): Configure isolated test fixtures and SQLite seeding (#55)

### DIFF
--- a/tests/e2e/fixtures/__tests__/fixtures.test.ts
+++ b/tests/e2e/fixtures/__tests__/fixtures.test.ts
@@ -1,0 +1,178 @@
+/**
+ * @jest-environment node
+ */
+import fs from 'fs'
+import path from 'path'
+
+import {
+  getIsolatedDataDir,
+  setupIsolatedDb,
+  teardownIsolatedDb,
+  seedVideo,
+  seedTranscript,
+  type FixtureContext,
+} from '../index'
+
+describe('getIsolatedDataDir()', () => {
+  it('returns a unique path on each call', () => {
+    const a = getIsolatedDataDir()
+    const b = getIsolatedDataDir()
+    expect(a).not.toBe(b)
+  })
+
+  it('incorporates the worker index when supplied', () => {
+    const dir = getIsolatedDataDir(3)
+    expect(dir).toContain('worker-3-')
+  })
+
+  it('returns a path inside os.tmpdir()', () => {
+    const os = require('os')
+    const dir = getIsolatedDataDir()
+    expect(dir.startsWith(os.tmpdir())).toBe(true)
+  })
+})
+
+describe('setupIsolatedDb() / teardownIsolatedDb()', () => {
+  let ctx: FixtureContext
+
+  beforeEach(() => {
+    jest.resetModules()
+    ctx = setupIsolatedDb()
+  })
+
+  afterEach(() => {
+    teardownIsolatedDb(ctx)
+  })
+
+  it('creates the data directory on disk', () => {
+    expect(fs.existsSync(ctx.dataDir)).toBe(true)
+  })
+
+  it('sets LINGOFLOW_DATA_DIR to the isolated dir', () => {
+    expect(process.env.LINGOFLOW_DATA_DIR).toBe(ctx.dataDir)
+  })
+
+  it('creates the transcripts subdirectory', () => {
+    expect(fs.existsSync(path.join(ctx.dataDir, 'transcripts'))).toBe(true)
+  })
+
+  it('creates the SQLite database file', () => {
+    expect(fs.existsSync(path.join(ctx.dataDir, 'lingoflow.db'))).toBe(true)
+  })
+
+  it('initialises the videos table', () => {
+    const { getDb } = require('../../../../src/lib/db')
+    const db = getDb()
+    const row = db
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='videos'")
+      .get()
+    expect(row).toBeDefined()
+  })
+
+  it('teardown removes the data directory', () => {
+    teardownIsolatedDb(ctx)
+    expect(fs.existsSync(ctx.dataDir)).toBe(false)
+    // Re-create a fresh ctx so afterEach does not fail
+    jest.resetModules()
+    ctx = setupIsolatedDb()
+  })
+
+  it('teardown restores LINGOFLOW_DATA_DIR', () => {
+    const before = ctx.originalEnv
+    teardownIsolatedDb(ctx)
+    expect(process.env.LINGOFLOW_DATA_DIR).toBe(before)
+    // Re-create a fresh ctx so afterEach does not fail
+    jest.resetModules()
+    ctx = setupIsolatedDb()
+  })
+
+  it('two consecutive runs do not share state', () => {
+    const { getDb } = require('../../../../src/lib/db')
+    getDb()
+      .prepare(
+        `INSERT INTO videos (id,youtube_url,youtube_id,title,author_name,thumbnail_url,transcript_path,transcript_format,tags)
+         VALUES ('v1','u','yi','t','a','th','tp','txt','[]')`
+      )
+      .run()
+
+    teardownIsolatedDb(ctx)
+    jest.resetModules()
+    ctx = setupIsolatedDb()
+
+    const { getDb: getDb2 } = require('../../../../src/lib/db')
+    const count = getDb2()
+      .prepare('SELECT COUNT(*) as c FROM videos')
+      .get() as { c: number }
+    expect(count.c).toBe(0)
+  })
+})
+
+describe('seedVideo()', () => {
+  let ctx: FixtureContext
+
+  beforeEach(() => {
+    jest.resetModules()
+    ctx = setupIsolatedDb()
+  })
+
+  afterEach(() => {
+    teardownIsolatedDb(ctx)
+  })
+
+  it('inserts a video and returns it', () => {
+    const video = seedVideo({ title: 'My Video', youtube_id: 'abc123' })
+    expect(video).toBeDefined()
+    expect(video.title).toBe('My Video')
+    expect(video.youtube_id).toBe('abc123')
+  })
+
+  it('works with all defaults (no params)', () => {
+    const video = seedVideo()
+    expect(video.id).toBeTruthy()
+    expect(video.tags).toEqual([])
+  })
+
+  it('persists the record in the database', () => {
+    const inserted = seedVideo({ title: 'Persisted' })
+    const { getVideoById } = require('../../../../src/lib/videos')
+    const fetched = getVideoById(inserted.id)
+    expect(fetched).toBeDefined()
+    expect(fetched!.title).toBe('Persisted')
+  })
+
+  it('accepts custom tags', () => {
+    const video = seedVideo({ tags: ['tag1', 'tag2'] })
+    expect(video.tags).toEqual(['tag1', 'tag2'])
+  })
+})
+
+describe('seedTranscript()', () => {
+  let ctx: FixtureContext
+
+  beforeEach(() => {
+    jest.resetModules()
+    ctx = setupIsolatedDb()
+  })
+
+  afterEach(() => {
+    teardownIsolatedDb(ctx)
+  })
+
+  it('writes a transcript file and returns its path', () => {
+    const filePath = seedTranscript('video1', 'txt', 'hello world')
+    expect(fs.existsSync(filePath)).toBe(true)
+    expect(fs.readFileSync(filePath, 'utf8')).toBe('hello world')
+  })
+
+  it('places the file inside the isolated transcripts dir', () => {
+    const filePath = seedTranscript('video2', 'vtt', 'subtitle content')
+    expect(filePath.startsWith(path.join(ctx.dataDir, 'transcripts'))).toBe(true)
+  })
+
+  it('supports different file extensions', () => {
+    const pathSrt = seedTranscript('v3', 'srt', 'srt content')
+    const pathVtt = seedTranscript('v3', 'vtt', 'vtt content')
+    expect(pathSrt.endsWith('.srt')).toBe(true)
+    expect(pathVtt.endsWith('.vtt')).toBe(true)
+  })
+})

--- a/tests/e2e/fixtures/index.ts
+++ b/tests/e2e/fixtures/index.ts
@@ -1,0 +1,116 @@
+/**
+ * E2E test fixtures: isolated LINGOFLOW_DATA_DIR provisioning, SQLite schema
+ * initialization, and seeding utilities.
+ *
+ * Usage:
+ *   const ctx = setupIsolatedDb()
+ *   // ... use ctx.dataDir, seedVideo(), seedTranscript() ...
+ *   teardownIsolatedDb(ctx)
+ */
+
+import crypto from 'crypto'
+import fs from 'fs'
+import path from 'path'
+import os from 'os'
+
+export interface FixtureContext {
+  dataDir: string
+  /** Original value of LINGOFLOW_DATA_DIR (may be undefined) */
+  originalEnv: string | undefined
+}
+
+/**
+ * Returns a unique data directory path (not yet created).
+ * Callers can optionally pass a Playwright worker index to make the name
+ * more deterministic for debugging.
+ */
+export function getIsolatedDataDir(workerIndex?: number): string {
+  const suffix = workerIndex !== undefined
+    ? `worker-${workerIndex}-${crypto.randomUUID()}`
+    : crypto.randomUUID()
+  return path.join(os.tmpdir(), `lingoflow-e2e-${suffix}`)
+}
+
+/**
+ * Creates an isolated data dir, sets LINGOFLOW_DATA_DIR, and initialises the
+ * SQLite schema by calling getDb().  Returns a context object that must be
+ * passed to teardownIsolatedDb() afterwards.
+ *
+ * IMPORTANT: call jest.resetModules() (or equivalent) before this if you need
+ * a fresh db singleton; in Playwright each worker process is isolated by default.
+ */
+export function setupIsolatedDb(workerIndex?: number): FixtureContext {
+  const dataDir = getIsolatedDataDir(workerIndex)
+  fs.mkdirSync(dataDir, { recursive: true })
+
+  const originalEnv = process.env.LINGOFLOW_DATA_DIR
+  process.env.LINGOFLOW_DATA_DIR = dataDir
+
+  // Initialise schema (creates tables, WAL mode, transcripts subdir)
+  const { getDb } = require('../../../src/lib/db')
+  getDb()
+
+  return { dataDir, originalEnv }
+}
+
+/**
+ * Closes the db singleton, removes the isolated data dir, and restores
+ * LINGOFLOW_DATA_DIR to its previous value.
+ */
+export function teardownIsolatedDb(ctx: FixtureContext): void {
+  const { _resetDbInstance } = require('../../../src/lib/db')
+  _resetDbInstance()
+
+  if (ctx.originalEnv === undefined) {
+    delete process.env.LINGOFLOW_DATA_DIR
+  } else {
+    process.env.LINGOFLOW_DATA_DIR = ctx.originalEnv
+  }
+
+  fs.rmSync(ctx.dataDir, { recursive: true, force: true })
+}
+
+// ---------------------------------------------------------------------------
+// Seeding helpers
+// ---------------------------------------------------------------------------
+
+export interface SeedVideoParams {
+  id?: string
+  youtube_url?: string
+  youtube_id?: string
+  title?: string
+  author_name?: string
+  thumbnail_url?: string
+  transcript_path?: string
+  transcript_format?: string
+  tags?: string[]
+}
+
+/**
+ * Inserts a video record into the isolated DB.  All fields have sensible
+ * defaults so callers only need to supply what they care about.
+ */
+export function seedVideo(params: SeedVideoParams = {}) {
+  const id = params.id ?? crypto.randomUUID()
+  const { insertVideo } = require('../../../src/lib/videos')
+  return insertVideo({
+    id,
+    youtube_url: params.youtube_url ?? `https://www.youtube.com/watch?v=${id}`,
+    youtube_id: params.youtube_id ?? id,
+    title: params.title ?? `Test Video ${id}`,
+    author_name: params.author_name ?? 'Test Author',
+    thumbnail_url: params.thumbnail_url ?? `https://img.youtube.com/vi/${id}/0.jpg`,
+    transcript_path: params.transcript_path ?? `transcripts/${id}.txt`,
+    transcript_format: params.transcript_format ?? 'txt',
+    tags: params.tags ?? [],
+  })
+}
+
+/**
+ * Writes a transcript file into `$LINGOFLOW_DATA_DIR/transcripts/`.
+ * Returns the absolute path of the written file.
+ */
+export function seedTranscript(videoId: string, ext: string, content: string): string {
+  const { writeTranscript } = require('../../../src/lib/transcripts')
+  return writeTranscript(videoId, ext, Buffer.from(content, 'utf8'))
+}


### PR DESCRIPTION
## Summary

Implements issue #55 — E2E test fixture utilities for isolated, zero-contamination test runs.

## Changes

### `tests/e2e/fixtures/index.ts`
- **`getIsolatedDataDir(workerIndex?)`** — returns a unique `os.tmpdir()/lingoflow-e2e-<uuid>` path per call (worker index optionally embedded for debuggability)
- **`setupIsolatedDb()`** — creates the isolated data dir, sets `LINGOFLOW_DATA_DIR`, calls `getDb()` to initialise the full SQLite schema (tables + WAL mode + transcripts subdir). Returns a `FixtureContext` for teardown.
- **`teardownIsolatedDb(ctx)`** — calls `_resetDbInstance()`, removes the data dir, restores `LINGOFLOW_DATA_DIR`
- **`seedVideo(params)`** — wraps `insertVideo()` with sensible defaults; all fields optional
- **`seedTranscript(videoId, ext, content)`** — wraps `writeTranscript()` to write content into the isolated `transcripts/` subdir

### `tests/e2e/fixtures/__tests__/fixtures.test.ts`
18 Jest unit tests covering:
- Uniqueness and structure of isolated dirs
- Schema initialisation (tables, transcripts dir, WAL db file)
- Teardown cleanup and env restoration
- Zero state contamination across consecutive runs
- `seedVideo` defaults, field overrides, persistence
- `seedTranscript` content, path placement, extension handling

## Test Results
```
Tests: 18 passed, 18 total (fixtures suite)
Build: ✓ Next.js build passes
```

Closes #55