### PR TITLE
feat(youtube): add E2E stub via E2E_STUB_YOUTUBE env var (issue #56)

### DIFF
--- a/src/lib/__tests__/youtube.test.ts
+++ b/src/lib/__tests__/youtube.test.ts
@@ -1,4 +1,4 @@
-import { fetchYoutubeMetadata, extractYoutubeId, YoutubeMetadataError } from '../youtube'
+import { fetchYoutubeMetadata, extractYoutubeId, YoutubeMetadataError, STUB_VIDEOS } from '../youtube'
 
 describe('extractYoutubeId', () => {
   it('extracts video ID from youtube.com/watch?v= format', () => {
@@ -109,6 +109,78 @@ describe('fetchYoutubeMetadata', () => {
       title: 'Short URL Video',
       author_name: 'Author',
       thumbnail_url: 'https://example.com/thumb.jpg',
+      youtube_id: 'dQw4w9WgXcQ',
+    })
+  })
+})
+
+describe('fetchYoutubeMetadata (E2E stub)', () => {
+  const originalEnv = process.env.E2E_STUB_YOUTUBE
+
+  beforeEach(() => {
+    process.env.E2E_STUB_YOUTUBE = 'true'
+    global.fetch = jest.fn() // should never be called
+  })
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.E2E_STUB_YOUTUBE
+    } else {
+      process.env.E2E_STUB_YOUTUBE = originalEnv
+    }
+    jest.restoreAllMocks()
+  })
+
+  it('never calls fetch when stub is active', async () => {
+    await fetchYoutubeMetadata('https://www.youtube.com/watch?v=dQw4w9WgXcQ')
+    expect(global.fetch).not.toHaveBeenCalled()
+  })
+
+  it('returns known stub entry for dQw4w9WgXcQ', async () => {
+    const result = await fetchYoutubeMetadata('https://www.youtube.com/watch?v=dQw4w9WgXcQ')
+    expect(result).toEqual({
+      ...STUB_VIDEOS['dQw4w9WgXcQ'],
+      youtube_id: 'dQw4w9WgXcQ',
+    })
+  })
+
+  it('returns known stub entry for jNQXAC9IVRw', async () => {
+    const result = await fetchYoutubeMetadata('https://www.youtube.com/watch?v=jNQXAC9IVRw')
+    expect(result).toEqual({
+      ...STUB_VIDEOS['jNQXAC9IVRw'],
+      youtube_id: 'jNQXAC9IVRw',
+    })
+  })
+
+  it('returns known stub entry for kJQP7kiw5Fk', async () => {
+    const result = await fetchYoutubeMetadata('https://www.youtube.com/watch?v=kJQP7kiw5Fk')
+    expect(result).toEqual({
+      ...STUB_VIDEOS['kJQP7kiw5Fk'],
+      youtube_id: 'kJQP7kiw5Fk',
+    })
+  })
+
+  it('returns fallback stub for an unknown video ID', async () => {
+    // Use a valid 11-char ID not in STUB_VIDEOS
+    const result = await fetchYoutubeMetadata('https://www.youtube.com/watch?v=unknownVid1')
+    expect(result).toEqual({
+      title: 'Stub Video',
+      author_name: 'Stub Author',
+      thumbnail_url: 'https://img.youtube.com/vi/unknownVid1/0.jpg',
+      youtube_id: 'unknownVid1',
+    })
+  })
+
+  it('still throws YoutubeMetadataError for an invalid URL even with stub active', async () => {
+    await expect(fetchYoutubeMetadata('https://www.example.com')).rejects.toThrow(
+      YoutubeMetadataError
+    )
+  })
+
+  it('works with youtu.be shortened URLs', async () => {
+    const result = await fetchYoutubeMetadata('https://youtu.be/dQw4w9WgXcQ')
+    expect(result).toEqual({
+      ...STUB_VIDEOS['dQw4w9WgXcQ'],
       youtube_id: 'dQw4w9WgXcQ',
     })
   })

--- a/src/lib/youtube.ts
+++ b/src/lib/youtube.ts
@@ -5,6 +5,34 @@ export interface YoutubeMetadata {
   youtube_id: string
 }
 
