### PR TITLE
feat: implement VideoStore interface and SqliteVideoStore (#78)

### DIFF
--- a/src/lib/__tests__/video-store.test.ts
+++ b/src/lib/__tests__/video-store.test.ts
@@ -1,0 +1,151 @@
+import { openDb, initializeSchema } from '../db'
+import { SqliteVideoStore } from '../video-store'
+import { InsertVideoParams } from '../videos'
+
+function makeParams(overrides: Partial<InsertVideoParams> = {}): InsertVideoParams {
+  return {
+    id: 'test-id-1',
+    youtube_url: 'https://youtube.com/watch?v=abc',
+    youtube_id: 'abc',
+    title: 'Test Video',
+    author_name: 'Test Author',
+    thumbnail_url: 'https://img.youtube.com/vi/abc/0.jpg',
+    transcript_path: '/transcripts/abc.json',
+    transcript_format: 'json',
+    tags: ['tag1', 'tag2'],
+    ...overrides,
+  }
+}
+
+describe('SqliteVideoStore', () => {
+  let store: SqliteVideoStore
+
+  beforeEach(() => {
+    const db = openDb(':memory:')
+    initializeSchema(db)
+    store = new SqliteVideoStore(db)
+  })
+
+  describe('insert', () => {
+    it('inserts a video and returns it', () => {
+      const video = store.insert(makeParams())
+      expect(video.id).toBe('test-id-1')
+      expect(video.title).toBe('Test Video')
+      expect(video.tags).toEqual(['tag1', 'tag2'])
+    })
+
+    it('serializes tags as JSON in the database and deserializes on read', () => {
+      const tags = ['typescript', 'sqlite', 'testing']
+      const video = store.insert(makeParams({ id: 'tag-test', tags }))
+      expect(video.tags).toEqual(tags)
+    })
+
+    it('stores empty tags array', () => {
+      const video = store.insert(makeParams({ id: 'no-tags', tags: [] }))
+      expect(video.tags).toEqual([])
+    })
+  })
+
+  describe('list', () => {
+    it('returns empty array when no videos exist', () => {
+      expect(store.list()).toEqual([])
+    })
+
+    it('returns all inserted videos', () => {
+      store.insert(makeParams({ id: 'v1' }))
+      store.insert(makeParams({ id: 'v2' }))
+      const videos = store.list()
+      expect(videos).toHaveLength(2)
+    })
+
+    it('orders videos by created_at DESC', async () => {
+      store.insert(makeParams({ id: 'first' }))
+      await new Promise(r => setTimeout(r, 5))
+      store.insert(makeParams({ id: 'second' }))
+      const videos = store.list()
+      expect(videos[0].id).toBe('second')
+      expect(videos[1].id).toBe('first')
+    })
+  })
+
+  describe('getById', () => {
+    it('returns video when found', () => {
+      store.insert(makeParams())
+      const video = store.getById('test-id-1')
+      expect(video).toBeDefined()
+      expect(video!.id).toBe('test-id-1')
+    })
+
+    it('returns undefined when not found', () => {
+      expect(store.getById('nonexistent')).toBeUndefined()
+    })
+
+    it('deserializes tags correctly on getById', () => {
+      store.insert(makeParams({ tags: ['a', 'b', 'c'] }))
+      const video = store.getById('test-id-1')
+      expect(video!.tags).toEqual(['a', 'b', 'c'])
+    })
+  })
+
+  describe('update', () => {
+    it('returns undefined for non-existent id', () => {
+      expect(store.update('nonexistent', { tags: ['x'] })).toBeUndefined()
+    })
+
+    it('updates tags', () => {
+      store.insert(makeParams())
+      const updated = store.update('test-id-1', { tags: ['new-tag'] })
+      expect(updated!.tags).toEqual(['new-tag'])
+    })
+
+    it('updates transcript_path', () => {
+      store.insert(makeParams())
+      const updated = store.update('test-id-1', { transcript_path: '/new/path.srt' })
+      expect(updated!.transcript_path).toBe('/new/path.srt')
+    })
+
+    it('updates transcript_format', () => {
+      store.insert(makeParams())
+      const updated = store.update('test-id-1', { transcript_format: 'srt' })
+      expect(updated!.transcript_format).toBe('srt')
+    })
+
+    it('updates multiple fields at once', () => {
+      store.insert(makeParams())
+      const updated = store.update('test-id-1', {
+        tags: ['updated'],
+        transcript_path: '/updated/path.vtt',
+        transcript_format: 'vtt',
+      })
+      expect(updated!.tags).toEqual(['updated'])
+      expect(updated!.transcript_path).toBe('/updated/path.vtt')
+      expect(updated!.transcript_format).toBe('vtt')
+    })
+
+    it('does not alter fields not included in params', () => {
+      store.insert(makeParams({ title: 'Original Title' }))
+      const updated = store.update('test-id-1', { tags: ['changed'] })
+      expect(updated!.title).toBe('Original Title')
+    })
+  })
+
+  describe('delete', () => {
+    it('returns false when video does not exist', () => {
+      expect(store.delete('nonexistent')).toBe(false)
+    })
+
+    it('returns true and removes the video', () => {
+      store.insert(makeParams())
+      expect(store.delete('test-id-1')).toBe(true)
+      expect(store.getById('test-id-1')).toBeUndefined()
+    })
+
+    it('does not affect other videos', () => {
+      store.insert(makeParams({ id: 'keep' }))
+      store.insert(makeParams({ id: 'remove' }))
+      store.delete('remove')
+      expect(store.getById('keep')).toBeDefined()
+      expect(store.list()).toHaveLength(1)
+    })
+  })
+})

--- a/src/lib/video-store.ts
+++ b/src/lib/video-store.ts
@@ -1,0 +1,87 @@
+import Database from 'better-sqlite3'
+import { Video, InsertVideoParams, UpdateVideoParams } from './videos'
+
+interface VideoRow {
+  id: string
+  youtube_url: string
+  youtube_id: string
+  title: string
+  author_name: string
+  thumbnail_url: string
+  transcript_path: string
+  transcript_format: string
+  tags: string
+  created_at: string
+  updated_at: string
+}
+
+function rowToVideo(row: VideoRow): Video {
+  return { ...row, tags: JSON.parse(row.tags) }
+}
+
+export interface VideoStore {
+  list(): Video[]
+  getById(id: string): Video | undefined
+  insert(params: InsertVideoParams): Video
+  update(id: string, params: UpdateVideoParams): Video | undefined
+  delete(id: string): boolean
+}
+
+export class SqliteVideoStore implements VideoStore {
+  constructor(private db: Database.Database) {}
+
+  list(): Video[] {
+    const rows = this.db.prepare('SELECT * FROM videos ORDER BY created_at DESC').all() as VideoRow[]
+    return rows.map(rowToVideo)
+  }
+
+  getById(id: string): Video | undefined {
+    const row = this.db.prepare('SELECT * FROM videos WHERE id = ?').get(id) as VideoRow | undefined
+    return row ? rowToVideo(row) : undefined
+  }
+
+  insert(params: InsertVideoParams): Video {
+    const now = new Date().toISOString()
+    this.db.prepare(`
+      INSERT INTO videos (id, youtube_url, youtube_id, title, author_name, thumbnail_url, transcript_path, transcript_format, tags, created_at, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      params.id, params.youtube_url, params.youtube_id, params.title,
+      params.author_name, params.thumbnail_url, params.transcript_path,
+      params.transcript_format, JSON.stringify(params.tags), now, now
+    )
+    return this.getById(params.id)!
+  }
+
+  update(id: string, params: UpdateVideoParams): Video | undefined {
+    const existing = this.getById(id)
+    if (!existing) return undefined
+
+    const updates: string[] = ['updated_at = ?']
+    const values: unknown[] = [new Date().toISOString()]
+
+    if (params.tags !== undefined) {
+      updates.push('tags = ?')
+      values.push(JSON.stringify(params.tags))
+    }
+    if (params.transcript_path !== undefined) {
+      updates.push('transcript_path = ?')
+      values.push(params.transcript_path)
+    }
+    if (params.transcript_format !== undefined) {
+      updates.push('transcript_format = ?')
+      values.push(params.transcript_format)
+    }
+
+    values.push(id)
+    this.db.prepare(`UPDATE videos SET ${updates.join(', ')} WHERE id = ?`).run(...values)
+    return this.getById(id)
+  }
+
+  delete(id: string): boolean {
+    const existing = this.getById(id)
+    if (!existing) return false
+    this.db.prepare('DELETE FROM videos WHERE id = ?').run(id)
+    return true
+  }
+}


### PR DESCRIPTION
Closes #78. Adds VideoStore interface and SqliteVideoStore with 18 passing tests (CRUD, tag serialization, ordering). Uses openDb(':memory:') + initializeSchema(db) directly. videos.ts untouched.