### PR TITLE
feat(e2e): add edit-tags E2E spec with persistence check (#60)

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -9,6 +9,7 @@ const createJestConfig = nextJest({
 const customJestConfig = {
   setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
   testEnvironment: 'jest-environment-jsdom',
+  testPathIgnorePatterns: ['<rootDir>/node_modules/', '<rootDir>/tests/e2e/'],
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
   },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
-    "test": "jest"
+    "test": "jest",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
     "@tanstack/react-query": "^5.96.2",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,36 @@
+import { defineConfig, devices } from '@playwright/test'
+import os from 'os'
+import path from 'path'
+import crypto from 'crypto'
+
+const e2eDataDir = path.join(os.tmpdir(), `lingoflow-e2e-${crypto.randomUUID()}`)
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  testMatch: ['**/*.spec.ts'],
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: 1,
+  reporter: 'list',
+  use: {
+    baseURL: 'http://localhost:3000',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: 'E2E_STUB_YOUTUBE=true pnpm dev',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120000,
+    env: {
+      E2E_STUB_YOUTUBE: 'true',
+      LINGOFLOW_DATA_DIR: e2eDataDir,
+    },
+  },
+})

--- a/src/components/EditVideoModal.tsx
+++ b/src/components/EditVideoModal.tsx
@@ -74,7 +74,7 @@ export default function EditVideoModal({ video, onClose, onSave }: EditVideoModa
   return (
     <div data-testid="edit-modal">
       <h2>Edit Video</h2>
-      {error && <p role="alert">{error}</p>}
+      {error && <p data-testid="edit-error" role="alert">{error}</p>}
 
       <div>
         {tags.map((tag) => (
@@ -116,7 +116,7 @@ export default function EditVideoModal({ video, onClose, onSave }: EditVideoModa
         ✕
       </button>
       <button onClick={onClose}>Cancel</button>
-      <button onClick={handleSave} disabled={isSaving}>
+      <button data-testid="save-button" onClick={handleSave} disabled={isSaving}>
         {isSaving ? 'Saving...' : 'Save'}
       </button>
     </div>

--- a/src/components/ImportVideoModal.tsx
+++ b/src/components/ImportVideoModal.tsx
@@ -152,7 +152,7 @@ export default function ImportVideoModal({ isOpen, onClose, onSuccess }: ImportV
           </div>
 
           {preview && (
-            <div className="preview-container">
+            <div data-testid="preview-container" className="preview-container">
               {/* eslint-disable-next-line @next/next/no-img-element */}
               <img src={preview.thumbnail_url} alt={preview.title} className="preview-image" />
               <div className="preview-text">

--- a/src/components/__tests__/EditVideoModal.test.tsx
+++ b/src/components/__tests__/EditVideoModal.test.tsx
@@ -60,6 +60,21 @@ describe('EditVideoModal', () => {
     expect(screen.getByText('subtitles.srt')).toBeInTheDocument()
   })
 
+  it('renders save button with correct testid', () => {
+    render(<EditVideoModal video={mockVideo} onClose={jest.fn()} onSave={jest.fn()} />)
+    expect(screen.getByTestId('save-button')).toBeInTheDocument()
+  })
+
+  it('shows edit-error testid when save fails', async () => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: false, text: async () => 'Save failed' })
+    render(<EditVideoModal video={mockVideo} onClose={jest.fn()} onSave={jest.fn()} />)
+    fireEvent.click(screen.getByTestId('save-button'))
+    await waitFor(() => {
+      expect(screen.getByTestId('edit-error')).toBeInTheDocument()
+      expect(screen.getByTestId('edit-error')).toHaveTextContent('Save failed')
+    })
+  })
+
   it('disables Save button when isSaving', async () => {
     let resolveFetch: (value: unknown) => void
     const hangingPromise = new Promise((resolve) => { resolveFetch = resolve })

--- a/src/components/__tests__/ImportVideoModal.test.tsx
+++ b/src/components/__tests__/ImportVideoModal.test.tsx
@@ -53,6 +53,7 @@ describe('ImportVideoModal', () => {
 
     await waitFor(() => {
       expect(screen.getByText('Test Video')).toBeInTheDocument()
+      expect(screen.getByTestId('preview-container')).toBeInTheDocument()
     })
   })
 

--- a/src/lib/__tests__/youtube.test.ts
+++ b/src/lib/__tests__/youtube.test.ts
@@ -1,4 +1,4 @@
-import { fetchYoutubeMetadata, extractYoutubeId, YoutubeMetadataError } from '../youtube'
+import { fetchYoutubeMetadata, extractYoutubeId, YoutubeMetadataError, STUB_VIDEOS } from '../youtube'
 
 describe('extractYoutubeId', () => {
   it('extracts video ID from youtube.com/watch?v= format', () => {
@@ -109,6 +109,78 @@ describe('fetchYoutubeMetadata', () => {
       title: 'Short URL Video',
       author_name: 'Author',
       thumbnail_url: 'https://example.com/thumb.jpg',
+      youtube_id: 'dQw4w9WgXcQ',
+    })
+  })
+})
+
+describe('fetchYoutubeMetadata (E2E stub)', () => {
+  const originalEnv = process.env.E2E_STUB_YOUTUBE
+
+  beforeEach(() => {
+    process.env.E2E_STUB_YOUTUBE = 'true'
+    global.fetch = jest.fn() // should never be called
+  })
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.E2E_STUB_YOUTUBE
+    } else {
+      process.env.E2E_STUB_YOUTUBE = originalEnv
+    }
+    jest.restoreAllMocks()
+  })
+
+  it('never calls fetch when stub is active', async () => {
+    await fetchYoutubeMetadata('https://www.youtube.com/watch?v=dQw4w9WgXcQ')
+    expect(global.fetch).not.toHaveBeenCalled()
+  })
+
+  it('returns known stub entry for dQw4w9WgXcQ', async () => {
+    const result = await fetchYoutubeMetadata('https://www.youtube.com/watch?v=dQw4w9WgXcQ')
+    expect(result).toEqual({
+      ...STUB_VIDEOS['dQw4w9WgXcQ'],
+      youtube_id: 'dQw4w9WgXcQ',
+    })
+  })
+
+  it('returns known stub entry for jNQXAC9IVRw', async () => {
+    const result = await fetchYoutubeMetadata('https://www.youtube.com/watch?v=jNQXAC9IVRw')
+    expect(result).toEqual({
+      ...STUB_VIDEOS['jNQXAC9IVRw'],
+      youtube_id: 'jNQXAC9IVRw',
+    })
+  })
+
+  it('returns known stub entry for kJQP7kiw5Fk', async () => {
+    const result = await fetchYoutubeMetadata('https://www.youtube.com/watch?v=kJQP7kiw5Fk')
+    expect(result).toEqual({
+      ...STUB_VIDEOS['kJQP7kiw5Fk'],
+      youtube_id: 'kJQP7kiw5Fk',
+    })
+  })
+
+  it('returns fallback stub for an unknown video ID', async () => {
+    // Use a valid 11-char ID not in STUB_VIDEOS
+    const result = await fetchYoutubeMetadata('https://www.youtube.com/watch?v=unknownVid1')
+    expect(result).toEqual({
+      title: 'Stub Video',
+      author_name: 'Stub Author',
+      thumbnail_url: 'https://img.youtube.com/vi/unknownVid1/0.jpg',
+      youtube_id: 'unknownVid1',
+    })
+  })
+
+  it('still throws YoutubeMetadataError for an invalid URL even with stub active', async () => {
+    await expect(fetchYoutubeMetadata('https://www.example.com')).rejects.toThrow(
+      YoutubeMetadataError
+    )
+  })
+
+  it('works with youtu.be shortened URLs', async () => {
+    const result = await fetchYoutubeMetadata('https://youtu.be/dQw4w9WgXcQ')
+    expect(result).toEqual({
+      ...STUB_VIDEOS['dQw4w9WgXcQ'],
       youtube_id: 'dQw4w9WgXcQ',
     })
   })

--- a/src/lib/youtube.ts
+++ b/src/lib/youtube.ts
@@ -5,6 +5,34 @@ export interface YoutubeMetadata {
   youtube_id: string
 }
 
+/**
+ * Canned responses returned when E2E_STUB_YOUTUBE=true.
+ * Keyed by YouTube video ID; the fallback entry handles any unknown ID.
+ */
+export const STUB_VIDEOS: Record<string, Omit<YoutubeMetadata, 'youtube_id'>> = {
+  dQw4w9WgXcQ: {
+    title: 'Rick Astley - Never Gonna Give You Up',
+    author_name: 'Rick Astley',
+    thumbnail_url: 'https://img.youtube.com/vi/dQw4w9WgXcQ/0.jpg',
+  },
+  jNQXAC9IVRw: {
+    title: 'Me at the zoo',
+    author_name: 'jawed',
+    thumbnail_url: 'https://img.youtube.com/vi/jNQXAC9IVRw/0.jpg',
+  },
+  kJQP7kiw5Fk: {
+    title: 'Luis Fonsi - Despacito ft. Daddy Yankee',
+    author_name: 'Luis Fonsi',
+    thumbnail_url: 'https://img.youtube.com/vi/kJQP7kiw5Fk/0.jpg',
+  },
+}
+
+const STUB_FALLBACK: Omit<YoutubeMetadata, 'youtube_id'> = {
+  title: 'Stub Video',
+  author_name: 'Stub Author',
+  thumbnail_url: '',
+}
+
 export class YoutubeMetadataError extends Error {
   constructor(message: string) {
     super(message)
@@ -70,6 +98,14 @@ export async function fetchYoutubeMetadata(url: string): Promise<YoutubeMetadata
 
   if (!videoId) {
     throw new YoutubeMetadataError('Invalid YouTube URL')
+  }
+
+  if (process.env.E2E_STUB_YOUTUBE === 'true') {
+    const stub = STUB_VIDEOS[videoId] ?? {
+      ...STUB_FALLBACK,
+      thumbnail_url: `https://img.youtube.com/vi/${videoId}/0.jpg`,
+    }
+    return { ...stub, youtube_id: videoId }
   }
 
   try {

--- a/tests/e2e/edit-tags.spec.ts
+++ b/tests/e2e/edit-tags.spec.ts
@@ -1,0 +1,61 @@
+/**
+ * E2E spec: edit tags workflow with persistence (issue #60)
+ *
+ * Tests the full tag-editing flow: importing a video with an initial tag,
+ * opening the edit modal, removing the old tag, adding new tags, saving,
+ * verifying the UI updates immediately, reloading, and confirming persistence.
+ */
+
+import { test, expect } from '@playwright/test'
+import path from 'path'
+import { DashboardPage } from './pages/DashboardPage'
+import { ImportActions } from './pages/ImportActions'
+import { EditActions } from './pages/EditActions'
+import { DeleteActions } from './pages/DeleteActions'
+
+const RICK_ASTLEY_URL = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ'
+const SAMPLE_SRT = path.join(__dirname, 'fixtures', 'sample.srt')
+
+test.describe('Edit tags', () => {
+  test('edits tags and persists after reload', async ({ page }) => {
+    const dashboard = new DashboardPage(page)
+    const importActions = new ImportActions(page)
+    const editActions = new EditActions(page)
+    const deleteActions = new DeleteActions(page)
+
+    // 1. Load dashboard and seed a video via import UI with an initial tag
+    await dashboard.loadDashboard()
+    await importActions.clickImportButton()
+    await importActions.fillYoutubeUrl(RICK_ASTLEY_URL)
+    await importActions.fillTranscriptFile(SAMPLE_SRT)
+    await importActions.fillTags('oldTag')
+    await importActions.clickSubmitImport()
+    await page.getByTestId('import-modal').waitFor({ state: 'hidden' })
+
+    // 2. Verify the video card is present
+    const cards = await dashboard.getVideoCards()
+    expect(cards.length).toBeGreaterThanOrEqual(1)
+
+    // 3. Open edit modal on the first card
+    await editActions.clickEditOnCard(0)
+
+    // 4. Remove existing tag and add new tags
+    await editActions.removeTag('oldTag')
+    await editActions.addTag('newTag1')
+    await editActions.addTag('newTag2')
+
+    // 5. Save and wait for modal to close
+    await editActions.clickSave()
+
+    // 6. Verify UI reflects new tags immediately
+    await editActions.assertTagsSaved(['newTag1', 'newTag2'])
+
+    // 7. Reload page and confirm tags persisted
+    await dashboard.loadDashboard()
+    await editActions.assertTagsSaved(['newTag1', 'newTag2'])
+
+    // 8. Clean up: delete the video so subsequent tests start with a clean state
+    await deleteActions.clickDeleteOnCard(0)
+    await deleteActions.confirmDelete()
+  })
+})

--- a/tests/e2e/fixtures/__tests__/fixtures.test.ts
+++ b/tests/e2e/fixtures/__tests__/fixtures.test.ts
@@ -10,6 +10,8 @@ import {
   teardownIsolatedDb,
   seedVideo,
   seedTranscript,
+  setupYoutubeStub,
+  teardownYoutubeStub,
   type FixtureContext,
 } from '../index'
 
@@ -174,5 +176,28 @@ describe('seedTranscript()', () => {
     const pathVtt = seedTranscript('v3', 'vtt', 'vtt content')
     expect(pathSrt.endsWith('.srt')).toBe(true)
     expect(pathVtt.endsWith('.vtt')).toBe(true)
+  })
+})
+
+describe('setupYoutubeStub / teardownYoutubeStub', () => {
+  it('sets E2E_STUB_YOUTUBE=true', () => {
+    const ctx = setupYoutubeStub()
+    expect(process.env.E2E_STUB_YOUTUBE).toBe('true')
+    teardownYoutubeStub(ctx)
+  })
+
+  it('restores the previous undefined value on teardown', () => {
+    delete process.env.E2E_STUB_YOUTUBE
+    const ctx = setupYoutubeStub()
+    teardownYoutubeStub(ctx)
+    expect(process.env.E2E_STUB_YOUTUBE).toBeUndefined()
+  })
+
+  it('restores a prior truthy value on teardown', () => {
+    process.env.E2E_STUB_YOUTUBE = 'false'
+    const ctx = setupYoutubeStub()
+    expect(process.env.E2E_STUB_YOUTUBE).toBe('true')
+    teardownYoutubeStub(ctx)
+    expect(process.env.E2E_STUB_YOUTUBE).toBe('false')
   })
 })

--- a/tests/e2e/fixtures/index.ts
+++ b/tests/e2e/fixtures/index.ts
@@ -114,3 +114,38 @@ export function seedTranscript(videoId: string, ext: string, content: string): s
   const { writeTranscript } = require('../../../src/lib/transcripts')
   return writeTranscript(videoId, ext, Buffer.from(content, 'utf8'))
 }
+
+// ---------------------------------------------------------------------------
+// YouTube stub helpers
+// ---------------------------------------------------------------------------
+
+export interface YoutubeStubContext {
+  /** Original value of E2E_STUB_YOUTUBE (may be undefined) */
+  originalEnv: string | undefined
+}
+
+/**
+ * Sets E2E_STUB_YOUTUBE=true so that fetchYoutubeMetadata() returns canned
+ * responses instead of calling the real YouTube oEmbed API.
+ *
+ * Usage:
+ *   const ctx = setupYoutubeStub()
+ *   // ... run tests that call fetchYoutubeMetadata() ...
+ *   teardownYoutubeStub(ctx)
+ */
+export function setupYoutubeStub(): YoutubeStubContext {
+  const originalEnv = process.env.E2E_STUB_YOUTUBE
+  process.env.E2E_STUB_YOUTUBE = 'true'
+  return { originalEnv }
+}
+
+/**
+ * Restores E2E_STUB_YOUTUBE to its previous value.
+ */
+export function teardownYoutubeStub(ctx: YoutubeStubContext): void {
+  if (ctx.originalEnv === undefined) {
+    delete process.env.E2E_STUB_YOUTUBE
+  } else {
+    process.env.E2E_STUB_YOUTUBE = ctx.originalEnv
+  }
+}

--- a/tests/e2e/fixtures/sample.srt
+++ b/tests/e2e/fixtures/sample.srt
@@ -1,0 +1,7 @@
+1
+00:00:01,000 --> 00:00:04,000
+Never gonna give you up
+
+2
+00:00:05,000 --> 00:00:08,000
+Never gonna let you down

--- a/tests/e2e/import-happy-path.spec.ts
+++ b/tests/e2e/import-happy-path.spec.ts
@@ -1,0 +1,62 @@
+/**
+ * E2E spec: import happy path — URL + transcript + tags
+ *
+ * Tests the full video import flow: entering a YouTube URL, uploading a
+ * transcript file, adding tags, submitting, verifying the video card appears,
+ * and confirming persistence after page reload.
+ */
+
+import { test, expect } from '@playwright/test'
+import path from 'path'
+import { DashboardPage } from './pages/DashboardPage'
+import { ImportActions } from './pages/ImportActions'
+
+const RICK_ASTLEY_URL = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ'
+const RICK_ASTLEY_TITLE = 'Rick Astley - Never Gonna Give You Up'
+const SAMPLE_SRT = path.join(__dirname, 'fixtures', 'sample.srt')
+
+test.describe('Import happy path', () => {
+  test('imports a video with URL, transcript, and tags', async ({ page }) => {
+    const dashboard = new DashboardPage(page)
+    const importActions = new ImportActions(page)
+
+    // 1. Load dashboard and assert empty state
+    await dashboard.loadDashboard()
+    await dashboard.assertEmpty()
+
+    // 2. Open import modal
+    await importActions.clickImportButton()
+
+    // 3. Fill YouTube URL
+    await importActions.fillYoutubeUrl(RICK_ASTLEY_URL)
+
+    // 4. Upload transcript file
+    await importActions.fillTranscriptFile(SAMPLE_SRT)
+
+    // 5. Add tags
+    await importActions.fillTags('music, classic')
+
+    // 6. Submit import
+    await importActions.clickSubmitImport()
+
+    // 7. Assert modal closes
+    await page.getByTestId('import-modal').waitFor({ state: 'hidden' })
+
+    // 8. Assert video card appears with correct title
+    const cards = await dashboard.getVideoCards()
+    expect(cards.length).toBeGreaterThanOrEqual(1)
+
+    const firstCard = cards[0]
+    await expect(firstCard).toContainText(RICK_ASTLEY_TITLE)
+
+    // 9. Assert tags visible on card
+    await expect(firstCard).toContainText('music')
+    await expect(firstCard).toContainText('classic')
+
+    // 10. Reload page and assert card still present (persistence check)
+    await dashboard.loadDashboard()
+    const cardsAfterReload = await dashboard.getVideoCards()
+    expect(cardsAfterReload.length).toBeGreaterThanOrEqual(1)
+    await expect(cardsAfterReload[0]).toContainText(RICK_ASTLEY_TITLE)
+  })
+})


### PR DESCRIPTION
Closes #60. Adds Playwright E2E spec for the edit-tags workflow: seed video via import UI, open edit modal, remove oldTag, add newTag1/newTag2, save, assert UI update, reload, confirm persistence. Cleans up with DeleteActions after the test. Both Playwright tests pass.