### PR TITLE
ci: add GitHub Actions E2E post-merge validation workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,88 @@
+name: E2E Post-Merge Validation
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  e2e:
+    name: Playwright E2E Suite
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      E2E_STUB_YOUTUBE: true
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Setup Node 24
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-chromium-${{ hashFiles('**/package.json') }}
+
+      - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Run Jest tests
+        run: pnpm test
+
+      - name: Run E2E tests
+        run: pnpm test:e2e --reporter=html,json
+
+      - name: Upload Playwright report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 30
+
+      - name: Upload test results on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: test-results/
+          retention-days: 30
+
+      - name: Comment on merged PR on failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prs = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'closed',
+              sort: 'updated',
+              direction: 'desc',
+              per_page: 10
+            })
+            const pr = prs.data.find(p => p.merge_commit_sha === context.sha)
+            if (pr) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                body: `❌ E2E tests failed after merge. [View run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`
+              })
+            }


### PR DESCRIPTION
## Summary

Closes #64

Adds a GitHub Actions workflow that runs the full Playwright E2E suite after every merge to `main`.

## What's included

- **Trigger:** `push` to `main` only
- **pnpm v9** setup via `pnpm/action-setup@v4`
- **Node 24** setup via `actions/setup-node@v4` with pnpm cache
- **Playwright browser caching** (key: `playwright-chromium-${{ hashFiles('**/package.json') }}`)
- **Jest tests** run before E2E suite
- **E2E tests** run with `--reporter=html,json`
- **Artifact upload** on failure: `playwright-report/` and `test-results/` (30-day retention)
- **PR comment** on failure: posts a link to the failed run on the merged PR
- **Timeout:** 30 minutes
- **Env:** `E2E_STUB_YOUTUBE=true`