+/**
+ * Canned responses returned when E2E_STUB_YOUTUBE=true.
+ * Keyed by YouTube video ID; the fallback entry handles any unknown ID.
+ */
+export const STUB_VIDEOS: Record<string, Omit<YoutubeMetadata, 'youtube_id'>> = {
+  dQw4w9WgXcQ: {
+    title: 'Rick Astley - Never Gonna Give You Up',
+    author_name: 'Rick Astley',
+    thumbnail_url: 'https://img.youtube.com/vi/dQw4w9WgXcQ/0.jpg',
+  },
+  jNQXAC9IVRw: {
+    title: 'Me at the zoo',
+    author_name: 'jawed',
+    thumbnail_url: 'https://img.youtube.com/vi/jNQXAC9IVRw/0.jpg',
+  },
+  kJQP7kiw5Fk: {
+    title: 'Luis Fonsi - Despacito ft. Daddy Yankee',
+    author_name: 'Luis Fonsi',
+    thumbnail_url: 'https://img.youtube.com/vi/kJQP7kiw5Fk/0.jpg',
+  },
+}
+
+const STUB_FALLBACK: Omit<YoutubeMetadata, 'youtube_id'> = {
+  title: 'Stub Video',
+  author_name: 'Stub Author',
+  thumbnail_url: '',
+}
+
 export class YoutubeMetadataError extends Error {
   constructor(message: string) {
     super(message)
@@ -70,6 +98,14 @@ export async function fetchYoutubeMetadata(url: string): Promise<YoutubeMetadata
 
   if (!videoId) {
     throw new YoutubeMetadataError('Invalid YouTube URL')
+  }
+
+  if (process.env.E2E_STUB_YOUTUBE === 'true') {
+    const stub = STUB_VIDEOS[videoId] ?? {
+      ...STUB_FALLBACK,
+      thumbnail_url: `https://img.youtube.com/vi/${videoId}/0.jpg`,
+    }
+    return { ...stub, youtube_id: videoId }
   }
 
   try {

--- a/tests/e2e/fixtures/__tests__/fixtures.test.ts
+++ b/tests/e2e/fixtures/__tests__/fixtures.test.ts
@@ -10,6 +10,8 @@ import {
   teardownIsolatedDb,
   seedVideo,
   seedTranscript,
+  setupYoutubeStub,
+  teardownYoutubeStub,
   type FixtureContext,
 } from '../index'
 
@@ -174,5 +176,28 @@ describe('seedTranscript()', () => {
     const pathVtt = seedTranscript('v3', 'vtt', 'vtt content')
     expect(pathSrt.endsWith('.srt')).toBe(true)
     expect(pathVtt.endsWith('.vtt')).toBe(true)
+  })
+})
+
+describe('setupYoutubeStub / teardownYoutubeStub', () => {
+  it('sets E2E_STUB_YOUTUBE=true', () => {
+    const ctx = setupYoutubeStub()
+    expect(process.env.E2E_STUB_YOUTUBE).toBe('true')
+    teardownYoutubeStub(ctx)
+  })
+
+  it('restores the previous undefined value on teardown', () => {
+    delete process.env.E2E_STUB_YOUTUBE
+    const ctx = setupYoutubeStub()
+    teardownYoutubeStub(ctx)
+    expect(process.env.E2E_STUB_YOUTUBE).toBeUndefined()
+  })
+
+  it('restores a prior truthy value on teardown', () => {
+    process.env.E2E_STUB_YOUTUBE = 'false'
+    const ctx = setupYoutubeStub()
+    expect(process.env.E2E_STUB_YOUTUBE).toBe('true')
+    teardownYoutubeStub(ctx)
+    expect(process.env.E2E_STUB_YOUTUBE).toBe('false')
   })
 })

--- a/tests/e2e/fixtures/index.ts
+++ b/tests/e2e/fixtures/index.ts
@@ -114,3 +114,38 @@ export function seedTranscript(videoId: string, ext: string, content: string): s
   const { writeTranscript } = require('../../../src/lib/transcripts')
   return writeTranscript(videoId, ext, Buffer.from(content, 'utf8'))
 }
+
+// ---------------------------------------------------------------------------
+// YouTube stub helpers
+// ---------------------------------------------------------------------------
+
+export interface YoutubeStubContext {
+  /** Original value of E2E_STUB_YOUTUBE (may be undefined) */
+  originalEnv: string | undefined
+}
+
+/**
+ * Sets E2E_STUB_YOUTUBE=true so that fetchYoutubeMetadata() returns canned
+ * responses instead of calling the real YouTube oEmbed API.
+ *
+ * Usage:
+ *   const ctx = setupYoutubeStub()
+ *   // ... run tests that call fetchYoutubeMetadata() ...
+ *   teardownYoutubeStub(ctx)
+ */
+export function setupYoutubeStub(): YoutubeStubContext {
+  const originalEnv = process.env.E2E_STUB_YOUTUBE
+  process.env.E2E_STUB_YOUTUBE = 'true'
+  return { originalEnv }
+}
+
+/**
+ * Restores E2E_STUB_YOUTUBE to its previous value.
+ */
+export function teardownYoutubeStub(ctx: YoutubeStubContext): void {
+  if (ctx.originalEnv === undefined) {
+    delete process.env.E2E_STUB_YOUTUBE
+  } else {
+    process.env.E2E_STUB_YOUTUBE = ctx.originalEnv
+  }
+}


### PR DESCRIPTION
## Summary

Closes #56

## Changes

### `src/lib/youtube.ts`
- Added `STUB_VIDEOS` map with 3 canned entries (Rick Astley, Me at the zoo, Despacito) plus a fallback for unknown IDs
- `fetchYoutubeMetadata()` checks `process.env.E2E_STUB_YOUTUBE === 'true'` and returns stub data immediately — no real `fetch` call made
- Works in both Node (API route) and Browser (component) contexts since it's pure env-var branching

### `tests/e2e/fixtures/index.ts`
- Added `YoutubeStubContext` interface
- Added `setupYoutubeStub()` — sets `E2E_STUB_YOUTUBE=true`, returns context with original value
- Added `teardownYoutubeStub(ctx)` — restores env var to prior value

### Tests
- `src/lib/__tests__/youtube.test.ts`: 7 new tests covering all 3 known stub entries, fallback for unknown IDs, invalid URL rejection with stub active, and youtu.be short URL support
- `tests/e2e/fixtures/__tests__/fixtures.test.ts`: 3 new tests for `setupYoutubeStub`/`teardownYoutubeStub`

## Test Results
- **Before**: 137 passing, 1 failing (pre-existing `youtu.be/` no-scheme test)
- **After**: 147 passing, 1 failing (same pre-existing test, not introduced by this PR)