### PR TITLE
feat(e2e): dashboard page object helpers (issue #58)

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "react-dom": "19.2.4"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,7 @@ importers:
         version: 12.8.0
       next:
         specifier: 16.2.3
-        version: 16.2.3(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 16.2.3(@babel/core@7.29.0)(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react:
         specifier: 19.2.4
         version: 19.2.4
@@ -24,6 +24,9 @@ importers:
         specifier: 19.2.4
         version: 19.2.4(react@19.2.4)
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.59.1
+        version: 1.59.1
       '@testing-library/dom':
         specifier: ^10.4.1
         version: 10.4.1
@@ -699,6 +702,11 @@ packages:
   '@pkgr/core@0.2.9':
     resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
+
+  '@playwright/test@1.59.1':
+    resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
@@ -1654,6 +1662,11 @@ packages:
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2480,6 +2493,16 @@ packages:
   pkg-dir@4.2.0:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
     engines: {node: '>=8'}
+
+  playwright-core@1.59.1:
+    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.59.1:
+    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -3786,6 +3809,10 @@ snapshots:
 
   '@pkgr/core@0.2.9': {}
 
+  '@playwright/test@1.59.1':
+    dependencies:
+      playwright: 1.59.1
+
   '@rtsao/scc@1.1.0': {}
 
   '@sinclair/typebox@0.34.49': {}
@@ -4905,6 +4932,9 @@ snapshots:
 
   fs.realpath@1.0.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -5752,7 +5782,7 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  next@16.2.3(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  next@16.2.3(@babel/core@7.29.0)(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@next/env': 16.2.3
       '@swc/helpers': 0.5.15
@@ -5771,6 +5801,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.2.3
       '@next/swc-win32-arm64-msvc': 16.2.3
       '@next/swc-win32-x64-msvc': 16.2.3
+      '@playwright/test': 1.59.1
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -5923,6 +5954,14 @@ snapshots:
   pkg-dir@4.2.0:
     dependencies:
       find-up: 4.1.0
+
+  playwright-core@1.59.1: {}
+
+  playwright@1.59.1:
+    dependencies:
+      playwright-core: 1.59.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   possible-typed-array-names@1.1.0: {}
 

--- a/src/components/EditVideoModal.tsx
+++ b/src/components/EditVideoModal.tsx
@@ -92,6 +92,7 @@ export default function EditVideoModal({ video, onClose, onSave }: EditVideoModa
       </div>
 
       <input
+        data-testid="tag-input"
         type="text"
         value={tagInput}
         onChange={(e) => setTagInput(e.target.value)}

--- a/src/components/ImportVideoModal.tsx
+++ b/src/components/ImportVideoModal.tsx
@@ -123,7 +123,7 @@ export default function ImportVideoModal({ isOpen, onClose, onSuccess }: ImportV
   const canSubmit = !isSubmitting && !isLoadingPreview && !previewError && !!transcriptFile && youtubeUrl.trim()
 
   return (
-    <div className="modal-overlay" onClick={onClose}>
+    <div data-testid="import-modal" className="modal-overlay" onClick={onClose}>
       <div className="modal-content" onClick={(e) => e.stopPropagation()}>
         <div className="modal-header">
           <h2>Import Video</h2>
@@ -133,12 +133,13 @@ export default function ImportVideoModal({ isOpen, onClose, onSuccess }: ImportV
         </div>
 
         <form onSubmit={handleSubmit} className="import-form">
-          {submitError && <div className="error-message">{submitError}</div>}
+          {submitError && <div data-testid="import-error" className="error-message">{submitError}</div>}
 
           <div className="form-field">
             <label htmlFor="youtubeUrl">YouTube URL</label>
             <input
               id="youtubeUrl"
+              data-testid="youtube-url-input"
               type="text"
               placeholder="https://www.youtube.com/watch?v=..."
               value={youtubeUrl}
@@ -165,6 +166,7 @@ export default function ImportVideoModal({ isOpen, onClose, onSuccess }: ImportV
             <label htmlFor="transcript">Transcript File</label>
             <input
               id="transcript"
+              data-testid="transcript-input"
               type="file"
               accept=".srt,.vtt,.txt"
               onChange={(e) => setTranscriptFile(e.target.files?.[0] || null)}
@@ -178,6 +180,7 @@ export default function ImportVideoModal({ isOpen, onClose, onSuccess }: ImportV
             <label htmlFor="tags">Tags (comma-separated)</label>
             <input
               id="tags"
+              data-testid="tags-input"
               type="text"
               placeholder="e.g., spanish, beginner, news"
               value={tags}
@@ -190,7 +193,7 @@ export default function ImportVideoModal({ isOpen, onClose, onSuccess }: ImportV
             <button type="button" onClick={onClose} disabled={isSubmitting}>
               Cancel
             </button>
-            <button type="submit" disabled={!canSubmit}>
+            <button data-testid="submit-import-button" type="submit" disabled={!canSubmit}>
               {isSubmitting ? 'Importing...' : 'Import Video'}
             </button>
           </div>

--- a/tests/e2e/fixtures/__tests__/fixtures.test.ts
+++ b/tests/e2e/fixtures/__tests__/fixtures.test.ts
@@ -1,0 +1,178 @@
+/**
+ * @jest-environment node
+ */
+import fs from 'fs'
+import path from 'path'
+
+import {
+  getIsolatedDataDir,
+  setupIsolatedDb,
+  teardownIsolatedDb,
+  seedVideo,
+  seedTranscript,
+  type FixtureContext,
+} from '../index'
+
+describe('getIsolatedDataDir()', () => {
+  it('returns a unique path on each call', () => {
+    const a = getIsolatedDataDir()
+    const b = getIsolatedDataDir()
+    expect(a).not.toBe(b)
+  })
+
+  it('incorporates the worker index when supplied', () => {
+    const dir = getIsolatedDataDir(3)
+    expect(dir).toContain('worker-3-')
+  })
+
+  it('returns a path inside os.tmpdir()', () => {
+    const os = require('os')
+    const dir = getIsolatedDataDir()
+    expect(dir.startsWith(os.tmpdir())).toBe(true)
+  })
+})
+
+describe('setupIsolatedDb() / teardownIsolatedDb()', () => {
+  let ctx: FixtureContext
+
+  beforeEach(() => {
+    jest.resetModules()
+    ctx = setupIsolatedDb()
+  })
+
+  afterEach(() => {
+    teardownIsolatedDb(ctx)
+  })
+
+  it('creates the data directory on disk', () => {
+    expect(fs.existsSync(ctx.dataDir)).toBe(true)
+  })
+
+  it('sets LINGOFLOW_DATA_DIR to the isolated dir', () => {
+    expect(process.env.LINGOFLOW_DATA_DIR).toBe(ctx.dataDir)
+  })
+
+  it('creates the transcripts subdirectory', () => {
+    expect(fs.existsSync(path.join(ctx.dataDir, 'transcripts'))).toBe(true)
+  })
+
+  it('creates the SQLite database file', () => {
+    expect(fs.existsSync(path.join(ctx.dataDir, 'lingoflow.db'))).toBe(true)
+  })
+
+  it('initialises the videos table', () => {
+    const { getDb } = require('../../../../src/lib/db')
+    const db = getDb()
+    const row = db
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='videos'")
+      .get()
+    expect(row).toBeDefined()
+  })
+
+  it('teardown removes the data directory', () => {
+    teardownIsolatedDb(ctx)
+    expect(fs.existsSync(ctx.dataDir)).toBe(false)
+    // Re-create a fresh ctx so afterEach does not fail
+    jest.resetModules()
+    ctx = setupIsolatedDb()
+  })
+
+  it('teardown restores LINGOFLOW_DATA_DIR', () => {
+    const before = ctx.originalEnv
+    teardownIsolatedDb(ctx)
+    expect(process.env.LINGOFLOW_DATA_DIR).toBe(before)
+    // Re-create a fresh ctx so afterEach does not fail
+    jest.resetModules()
+    ctx = setupIsolatedDb()
+  })
+
+  it('two consecutive runs do not share state', () => {
+    const { getDb } = require('../../../../src/lib/db')
+    getDb()
+      .prepare(
+        `INSERT INTO videos (id,youtube_url,youtube_id,title,author_name,thumbnail_url,transcript_path,transcript_format,tags)
+         VALUES ('v1','u','yi','t','a','th','tp','txt','[]')`
+      )
+      .run()
+
+    teardownIsolatedDb(ctx)
+    jest.resetModules()
+    ctx = setupIsolatedDb()
+
+    const { getDb: getDb2 } = require('../../../../src/lib/db')
+    const count = getDb2()
+      .prepare('SELECT COUNT(*) as c FROM videos')
+      .get() as { c: number }
+    expect(count.c).toBe(0)
+  })
+})
+
+describe('seedVideo()', () => {
+  let ctx: FixtureContext
+
+  beforeEach(() => {
+    jest.resetModules()
+    ctx = setupIsolatedDb()
+  })
+
+  afterEach(() => {
+    teardownIsolatedDb(ctx)
+  })
+
+  it('inserts a video and returns it', () => {
+    const video = seedVideo({ title: 'My Video', youtube_id: 'abc123' })
+    expect(video).toBeDefined()
+    expect(video.title).toBe('My Video')
+    expect(video.youtube_id).toBe('abc123')
+  })
+
+  it('works with all defaults (no params)', () => {
+    const video = seedVideo()
+    expect(video.id).toBeTruthy()
+    expect(video.tags).toEqual([])
+  })
+
+  it('persists the record in the database', () => {
+    const inserted = seedVideo({ title: 'Persisted' })
+    const { getVideoById } = require('../../../../src/lib/videos')
+    const fetched = getVideoById(inserted.id)
+    expect(fetched).toBeDefined()
+    expect(fetched!.title).toBe('Persisted')
+  })
+
+  it('accepts custom tags', () => {
+    const video = seedVideo({ tags: ['tag1', 'tag2'] })
+    expect(video.tags).toEqual(['tag1', 'tag2'])
+  })
+})
+
+describe('seedTranscript()', () => {
+  let ctx: FixtureContext
+
+  beforeEach(() => {
+    jest.resetModules()
+    ctx = setupIsolatedDb()
+  })
+
+  afterEach(() => {
+    teardownIsolatedDb(ctx)
+  })
+
+  it('writes a transcript file and returns its path', () => {
+    const filePath = seedTranscript('video1', 'txt', 'hello world')
+    expect(fs.existsSync(filePath)).toBe(true)
+    expect(fs.readFileSync(filePath, 'utf8')).toBe('hello world')
+  })
+
+  it('places the file inside the isolated transcripts dir', () => {
+    const filePath = seedTranscript('video2', 'vtt', 'subtitle content')
+    expect(filePath.startsWith(path.join(ctx.dataDir, 'transcripts'))).toBe(true)
+  })
+
+  it('supports different file extensions', () => {
+    const pathSrt = seedTranscript('v3', 'srt', 'srt content')
+    const pathVtt = seedTranscript('v3', 'vtt', 'vtt content')
+    expect(pathSrt.endsWith('.srt')).toBe(true)
+    expect(pathVtt.endsWith('.vtt')).toBe(true)
+  })
+})

--- a/tests/e2e/fixtures/index.ts
+++ b/tests/e2e/fixtures/index.ts
@@ -1,0 +1,116 @@
+/**
+ * E2E test fixtures: isolated LINGOFLOW_DATA_DIR provisioning, SQLite schema
+ * initialization, and seeding utilities.
+ *
+ * Usage:
+ *   const ctx = setupIsolatedDb()
+ *   // ... use ctx.dataDir, seedVideo(), seedTranscript() ...
+ *   teardownIsolatedDb(ctx)
+ */
+
+import crypto from 'crypto'
+import fs from 'fs'
+import path from 'path'
+import os from 'os'
+
+export interface FixtureContext {
+  dataDir: string
+  /** Original value of LINGOFLOW_DATA_DIR (may be undefined) */
+  originalEnv: string | undefined
+}
+
+/**
+ * Returns a unique data directory path (not yet created).
+ * Callers can optionally pass a Playwright worker index to make the name
+ * more deterministic for debugging.
+ */
+export function getIsolatedDataDir(workerIndex?: number): string {
+  const suffix = workerIndex !== undefined
+    ? `worker-${workerIndex}-${crypto.randomUUID()}`
+    : crypto.randomUUID()
+  return path.join(os.tmpdir(), `lingoflow-e2e-${suffix}`)
+}
+
+/**
+ * Creates an isolated data dir, sets LINGOFLOW_DATA_DIR, and initialises the
+ * SQLite schema by calling getDb().  Returns a context object that must be
+ * passed to teardownIsolatedDb() afterwards.
+ *
+ * IMPORTANT: call jest.resetModules() (or equivalent) before this if you need
+ * a fresh db singleton; in Playwright each worker process is isolated by default.
+ */
+export function setupIsolatedDb(workerIndex?: number): FixtureContext {
+  const dataDir = getIsolatedDataDir(workerIndex)
+  fs.mkdirSync(dataDir, { recursive: true })
+
+  const originalEnv = process.env.LINGOFLOW_DATA_DIR
+  process.env.LINGOFLOW_DATA_DIR = dataDir
+
+  // Initialise schema (creates tables, WAL mode, transcripts subdir)
+  const { getDb } = require('../../../src/lib/db')
+  getDb()
+
+  return { dataDir, originalEnv }
+}
+
+/**
+ * Closes the db singleton, removes the isolated data dir, and restores
+ * LINGOFLOW_DATA_DIR to its previous value.
+ */
+export function teardownIsolatedDb(ctx: FixtureContext): void {
+  const { _resetDbInstance } = require('../../../src/lib/db')
+  _resetDbInstance()
+
+  if (ctx.originalEnv === undefined) {
+    delete process.env.LINGOFLOW_DATA_DIR
+  } else {
+    process.env.LINGOFLOW_DATA_DIR = ctx.originalEnv
+  }
+
+  fs.rmSync(ctx.dataDir, { recursive: true, force: true })
+}
+
+// ---------------------------------------------------------------------------
+// Seeding helpers
+// ---------------------------------------------------------------------------
+
+export interface SeedVideoParams {
+  id?: string
+  youtube_url?: string
+  youtube_id?: string
+  title?: string
+  author_name?: string
+  thumbnail_url?: string
+  transcript_path?: string
+  transcript_format?: string
+  tags?: string[]
+}
+
+/**
+ * Inserts a video record into the isolated DB.  All fields have sensible
+ * defaults so callers only need to supply what they care about.
+ */
+export function seedVideo(params: SeedVideoParams = {}) {
+  const id = params.id ?? crypto.randomUUID()
+  const { insertVideo } = require('../../../src/lib/videos')
+  return insertVideo({
+    id,
+    youtube_url: params.youtube_url ?? `https://www.youtube.com/watch?v=${id}`,
+    youtube_id: params.youtube_id ?? id,
+    title: params.title ?? `Test Video ${id}`,
+    author_name: params.author_name ?? 'Test Author',
+    thumbnail_url: params.thumbnail_url ?? `https://img.youtube.com/vi/${id}/0.jpg`,
+    transcript_path: params.transcript_path ?? `transcripts/${id}.txt`,
+    transcript_format: params.transcript_format ?? 'txt',
+    tags: params.tags ?? [],
+  })
+}
+
+/**
+ * Writes a transcript file into `$LINGOFLOW_DATA_DIR/transcripts/`.
+ * Returns the absolute path of the written file.
+ */
+export function seedTranscript(videoId: string, ext: string, content: string): string {
+  const { writeTranscript } = require('../../../src/lib/transcripts')
+  return writeTranscript(videoId, ext, Buffer.from(content, 'utf8'))
+}

--- a/tests/e2e/pages/DashboardPage.ts
+++ b/tests/e2e/pages/DashboardPage.ts
@@ -1,0 +1,53 @@
+/**
+ * DashboardPage: page-object for the lingoFlow dashboard route.
+ *
+ * Encapsulates all interactions with the main dashboard view,
+ * including navigation, loading/empty state assertions, and
+ * the video-card grid.
+ *
+ * Usage:
+ *   const dashboard = new DashboardPage(page)
+ *   await dashboard.loadDashboard()
+ *   await dashboard.assertEmpty()
+ */
+
+import type { Page, Locator } from '@playwright/test'
+
+export class DashboardPage {
+  readonly page: Page
+
+  constructor(page: Page) {
+    this.page = page
+  }
+
+  /** Navigates to the dashboard and waits for the network to be idle. */
+  async loadDashboard(): Promise<void> {
+    await this.page.goto('/dashboard', { waitUntil: 'networkidle' })
+  }
+
+  /** Asserts that the loading indicator is visible. */
+  async assertLoading(): Promise<void> {
+    await this.page.getByTestId('loading-indicator').waitFor({ state: 'visible' })
+  }
+
+  /** Asserts that the empty-state placeholder is visible (no videos imported). */
+  async assertEmpty(): Promise<void> {
+    await this.page.getByTestId('empty-state').waitFor({ state: 'visible' })
+  }
+
+  /**
+   * Returns all video-card locators currently rendered in the grid.
+   * Waits for the grid to be present before querying cards.
+   */
+  async getVideoCards(): Promise<Locator[]> {
+    const grid = this.page.getByTestId('video-grid')
+    await grid.waitFor({ state: 'visible' })
+    return grid.locator('[data-testid^="video-card-"]').all()
+  }
+
+  /** Returns the number of video cards currently visible in the grid. */
+  async getVideoCardCount(): Promise<number> {
+    const cards = await this.getVideoCards()
+    return cards.length
+  }
+}

--- a/tests/e2e/pages/DeleteActions.ts
+++ b/tests/e2e/pages/DeleteActions.ts
@@ -1,0 +1,51 @@
+/**
+ * DeleteActions: page-object for the DeleteVideoModal interactions.
+ *
+ * Encapsulates the actions a user performs when deleting a video,
+ * including triggering the delete flow from a specific card and
+ * confirming the deletion.
+ *
+ * Usage:
+ *   const deleteActions = new DeleteActions(page)
+ *   await deleteActions.clickDeleteOnCard(0)
+ *   await deleteActions.confirmDelete()
+ *   await deleteActions.assertCardRemoved('video-id-123')
+ */
+
+import type { Page } from '@playwright/test'
+
+export class DeleteActions {
+  readonly page: Page
+
+  constructor(page: Page) {
+    this.page = page
+  }
+
+  /**
+   * Clicks the delete button on the video card at the given zero-based index.
+   * Waits for the delete confirmation modal to appear.
+   * @param index - Zero-based index of the card in the video grid.
+   */
+  async clickDeleteOnCard(index: number): Promise<void> {
+    const deleteButtons = await this.page
+      .getByTestId('video-grid')
+      .locator('[data-testid="delete-button"]')
+      .all()
+    await deleteButtons[index].click()
+    await this.page.getByTestId('delete-modal').waitFor({ state: 'visible' })
+  }
+
+  /** Clicks the confirm-delete button and waits for the modal to close. */
+  async confirmDelete(): Promise<void> {
+    await this.page.getByTestId('confirm-delete-button').click()
+    await this.page.getByTestId('delete-modal').waitFor({ state: 'hidden' })
+  }
+
+  /**
+   * Asserts that the video card with the given ID is no longer in the DOM.
+   * @param videoId - The video ID used in the `video-card-{id}` testid.
+   */
+  async assertCardRemoved(videoId: string): Promise<void> {
+    await this.page.getByTestId(`video-card-${videoId}`).waitFor({ state: 'hidden' })
+  }
+}

--- a/tests/e2e/pages/EditActions.ts
+++ b/tests/e2e/pages/EditActions.ts
@@ -1,0 +1,76 @@
+/**
+ * EditActions: page-object for the EditVideoModal interactions.
+ *
+ * Encapsulates the actions a user performs inside the Edit Video modal,
+ * including opening the modal from a specific card, managing tags, and
+ * saving changes.
+ *
+ * Usage:
+ *   const editActions = new EditActions(page)
+ *   await editActions.clickEditOnCard(0)
+ *   await editActions.addTag('newTag')
+ *   await editActions.removeTag('oldTag')
+ *   await editActions.clickSave()
+ *   await editActions.assertTagsSaved(['newTag'])
+ */
+
+import type { Page } from '@playwright/test'
+
+export class EditActions {
+  readonly page: Page
+
+  constructor(page: Page) {
+    this.page = page
+  }
+
+  /**
+   * Clicks the edit button on the video card at the given zero-based index.
+   * Waits for the edit modal to appear after clicking.
+   * @param index - Zero-based index of the card in the video grid.
+   */
+  async clickEditOnCard(index: number): Promise<void> {
+    const editButtons = await this.page
+      .getByTestId('video-grid')
+      .locator('[data-testid="edit-button"]')
+      .all()
+    await editButtons[index].click()
+    await this.page.getByTestId('edit-modal').waitFor({ state: 'visible' })
+  }
+
+  /**
+   * Types a new tag into the tag input and presses Enter to add it.
+   * @param tag - The tag text to add.
+   */
+  async addTag(tag: string): Promise<void> {
+    const tagInput = this.page.getByTestId('tag-input')
+    await tagInput.fill(tag)
+    await tagInput.press('Enter')
+  }
+
+  /**
+   * Removes an existing tag by clicking its remove button.
+   * @param tagName - The exact tag text to remove.
+   */
+  async removeTag(tagName: string): Promise<void> {
+    await this.page.getByTestId(`remove-tag-${tagName}`).click()
+  }
+
+  /** Clicks the Save button in the edit modal and waits for the modal to close. */
+  async clickSave(): Promise<void> {
+    await this.page.getByTestId('edit-modal').getByRole('button', { name: 'Save' }).click()
+    await this.page.getByTestId('edit-modal').waitFor({ state: 'hidden' })
+  }
+
+  /**
+   * Asserts that the expected tags are displayed on the last-edited card.
+   * Navigates through the tag pills visible in the edit modal before saving;
+   * call this before clickSave() if you need to inspect the in-modal state,
+   * or after a page reload to verify persistence.
+   * @param expectedTags - Array of tag strings that should all be visible.
+   */
+  async assertTagsSaved(expectedTags: string[]): Promise<void> {
+    for (const tag of expectedTags) {
+      await this.page.getByText(tag).waitFor({ state: 'visible' })
+    }
+  }
+}

--- a/tests/e2e/pages/ImportActions.ts
+++ b/tests/e2e/pages/ImportActions.ts
@@ -1,0 +1,67 @@
+/**
+ * ImportActions: page-object for the ImportVideoModal interactions.
+ *
+ * Encapsulates the actions a user performs inside the Import Video modal,
+ * including opening the modal, filling form fields, and asserting on
+ * validation errors.
+ *
+ * Usage:
+ *   const importActions = new ImportActions(page)
+ *   await importActions.clickImportButton()
+ *   await importActions.fillYoutubeUrl('https://www.youtube.com/watch?v=abc')
+ *   await importActions.fillTags('spanish, beginner')
+ *   await importActions.clickSubmitImport()
+ */
+
+import type { Page } from '@playwright/test'
+
+export class ImportActions {
+  readonly page: Page
+
+  constructor(page: Page) {
+    this.page = page
+  }
+
+  /** Clicks the "Import Video" button on the dashboard to open the modal. */
+  async clickImportButton(): Promise<void> {
+    await this.page.getByTestId('import-modal').waitFor({ state: 'hidden' }).catch(() => {})
+    await this.page.getByRole('button', { name: 'Import Video' }).click()
+    await this.page.getByTestId('import-modal').waitFor({ state: 'visible' })
+  }
+
+  /** Fills the YouTube URL field in the import modal. */
+  async fillYoutubeUrl(url: string): Promise<void> {
+    await this.page.getByTestId('youtube-url-input').fill(url)
+  }
+
+  /**
+   * Sets the transcript file input using the provided file path.
+   * @param filePath - Absolute or project-relative path to the transcript file.
+   */
+  async fillTranscriptFile(filePath: string): Promise<void> {
+    await this.page.getByTestId('transcript-input').setInputFiles(filePath)
+  }
+
+  /** Fills the tags field in the import modal (comma-separated string). */
+  async fillTags(tags: string): Promise<void> {
+    await this.page.getByTestId('tags-input').fill(tags)
+  }
+
+  /** Clicks the submit button to trigger the import. */
+  async clickSubmitImport(): Promise<void> {
+    await this.page.getByTestId('submit-import-button').click()
+  }
+
+  /**
+   * Asserts that an import validation error is visible and optionally
+   * contains the given message text.
+   * @param message - Optional substring to match within the error message.
+   */
+  async assertValidationError(message?: string): Promise<void> {
+    const errorLocator = this.page.getByTestId('import-error')
+    await errorLocator.waitFor({ state: 'visible' })
+    if (message !== undefined) {
+      await errorLocator.filter({ hasText: message }).waitFor({ state: 'visible' })
+    }
+  }
+}

--- a/tests/e2e/pages/__tests__/DashboardPage.test.ts
+++ b/tests/e2e/pages/__tests__/DashboardPage.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Unit tests for DashboardPage page-object.
+ * Mocks the Playwright Page API and verifies that selector calls match
+ * the expected data-testid attributes.
+ */
+
+import { DashboardPage } from '../DashboardPage'
+
+/** Minimal mock for a Playwright Locator */
+function makeLocator(overrides: Partial<Record<string, jest.Mock>> = {}) {
+  const locator: Record<string, jest.Mock> = {
+    waitFor: jest.fn().mockResolvedValue(undefined),
+    all: jest.fn().mockResolvedValue([]),
+    locator: jest.fn(),
+    ...overrides,
+  }
+  // chainable locator()
+  locator.locator.mockReturnValue(locator)
+  return locator
+}
+
+/** Builds a minimal Playwright Page mock */
+function makePage() {
+  const locator = makeLocator()
+  const page = {
+    goto: jest.fn().mockResolvedValue(undefined),
+    getByTestId: jest.fn().mockReturnValue(locator),
+    getByRole: jest.fn().mockReturnValue(locator),
+  }
+  return { page, locator }
+}
+
+describe('DashboardPage', () => {
+  it('loadDashboard() navigates to /dashboard with networkidle', async () => {
+    const { page } = makePage()
+    const dashboard = new DashboardPage(page as any)
+    await dashboard.loadDashboard()
+    expect(page.goto).toHaveBeenCalledWith('/dashboard', { waitUntil: 'networkidle' })
+  })
+
+  it('assertLoading() waits for loading-indicator to be visible', async () => {
+    const { page, locator } = makePage()
+    const dashboard = new DashboardPage(page as any)
+    await dashboard.assertLoading()
+    expect(page.getByTestId).toHaveBeenCalledWith('loading-indicator')
+    expect(locator.waitFor).toHaveBeenCalledWith({ state: 'visible' })
+  })
+
+  it('assertEmpty() waits for empty-state to be visible', async () => {
+    const { page, locator } = makePage()
+    const dashboard = new DashboardPage(page as any)
+    await dashboard.assertEmpty()
+    expect(page.getByTestId).toHaveBeenCalledWith('empty-state')
+    expect(locator.waitFor).toHaveBeenCalledWith({ state: 'visible' })
+  })
+
+  it('getVideoCards() queries video-grid and card locators', async () => {
+    const cards = [{}, {}, {}]
+    const cardLocator = makeLocator()
+    cardLocator.all.mockResolvedValue(cards)
+
+    const gridLocator = makeLocator()
+    gridLocator.locator.mockReturnValue(cardLocator) // override default chaining
+
+    const page = {
+      goto: jest.fn(),
+      getByTestId: jest.fn().mockReturnValue(gridLocator),
+      getByRole: jest.fn(),
+    }
+    const dashboard = new DashboardPage(page as any)
+    const result = await dashboard.getVideoCards()
+    expect(page.getByTestId).toHaveBeenCalledWith('video-grid')
+    expect(gridLocator.locator).toHaveBeenCalledWith('[data-testid^="video-card-"]')
+    expect(result).toHaveLength(3)
+  })
+
+  it('getVideoCardCount() returns the count of video cards', async () => {
+    const cardLocator = makeLocator()
+    cardLocator.all.mockResolvedValue([{}, {}])
+
+    const gridLocator = makeLocator()
+    gridLocator.locator.mockReturnValue(cardLocator)
+
+    const page = {
+      goto: jest.fn(),
+      getByTestId: jest.fn().mockReturnValue(gridLocator),
+      getByRole: jest.fn(),
+    }
+    const dashboard = new DashboardPage(page as any)
+    const count = await dashboard.getVideoCardCount()
+    expect(count).toBe(2)
+  })
+})

--- a/tests/e2e/pages/__tests__/DeleteActions.test.ts
+++ b/tests/e2e/pages/__tests__/DeleteActions.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Unit tests for DeleteActions page-object.
+ * Mocks the Playwright Page API and verifies method→selector mappings.
+ */
+
+import { DeleteActions } from '../DeleteActions'
+
+function makeLocator(overrides: Partial<Record<string, jest.Mock>> = {}) {
+  const locator: Record<string, jest.Mock> = {
+    waitFor: jest.fn().mockResolvedValue(undefined),
+    click: jest.fn().mockResolvedValue(undefined),
+    all: jest.fn().mockResolvedValue([]),
+    locator: jest.fn(),
+    ...overrides,
+  }
+  locator.locator.mockReturnValue(locator)
+  return locator
+}
+
+function makePage() {
+  const locator = makeLocator()
+  const page = {
+    getByTestId: jest.fn().mockReturnValue(locator),
+    getByRole: jest.fn().mockReturnValue(locator),
+  }
+  return { page, locator }
+}
+
+describe('DeleteActions', () => {
+  it('clickDeleteOnCard() clicks the delete button at given index and waits for modal', async () => {
+    const deleteBtn0 = makeLocator()
+    const deleteBtn1 = makeLocator()
+    const btnListLocator = makeLocator()
+    btnListLocator.all.mockResolvedValue([deleteBtn0, deleteBtn1])
+
+    const gridLocator = makeLocator()
+    gridLocator.locator.mockReturnValue(btnListLocator)
+
+    const modalLocator = makeLocator()
+
+    const page = {
+      getByTestId: jest.fn().mockImplementation((id: string) => {
+        if (id === 'video-grid') return gridLocator
+        if (id === 'delete-modal') return modalLocator
+        return makeLocator()
+      }),
+      getByRole: jest.fn().mockReturnValue(makeLocator()),
+    }
+
+    const deleteActions = new DeleteActions(page as any)
+    await deleteActions.clickDeleteOnCard(0)
+
+    expect(page.getByTestId).toHaveBeenCalledWith('video-grid')
+    expect(gridLocator.locator).toHaveBeenCalledWith('[data-testid="delete-button"]')
+    expect(deleteBtn0.click).toHaveBeenCalled()
+    expect(modalLocator.waitFor).toHaveBeenCalledWith({ state: 'visible' })
+  })
+
+  it('confirmDelete() clicks confirm-delete-button and waits for modal to close', async () => {
+    const confirmLocator = makeLocator()
+    const modalLocator = makeLocator()
+
+    const page = {
+      getByTestId: jest.fn().mockImplementation((id: string) => {
+        if (id === 'confirm-delete-button') return confirmLocator
+        if (id === 'delete-modal') return modalLocator
+        return makeLocator()
+      }),
+      getByRole: jest.fn().mockReturnValue(makeLocator()),
+    }
+
+    const deleteActions = new DeleteActions(page as any)
+    await deleteActions.confirmDelete()
+
+    expect(page.getByTestId).toHaveBeenCalledWith('confirm-delete-button')
+    expect(confirmLocator.click).toHaveBeenCalled()
+    expect(modalLocator.waitFor).toHaveBeenCalledWith({ state: 'hidden' })
+  })
+
+  it('assertCardRemoved() waits for the video card to be hidden', async () => {
+    const cardLocator = makeLocator()
+    const page = {
+      getByTestId: jest.fn().mockReturnValue(cardLocator),
+      getByRole: jest.fn().mockReturnValue(makeLocator()),
+    }
+
+    const deleteActions = new DeleteActions(page as any)
+    await deleteActions.assertCardRemoved('abc-123')
+
+    expect(page.getByTestId).toHaveBeenCalledWith('video-card-abc-123')
+    expect(cardLocator.waitFor).toHaveBeenCalledWith({ state: 'hidden' })
+  })
+})

--- a/tests/e2e/pages/__tests__/EditActions.test.ts
+++ b/tests/e2e/pages/__tests__/EditActions.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Unit tests for EditActions page-object.
+ * Mocks the Playwright Page API and verifies method→selector mappings.
+ */
+
+import { EditActions } from '../EditActions'
+
+function makeLocator(overrides: Partial<Record<string, jest.Mock>> = {}) {
+  const locator: Record<string, jest.Mock> = {
+    waitFor: jest.fn().mockResolvedValue(undefined),
+    fill: jest.fn().mockResolvedValue(undefined),
+    click: jest.fn().mockResolvedValue(undefined),
+    press: jest.fn().mockResolvedValue(undefined),
+    all: jest.fn().mockResolvedValue([]),
+    locator: jest.fn(),
+    getByRole: jest.fn(),
+    getByTestId: jest.fn(),
+    getByText: jest.fn(),
+    ...overrides,
+  }
+  locator.locator.mockReturnValue(locator)
+  locator.getByRole.mockReturnValue(locator)
+  locator.getByTestId.mockReturnValue(locator)
+  locator.getByText.mockReturnValue(locator)
+  return locator
+}
+
+function makePage() {
+  const locator = makeLocator()
+  const page = {
+    getByTestId: jest.fn().mockReturnValue(locator),
+    getByRole: jest.fn().mockReturnValue(locator),
+    getByText: jest.fn().mockReturnValue(locator),
+  }
+  return { page, locator }
+}
+
+describe('EditActions', () => {
+  it('clickEditOnCard() clicks the edit button at given index and waits for modal', async () => {
+    const editBtn0 = makeLocator()
+    const editBtn1 = makeLocator()
+    const btnListLocator = makeLocator()
+    btnListLocator.all.mockResolvedValue([editBtn0, editBtn1])
+
+    const gridLocator = makeLocator()
+    gridLocator.locator.mockReturnValue(btnListLocator)
+
+    const modalLocator = makeLocator()
+
+    const page = {
+      getByTestId: jest.fn().mockImplementation((id: string) => {
+        if (id === 'video-grid') return gridLocator
+        if (id === 'edit-modal') return modalLocator
+        return makeLocator()
+      }),
+      getByRole: jest.fn().mockReturnValue(makeLocator()),
+      getByText: jest.fn().mockReturnValue(makeLocator()),
+    }
+
+    const editActions = new EditActions(page as any)
+    await editActions.clickEditOnCard(1)
+
+    expect(editBtn1.click).toHaveBeenCalled()
+    expect(modalLocator.waitFor).toHaveBeenCalledWith({ state: 'visible' })
+  })
+
+  it('addTag() fills tag-input and presses Enter', async () => {
+    const tagInputLocator = makeLocator()
+    const page = {
+      getByTestId: jest.fn().mockImplementation((id: string) => {
+        if (id === 'tag-input') return tagInputLocator
+        return makeLocator()
+      }),
+      getByRole: jest.fn().mockReturnValue(makeLocator()),
+      getByText: jest.fn().mockReturnValue(makeLocator()),
+    }
+
+    const editActions = new EditActions(page as any)
+    await editActions.addTag('spanish')
+    expect(page.getByTestId).toHaveBeenCalledWith('tag-input')
+    expect(tagInputLocator.fill).toHaveBeenCalledWith('spanish')
+    expect(tagInputLocator.press).toHaveBeenCalledWith('Enter')
+  })
+
+  it('removeTag() clicks the remove-tag-{tagName} button', async () => {
+    const removeLocator = makeLocator()
+    const page = {
+      getByTestId: jest.fn().mockReturnValue(removeLocator),
+      getByRole: jest.fn().mockReturnValue(makeLocator()),
+      getByText: jest.fn().mockReturnValue(makeLocator()),
+    }
+
+    const editActions = new EditActions(page as any)
+    await editActions.removeTag('spanish')
+    expect(page.getByTestId).toHaveBeenCalledWith('remove-tag-spanish')
+    expect(removeLocator.click).toHaveBeenCalled()
+  })
+
+  it('clickSave() clicks Save button and waits for modal to close', async () => {
+    const saveBtn = makeLocator()
+    const modalLocator = makeLocator()
+    // Override getByRole to return saveBtn (after locator is constructed)
+    modalLocator.getByRole.mockReturnValue(saveBtn)
+
+    const page = {
+      getByTestId: jest.fn().mockReturnValue(modalLocator),
+      getByRole: jest.fn().mockReturnValue(makeLocator()),
+      getByText: jest.fn().mockReturnValue(makeLocator()),
+    }
+
+    const editActions = new EditActions(page as any)
+    await editActions.clickSave()
+    expect(modalLocator.getByRole).toHaveBeenCalledWith('button', { name: 'Save' })
+    expect(saveBtn.click).toHaveBeenCalled()
+    expect(modalLocator.waitFor).toHaveBeenCalledWith({ state: 'hidden' })
+  })
+
+  it('assertTagsSaved() waits for each tag text to be visible', async () => {
+    const tagLocator = makeLocator()
+    const page = {
+      getByTestId: jest.fn().mockReturnValue(makeLocator()),
+      getByRole: jest.fn().mockReturnValue(makeLocator()),
+      getByText: jest.fn().mockReturnValue(tagLocator),
+    }
+
+    const editActions = new EditActions(page as any)
+    await editActions.assertTagsSaved(['spanish', 'beginner'])
+    expect(page.getByText).toHaveBeenCalledWith('spanish')
+    expect(page.getByText).toHaveBeenCalledWith('beginner')
+    expect(tagLocator.waitFor).toHaveBeenCalledWith({ state: 'visible' })
+  })
+})

--- a/tests/e2e/pages/__tests__/ImportActions.test.ts
+++ b/tests/e2e/pages/__tests__/ImportActions.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Unit tests for ImportActions page-object.
+ * Mocks the Playwright Page API and verifies method→selector mappings.
+ */
+
+import { ImportActions } from '../ImportActions'
+
+function makeLocator(overrides: Partial<Record<string, jest.Mock>> = {}) {
+  const locator: Record<string, jest.Mock> = {
+    waitFor: jest.fn().mockResolvedValue(undefined),
+    fill: jest.fn().mockResolvedValue(undefined),
+    click: jest.fn().mockResolvedValue(undefined),
+    setInputFiles: jest.fn().mockResolvedValue(undefined),
+    filter: jest.fn(),
+    ...overrides,
+  }
+  locator.filter.mockReturnValue(locator)
+  return locator
+}
+
+function makePage() {
+  const locator = makeLocator()
+  const page = {
+    getByTestId: jest.fn().mockReturnValue(locator),
+    getByRole: jest.fn().mockReturnValue(locator),
+  }
+  return { page, locator }
+}
+
+describe('ImportActions', () => {
+  it('clickImportButton() opens the import modal', async () => {
+    const hiddenLocator = makeLocator({
+      waitFor: jest.fn().mockResolvedValue(undefined),
+    })
+    const visibleLocator = makeLocator({
+      waitFor: jest.fn().mockResolvedValue(undefined),
+    })
+    const buttonLocator = makeLocator()
+
+    let callCount = 0
+    const page = {
+      getByTestId: jest.fn().mockImplementation(() => {
+        callCount++
+        // first call → hidden check; second call → visible check
+        return callCount === 1 ? hiddenLocator : visibleLocator
+      }),
+      getByRole: jest.fn().mockReturnValue(buttonLocator),
+    }
+
+    const importActions = new ImportActions(page as any)
+    await importActions.clickImportButton()
+
+    expect(page.getByTestId).toHaveBeenCalledWith('import-modal')
+    expect(buttonLocator.click).toHaveBeenCalled()
+  })
+
+  it('fillYoutubeUrl() fills the youtube-url-input', async () => {
+    const { page, locator } = makePage()
+    const importActions = new ImportActions(page as any)
+    await importActions.fillYoutubeUrl('https://www.youtube.com/watch?v=abc')
+    expect(page.getByTestId).toHaveBeenCalledWith('youtube-url-input')
+    expect(locator.fill).toHaveBeenCalledWith('https://www.youtube.com/watch?v=abc')
+  })
+
+  it('fillTranscriptFile() calls setInputFiles on transcript-input', async () => {
+    const { page, locator } = makePage()
+    const importActions = new ImportActions(page as any)
+    await importActions.fillTranscriptFile('/path/to/transcript.srt')
+    expect(page.getByTestId).toHaveBeenCalledWith('transcript-input')
+    expect(locator.setInputFiles).toHaveBeenCalledWith('/path/to/transcript.srt')
+  })
+
+  it('fillTags() fills the tags-input', async () => {
+    const { page, locator } = makePage()
+    const importActions = new ImportActions(page as any)
+    await importActions.fillTags('spanish, beginner')
+    expect(page.getByTestId).toHaveBeenCalledWith('tags-input')
+    expect(locator.fill).toHaveBeenCalledWith('spanish, beginner')
+  })
+
+  it('clickSubmitImport() clicks the submit-import-button', async () => {
+    const { page, locator } = makePage()
+    const importActions = new ImportActions(page as any)
+    await importActions.clickSubmitImport()
+    expect(page.getByTestId).toHaveBeenCalledWith('submit-import-button')
+    expect(locator.click).toHaveBeenCalled()
+  })
+
+  it('assertValidationError() waits for import-error to be visible', async () => {
+    const { page, locator } = makePage()
+    const importActions = new ImportActions(page as any)
+    await importActions.assertValidationError()
+    expect(page.getByTestId).toHaveBeenCalledWith('import-error')
+    expect(locator.waitFor).toHaveBeenCalledWith({ state: 'visible' })
+  })
+
+  it('assertValidationError() filters by message text when provided', async () => {
+    const { page, locator } = makePage()
+    const importActions = new ImportActions(page as any)
+    await importActions.assertValidationError('YouTube URL is required')
+    expect(locator.filter).toHaveBeenCalledWith({ hasText: 'YouTube URL is required' })
+    expect(locator.waitFor).toHaveBeenCalledWith({ state: 'visible' })
+  })
+})


### PR DESCRIPTION
## Summary

Closes #58

Implements Playwright page-object abstractions under `tests/e2e/pages/` for the lingoFlow dashboard.

## Changes

### Missing `data-testid` attributes added
- `ImportVideoModal`: `import-modal`, `youtube-url-input`, `transcript-input`, `tags-input`, `submit-import-button`, `import-error`
- `EditVideoModal`: `tag-input`

### New page object classes (`tests/e2e/pages/`)
| Class | Methods |
|---|---|
| `DashboardPage` | `loadDashboard()`, `assertLoading()`, `assertEmpty()`, `getVideoCards()`, `getVideoCardCount()` |
| `ImportActions` | `clickImportButton()`, `fillYoutubeUrl()`, `fillTranscriptFile()`, `fillTags()`, `clickSubmitImport()`, `assertValidationError()` |
| `EditActions` | `clickEditOnCard(index)`, `addTag()`, `removeTag()`, `clickSave()`, `assertTagsSaved()` |
| `DeleteActions` | `clickDeleteOnCard(index)`, `confirmDelete()`, `assertCardRemoved()` |

### Tests
20 Jest unit tests across 4 test files verifying selector calls and method behavior via Page mocks.

## Test Results
- ✅ 20/20 new page-object tests pass
- ✅ Build succeeds
- ℹ️ 1 pre-existing failure in `youtube.test.ts` (unrelated, present on main)