### PR TITLE
Refactor Playwright E2E tests for best practices

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -8,14 +8,16 @@ const e2eDataDir = path.join(os.tmpdir(), `lingoflow-e2e-${crypto.randomUUID()}`
 export default defineConfig({
   testDir: './tests/e2e',
   testMatch: ['**/*.spec.ts'],
-  fullyParallel: false,
+  fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  workers: 1,
-  reporter: 'list',
+  reporter: [
+    ['list'],
+    ['html', { open: 'never' }],
+  ],
   use: {
     baseURL: 'http://localhost:3000',
-    trace: 'on-first-retry',
+    trace: 'retain-on-failure',
   },
   projects: [
     {

--- a/src/components/ImportVideoModal.tsx
+++ b/src/components/ImportVideoModal.tsx
@@ -148,7 +148,7 @@ export default function ImportVideoModal({ isOpen, onClose, onSuccess }: ImportV
               required
             />
             {isLoadingPreview && <p className="loading-text">Loading preview...</p>}
-            {previewError && <p className="error-text">{previewError}</p>}
+            {previewError && <p data-testid="url-preview-error" className="error-text">{previewError}</p>}
           </div>
 
           {preview && (

--- a/tests/e2e/dashboard-states.spec.ts
+++ b/tests/e2e/dashboard-states.spec.ts
@@ -66,8 +66,7 @@ test.describe('Dashboard states', () => {
     const grid = page.getByTestId('video-grid')
     await expect(grid).toBeVisible()
 
-    const count = await dashboard.getVideoCardCount()
-    expect(count).toBe(1)
+    await dashboard.assertVideoCardCount(1)
   })
 
   test('hides loading indicator after response is received', async ({ page }) => {

--- a/tests/e2e/delete-video.spec.ts
+++ b/tests/e2e/delete-video.spec.ts
@@ -67,7 +67,7 @@ test.describe('Delete video workflow', () => {
     })
 
     await dashboard.loadDashboard()
-    expect(await dashboard.getVideoCardCount()).toBe(1)
+    await dashboard.assertVideoCardCount(1)
 
     await deleteActions.clickDeleteOnCard(0)
     await deleteActions.confirmDelete()
@@ -98,13 +98,13 @@ test.describe('Delete video workflow', () => {
     })
 
     await dashboard.loadDashboard()
-    expect(await dashboard.getVideoCardCount()).toBe(2)
+    await dashboard.assertVideoCardCount(2)
 
     await deleteActions.clickDeleteOnCard(0)
     await deleteActions.confirmDelete()
 
     await deleteActions.assertCardRemoved(MOCK_VIDEO_1.id)
-    expect(await dashboard.getVideoCardCount()).toBe(1)
+    await dashboard.assertVideoCardCount(1)
     await expect(page.getByTestId(`video-card-${MOCK_VIDEO_2.id}`)).toBeVisible()
   })
 })

--- a/tests/e2e/edit-tags.spec.ts
+++ b/tests/e2e/edit-tags.spec.ts
@@ -7,55 +7,70 @@
  */
 
 import { test, expect } from '@playwright/test'
-import path from 'path'
 import { DashboardPage } from './pages/DashboardPage'
-import { ImportActions } from './pages/ImportActions'
 import { EditActions } from './pages/EditActions'
-import { DeleteActions } from './pages/DeleteActions'
-
-const RICK_ASTLEY_URL = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ'
-const SAMPLE_SRT = path.join(__dirname, 'fixtures', 'sample.srt')
 
 test.describe('Edit tags', () => {
   test('edits tags and persists after reload', async ({ page }) => {
     const dashboard = new DashboardPage(page)
-    const importActions = new ImportActions(page)
     const editActions = new EditActions(page)
-    const deleteActions = new DeleteActions(page)
+    const initialVideo = {
+      id: 'test-vid-1',
+      youtube_url: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+      youtube_id: 'dQw4w9WgXcQ',
+      title: 'Rick Astley - Never Gonna Give You Up',
+      author_name: 'Rick Astley',
+      thumbnail_url: 'https://img.youtube.com/vi/dQw4w9WgXcQ/0.jpg',
+      transcript_path: '/tmp/test/transcripts/test-vid-1.srt',
+      transcript_format: 'srt',
+      tags: ['oldTag'],
+      created_at: '2024-01-01T00:00:00.000Z',
+      updated_at: '2024-01-01T00:00:00.000Z',
+    }
+    let video = initialVideo
 
-    // 1. Load dashboard and seed a video via import UI with an initial tag
+    await page.route('**/api/videos', async route => {
+      await route.fulfill({ json: [video] })
+    })
+
+    await page.route(`**/api/videos/${initialVideo.id}`, async route => {
+      if (route.request().method() !== 'PATCH') {
+        await route.continue()
+        return
+      }
+
+      video = {
+        ...video,
+        tags: ['newTag1', 'newTag2'],
+        updated_at: '2024-01-02T00:00:00.000Z',
+      }
+      await route.fulfill({ status: 200, json: video })
+    })
+
+    // 1. Load dashboard with one video
     await dashboard.loadDashboard()
-    await importActions.clickImportButton()
-    await importActions.fillYoutubeUrl(RICK_ASTLEY_URL)
-    await importActions.fillTranscriptFile(SAMPLE_SRT)
-    await importActions.fillTags('oldTag')
-    await importActions.clickSubmitImport()
-    await page.getByTestId('import-modal').waitFor({ state: 'hidden' })
+    await dashboard.assertVideoCardCount(1)
+    await expect(page.getByTestId(`video-card-${initialVideo.id}`)).toContainText('oldTag')
 
-    // 2. Verify the video card is present
-    const cards = await dashboard.getVideoCards()
-    expect(cards.length).toBeGreaterThanOrEqual(1)
-
-    // 3. Open edit modal on the first card
+    // 2. Open edit modal on the first card
     await editActions.clickEditOnCard(0)
 
-    // 4. Remove existing tag and add new tags
+    // 3. Remove existing tag and add new tags
     await editActions.removeTag('oldTag')
     await editActions.addTag('newTag1')
     await editActions.addTag('newTag2')
 
-    // 5. Save and wait for modal to close
+    // 4. Save and wait for modal to close
     await editActions.clickSave()
 
-    // 6. Verify UI reflects new tags immediately
+    // 5. Verify UI reflects new tags immediately
     await editActions.assertTagsSaved(['newTag1', 'newTag2'])
 
-    // 7. Reload page and confirm tags persisted
+    // 6. Reload page and confirm tags persisted
     await dashboard.loadDashboard()
-    await editActions.assertTagsSaved(['newTag1', 'newTag2'])
-
-    // 8. Clean up: delete the video so subsequent tests start with a clean state
-    await deleteActions.clickDeleteOnCard(0)
-    await deleteActions.confirmDelete()
+    const cardAfterReload = page.getByTestId(`video-card-${initialVideo.id}`)
+    await expect(cardAfterReload).toContainText('newTag1')
+    await expect(cardAfterReload).toContainText('newTag2')
+    await expect(cardAfterReload).not.toContainText('oldTag')
   })
 })

--- a/tests/e2e/import-happy-path.spec.ts
+++ b/tests/e2e/import-happy-path.spec.ts
@@ -19,6 +19,29 @@ test.describe('Import happy path', () => {
   test('imports a video with URL, transcript, and tags', async ({ page }) => {
     const dashboard = new DashboardPage(page)
     const importActions = new ImportActions(page)
+    const importedVideo = {
+      id: 'test-vid-1',
+      youtube_url: RICK_ASTLEY_URL,
+      youtube_id: 'dQw4w9WgXcQ',
+      title: RICK_ASTLEY_TITLE,
+      author_name: 'Rick Astley',
+      thumbnail_url: 'https://img.youtube.com/vi/dQw4w9WgXcQ/0.jpg',
+      transcript_path: '/tmp/test/transcripts/test-vid-1.srt',
+      transcript_format: 'srt',
+      tags: ['music', 'classic'],
+      created_at: '2024-01-01T00:00:00.000Z',
+      updated_at: '2024-01-01T00:00:00.000Z',
+    }
+    let videos: typeof importedVideo[] = []
+
+    await page.route('**/api/videos', async route => {
+      await route.fulfill({ json: videos })
+    })
+
+    await page.route('**/api/videos/import', async route => {
+      videos = [importedVideo]
+      await route.fulfill({ status: 201, json: importedVideo })
+    })
 
     // 1. Load dashboard and assert empty state
     await dashboard.loadDashboard()
@@ -35,18 +58,17 @@ test.describe('Import happy path', () => {
 
     // 5. Add tags
     await importActions.fillTags('music, classic')
+    await expect(page.getByTestId('preview-container')).toBeVisible()
 
     // 6. Submit import
     await importActions.clickSubmitImport()
 
     // 7. Assert modal closes
-    await page.getByTestId('import-modal').waitFor({ state: 'hidden' })
+    await expect(page.getByTestId('import-modal')).toBeHidden()
 
     // 8. Assert video card appears with correct title
-    const cards = await dashboard.getVideoCards()
-    expect(cards.length).toBeGreaterThanOrEqual(1)
-
-    const firstCard = cards[0]
+    await dashboard.assertVideoCardCount(1)
+    const firstCard = page.getByTestId(`video-card-${importedVideo.id}`)
     await expect(firstCard).toContainText(RICK_ASTLEY_TITLE)
 
     // 9. Assert tags visible on card
@@ -55,8 +77,7 @@ test.describe('Import happy path', () => {
 
     // 10. Reload page and assert card still present (persistence check)
     await dashboard.loadDashboard()
-    const cardsAfterReload = await dashboard.getVideoCards()
-    expect(cardsAfterReload.length).toBeGreaterThanOrEqual(1)
-    await expect(cardsAfterReload[0]).toContainText(RICK_ASTLEY_TITLE)
+    await dashboard.assertVideoCardCount(1)
+    await expect(page.getByTestId(`video-card-${importedVideo.id}`)).toContainText(RICK_ASTLEY_TITLE)
   })
 })

--- a/tests/e2e/import-validation.spec.ts
+++ b/tests/e2e/import-validation.spec.ts
@@ -5,8 +5,8 @@
  * validation (400/422 responses) surface the correct user-facing error messages.
  *
  * Scenarios:
- *   1. Plain invalid URL  → preview error (.error-text) + submit disabled
- *   2. Non-YouTube URL    → preview error (.error-text) + submit disabled
+ *   1. Plain invalid URL  → preview error + submit disabled
+ *   2. Non-YouTube URL    → preview error + submit disabled
  *   3. Valid URL, no file → submit button disabled
  *   4. Valid URL + .doc   → submit → server 400 → import-error "Invalid file extension"
  *   5. Bad URL → fix URL + add file → error clears + submit re-enabled
@@ -21,106 +21,79 @@ const RICK_ASTLEY_URL = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ'
 const SAMPLE_SRT = path.join(__dirname, 'fixtures', 'sample.srt')
 
 test.describe('Import form validation', () => {
-  test('1 — plain invalid URL shows preview error and disables submit', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     const dashboard = new DashboardPage(page)
     const importActions = new ImportActions(page)
-
     await dashboard.loadDashboard()
     await importActions.clickImportButton()
+  })
+
+  test('1 — plain invalid URL shows preview error and disables submit', async ({ page }) => {
+    const importActions = new ImportActions(page)
 
     await importActions.fillYoutubeUrl('not-a-url')
 
-    // Wait for the debounced preview fetch to complete and error to appear
-    await page.locator('.error-text').waitFor({ state: 'visible' })
+    await expect(page.getByTestId('url-preview-error')).toBeVisible()
 
     const submitBtn = page.getByTestId('submit-import-button')
     await expect(submitBtn).toBeDisabled()
   })
 
   test('2 — non-YouTube URL shows preview error and disables submit', async ({ page }) => {
-    const dashboard = new DashboardPage(page)
     const importActions = new ImportActions(page)
-
-    await dashboard.loadDashboard()
-    await importActions.clickImportButton()
 
     await importActions.fillYoutubeUrl('https://notyoutube.com/watch?v=abc')
 
-    await page.locator('.error-text').waitFor({ state: 'visible' })
+    await expect(page.getByTestId('url-preview-error')).toBeVisible()
 
     const submitBtn = page.getByTestId('submit-import-button')
     await expect(submitBtn).toBeDisabled()
   })
 
   test('3 — valid URL with no transcript file keeps submit disabled', async ({ page }) => {
-    const dashboard = new DashboardPage(page)
     const importActions = new ImportActions(page)
 
-    await dashboard.loadDashboard()
-    await importActions.clickImportButton()
-
     await importActions.fillYoutubeUrl(RICK_ASTLEY_URL)
-
-    // Wait for preview to load successfully (no error-text)
-    await page.locator('.error-text').waitFor({ state: 'hidden' }).catch(() => {})
-    // Give debounce time to settle
-    await page.waitForTimeout(700)
+    await expect(page.getByTestId('url-preview-error')).toBeHidden()
+    await expect(page.getByTestId('preview-container')).toBeVisible()
 
     const submitBtn = page.getByTestId('submit-import-button')
     await expect(submitBtn).toBeDisabled()
   })
 
   test('4 — valid URL + .doc file → server 400 shows "Invalid file extension" error', async ({ page }) => {
-    const dashboard = new DashboardPage(page)
     const importActions = new ImportActions(page)
 
-    await dashboard.loadDashboard()
-    await importActions.clickImportButton()
-
     await importActions.fillYoutubeUrl(RICK_ASTLEY_URL)
+    await expect(page.getByTestId('url-preview-error')).toBeHidden()
+    await expect(page.getByTestId('preview-container')).toBeVisible()
 
-    // Wait for preview to load (debounce + fetch)
-    await page.waitForTimeout(700)
-    // Ensure no preview error before uploading bad file
-    const errorVisible = await page.locator('.error-text').isVisible()
-    if (!errorVisible) {
-      // Preview loaded successfully; upload the unsupported file
-      await page.getByTestId('transcript-input').setInputFiles({
-        name: 'transcript.doc',
-        mimeType: 'application/msword',
-        buffer: Buffer.from('fake doc content'),
-      })
+    await importActions.fillTranscriptFile({
+      name: 'transcript.doc',
+      mimeType: 'application/msword',
+      buffer: Buffer.from('fake doc content'),
+    })
 
-      await importActions.clickSubmitImport()
-      await importActions.assertValidationError('Invalid file extension')
-    } else {
-      // Preview errored (e.g. stub not responding in time) — skip gracefully
-      test.skip()
-    }
+    await importActions.clickSubmitImport()
+    await importActions.assertValidationError('Invalid file extension')
   })
 
   test('5 — bad URL fixed to valid URL + file clears error and re-enables submit', async ({ page }) => {
-    const dashboard = new DashboardPage(page)
     const importActions = new ImportActions(page)
-
-    await dashboard.loadDashboard()
-    await importActions.clickImportButton()
 
     // Enter invalid URL first
     await importActions.fillYoutubeUrl('not-a-url')
-    await page.locator('.error-text').waitFor({ state: 'visible' })
+    await expect(page.getByTestId('url-preview-error')).toBeVisible()
 
     // Fix URL and add valid transcript file
     await page.getByTestId('youtube-url-input').fill('')
     await importActions.fillYoutubeUrl(RICK_ASTLEY_URL)
 
     // Wait for preview to load and error to clear
-    await page.locator('.error-text').waitFor({ state: 'hidden' })
+    await expect(page.getByTestId('url-preview-error')).toBeHidden()
+    await expect(page.getByTestId('preview-container')).toBeVisible()
 
     await importActions.fillTranscriptFile(SAMPLE_SRT)
-
-    // Wait for canSubmit to become true
-    await page.waitForTimeout(800)
 
     const submitBtn = page.getByTestId('submit-import-button')
     await expect(submitBtn).toBeEnabled()

--- a/tests/e2e/pages/DashboardPage.ts
+++ b/tests/e2e/pages/DashboardPage.ts
@@ -11,7 +11,7 @@
  *   await dashboard.assertEmpty()
  */
 
-import type { Page, Locator } from '@playwright/test'
+import { expect, type Page, type Locator } from '@playwright/test'
 
 export class DashboardPage {
   readonly page: Page
@@ -27,12 +27,22 @@ export class DashboardPage {
 
   /** Asserts that the loading indicator is visible. */
   async assertLoading(): Promise<void> {
-    await this.page.getByTestId('loading-indicator').waitFor({ state: 'visible' })
+    await expect(this.page.getByTestId('loading-indicator')).toBeVisible()
   }
 
   /** Asserts that the empty-state placeholder is visible (no videos imported). */
   async assertEmpty(): Promise<void> {
-    await this.page.getByTestId('empty-state').waitFor({ state: 'visible' })
+    await expect(this.page.getByTestId('empty-state')).toBeVisible()
+  }
+
+  /** Returns the video-card locator list in the dashboard grid. */
+  videoCards(): Locator {
+    return this.page.getByTestId('video-grid').locator('[data-testid^="video-card-"]')
+  }
+
+  /** Asserts the exact number of video cards rendered in the grid. */
+  async assertVideoCardCount(count: number): Promise<void> {
+    await expect(this.videoCards()).toHaveCount(count)
   }
 
   /**
@@ -40,9 +50,7 @@ export class DashboardPage {
    * Waits for the grid to be present before querying cards.
    */
   async getVideoCards(): Promise<Locator[]> {
-    const grid = this.page.getByTestId('video-grid')
-    await grid.waitFor({ state: 'visible' })
-    return grid.locator('[data-testid^="video-card-"]').all()
+    return this.videoCards().all()
   }
 
   /** Returns the number of video cards currently visible in the grid. */

--- a/tests/e2e/pages/DeleteActions.ts
+++ b/tests/e2e/pages/DeleteActions.ts
@@ -12,7 +12,7 @@
  *   await deleteActions.assertCardRemoved('video-id-123')
  */
 
-import type { Page } from '@playwright/test'
+import { expect, type Page } from '@playwright/test'
 
 export class DeleteActions {
   readonly page: Page
@@ -27,18 +27,18 @@ export class DeleteActions {
    * @param index - Zero-based index of the card in the video grid.
    */
   async clickDeleteOnCard(index: number): Promise<void> {
-    const deleteButtons = await this.page
+    await this.page
       .getByTestId('video-grid')
       .locator('[data-testid="delete-button"]')
-      .all()
-    await deleteButtons[index].click()
-    await this.page.getByTestId('delete-modal').waitFor({ state: 'visible' })
+      .nth(index)
+      .click()
+    await expect(this.page.getByTestId('delete-modal')).toBeVisible()
   }
 
   /** Clicks the confirm-delete button and waits for the modal to close. */
   async confirmDelete(): Promise<void> {
     await this.page.getByTestId('confirm-delete-button').click()
-    await this.page.getByTestId('delete-modal').waitFor({ state: 'hidden' })
+    await expect(this.page.getByTestId('delete-modal')).toBeHidden()
   }
 
   /**
@@ -46,6 +46,6 @@ export class DeleteActions {
    * @param videoId - The video ID used in the `video-card-{id}` testid.
    */
   async assertCardRemoved(videoId: string): Promise<void> {
-    await this.page.getByTestId(`video-card-${videoId}`).waitFor({ state: 'hidden' })
+    await expect(this.page.getByTestId(`video-card-${videoId}`)).toBeHidden()
   }
 }

--- a/tests/e2e/pages/EditActions.ts
+++ b/tests/e2e/pages/EditActions.ts
@@ -14,7 +14,7 @@
  *   await editActions.assertTagsSaved(['newTag'])
  */
 
-import type { Page } from '@playwright/test'
+import { expect, type Page } from '@playwright/test'
 
 export class EditActions {
   readonly page: Page
@@ -29,12 +29,12 @@ export class EditActions {
    * @param index - Zero-based index of the card in the video grid.
    */
   async clickEditOnCard(index: number): Promise<void> {
-    const editButtons = await this.page
+    await this.page
       .getByTestId('video-grid')
       .locator('[data-testid="edit-button"]')
-      .all()
-    await editButtons[index].click()
-    await this.page.getByTestId('edit-modal').waitFor({ state: 'visible' })
+      .nth(index)
+      .click()
+    await expect(this.page.getByTestId('edit-modal')).toBeVisible()
   }
 
   /**
@@ -58,7 +58,7 @@ export class EditActions {
   /** Clicks the Save button in the edit modal and waits for the modal to close. */
   async clickSave(): Promise<void> {
     await this.page.getByTestId('edit-modal').getByRole('button', { name: 'Save' }).click()
-    await this.page.getByTestId('edit-modal').waitFor({ state: 'hidden' })
+    await expect(this.page.getByTestId('edit-modal')).toBeHidden()
   }
 
   /**
@@ -70,7 +70,7 @@ export class EditActions {
    */
   async assertTagsSaved(expectedTags: string[]): Promise<void> {
     for (const tag of expectedTags) {
-      await this.page.getByText(tag).waitFor({ state: 'visible' })
+      await expect(this.page.getByText(tag)).toBeVisible()
     }
   }
 }

--- a/tests/e2e/pages/ImportActions.ts
+++ b/tests/e2e/pages/ImportActions.ts
@@ -13,7 +13,9 @@
  *   await importActions.clickSubmitImport()
  */
 
-import type { Page } from '@playwright/test'
+import { expect, type Page, type Locator } from '@playwright/test'
+
+type TranscriptInput = Parameters<Locator['setInputFiles']>[0]
 
 export class ImportActions {
   readonly page: Page
@@ -24,9 +26,9 @@ export class ImportActions {
 
   /** Clicks the "Import Video" button on the dashboard to open the modal. */
   async clickImportButton(): Promise<void> {
-    await this.page.getByTestId('import-modal').waitFor({ state: 'hidden' }).catch(() => {})
+    await expect(this.page.getByTestId('import-modal')).toBeHidden()
     await this.page.getByRole('button', { name: 'Import Video' }).click()
-    await this.page.getByTestId('import-modal').waitFor({ state: 'visible' })
+    await expect(this.page.getByTestId('import-modal')).toBeVisible()
   }
 
   /** Fills the YouTube URL field in the import modal. */
@@ -38,8 +40,8 @@ export class ImportActions {
    * Sets the transcript file input using the provided file path.
    * @param filePath - Absolute or project-relative path to the transcript file.
    */
-  async fillTranscriptFile(filePath: string): Promise<void> {
-    await this.page.getByTestId('transcript-input').setInputFiles(filePath)
+  async fillTranscriptFile(file: TranscriptInput): Promise<void> {
+    await this.page.getByTestId('transcript-input').setInputFiles(file)
   }
 
   /** Fills the tags field in the import modal (comma-separated string). */
@@ -59,9 +61,9 @@ export class ImportActions {
    */
   async assertValidationError(message?: string): Promise<void> {
     const errorLocator = this.page.getByTestId('import-error')
-    await errorLocator.waitFor({ state: 'visible' })
+    await expect(errorLocator).toBeVisible()
     if (message !== undefined) {
-      await errorLocator.filter({ hasText: message }).waitFor({ state: 'visible' })
+      await expect(errorLocator).toContainText(message)
     }
   }
 }

--- a/tests/e2e/pages/__tests__/DashboardPage.test.ts
+++ b/tests/e2e/pages/__tests__/DashboardPage.test.ts
@@ -6,12 +6,19 @@
 
 import { DashboardPage } from '../DashboardPage'
 
+jest.mock('@playwright/test', () => ({
+  expect: jest.fn(() => ({
+    toBeVisible: jest.fn().mockResolvedValue(undefined),
+    toHaveCount: jest.fn().mockResolvedValue(undefined),
+  })),
+}))
+
 /** Minimal mock for a Playwright Locator */
 function makeLocator(overrides: Partial<Record<string, jest.Mock>> = {}) {
   const locator: Record<string, jest.Mock> = {
-    waitFor: jest.fn().mockResolvedValue(undefined),
     all: jest.fn().mockResolvedValue([]),
     locator: jest.fn(),
+    count: jest.fn().mockResolvedValue(0),
     ...overrides,
   }
   // chainable locator()
@@ -39,19 +46,17 @@ describe('DashboardPage', () => {
   })
 
   it('assertLoading() waits for loading-indicator to be visible', async () => {
-    const { page, locator } = makePage()
+    const { page } = makePage()
     const dashboard = new DashboardPage(page as any)
     await dashboard.assertLoading()
     expect(page.getByTestId).toHaveBeenCalledWith('loading-indicator')
-    expect(locator.waitFor).toHaveBeenCalledWith({ state: 'visible' })
   })
 
   it('assertEmpty() waits for empty-state to be visible', async () => {
-    const { page, locator } = makePage()
+    const { page } = makePage()
     const dashboard = new DashboardPage(page as any)
     await dashboard.assertEmpty()
     expect(page.getByTestId).toHaveBeenCalledWith('empty-state')
-    expect(locator.waitFor).toHaveBeenCalledWith({ state: 'visible' })
   })
 
   it('getVideoCards() queries video-grid and card locators', async () => {

--- a/tests/e2e/pages/__tests__/DeleteActions.test.ts
+++ b/tests/e2e/pages/__tests__/DeleteActions.test.ts
@@ -5,15 +5,22 @@
 
 import { DeleteActions } from '../DeleteActions'
 
+jest.mock('@playwright/test', () => ({
+  expect: jest.fn(() => ({
+    toBeVisible: jest.fn().mockResolvedValue(undefined),
+    toBeHidden: jest.fn().mockResolvedValue(undefined),
+  })),
+}))
+
 function makeLocator(overrides: Partial<Record<string, jest.Mock>> = {}) {
   const locator: Record<string, jest.Mock> = {
-    waitFor: jest.fn().mockResolvedValue(undefined),
     click: jest.fn().mockResolvedValue(undefined),
-    all: jest.fn().mockResolvedValue([]),
+    nth: jest.fn(),
     locator: jest.fn(),
     ...overrides,
   }
   locator.locator.mockReturnValue(locator)
+  locator.nth.mockReturnValue(locator)
   return locator
 }
 
@@ -28,20 +35,14 @@ function makePage() {
 
 describe('DeleteActions', () => {
   it('clickDeleteOnCard() clicks the delete button at given index and waits for modal', async () => {
-    const deleteBtn0 = makeLocator()
-    const deleteBtn1 = makeLocator()
     const btnListLocator = makeLocator()
-    btnListLocator.all.mockResolvedValue([deleteBtn0, deleteBtn1])
 
     const gridLocator = makeLocator()
     gridLocator.locator.mockReturnValue(btnListLocator)
 
-    const modalLocator = makeLocator()
-
     const page = {
       getByTestId: jest.fn().mockImplementation((id: string) => {
         if (id === 'video-grid') return gridLocator
-        if (id === 'delete-modal') return modalLocator
         return makeLocator()
       }),
       getByRole: jest.fn().mockReturnValue(makeLocator()),
@@ -52,18 +53,16 @@ describe('DeleteActions', () => {
 
     expect(page.getByTestId).toHaveBeenCalledWith('video-grid')
     expect(gridLocator.locator).toHaveBeenCalledWith('[data-testid="delete-button"]')
-    expect(deleteBtn0.click).toHaveBeenCalled()
-    expect(modalLocator.waitFor).toHaveBeenCalledWith({ state: 'visible' })
+    expect(btnListLocator.nth).toHaveBeenCalledWith(0)
+    expect(btnListLocator.click).toHaveBeenCalled()
   })
 
   it('confirmDelete() clicks confirm-delete-button and waits for modal to close', async () => {
     const confirmLocator = makeLocator()
-    const modalLocator = makeLocator()
 
     const page = {
       getByTestId: jest.fn().mockImplementation((id: string) => {
         if (id === 'confirm-delete-button') return confirmLocator
-        if (id === 'delete-modal') return modalLocator
         return makeLocator()
       }),
       getByRole: jest.fn().mockReturnValue(makeLocator()),
@@ -74,7 +73,6 @@ describe('DeleteActions', () => {
 
     expect(page.getByTestId).toHaveBeenCalledWith('confirm-delete-button')
     expect(confirmLocator.click).toHaveBeenCalled()
-    expect(modalLocator.waitFor).toHaveBeenCalledWith({ state: 'hidden' })
   })
 
   it('assertCardRemoved() waits for the video card to be hidden', async () => {
@@ -88,6 +86,5 @@ describe('DeleteActions', () => {
     await deleteActions.assertCardRemoved('abc-123')
 
     expect(page.getByTestId).toHaveBeenCalledWith('video-card-abc-123')
-    expect(cardLocator.waitFor).toHaveBeenCalledWith({ state: 'hidden' })
   })
 })

--- a/tests/e2e/pages/__tests__/EditActions.test.ts
+++ b/tests/e2e/pages/__tests__/EditActions.test.ts
@@ -5,13 +5,19 @@
 
 import { EditActions } from '../EditActions'
 
+jest.mock('@playwright/test', () => ({
+  expect: jest.fn(() => ({
+    toBeVisible: jest.fn().mockResolvedValue(undefined),
+    toBeHidden: jest.fn().mockResolvedValue(undefined),
+  })),
+}))
+
 function makeLocator(overrides: Partial<Record<string, jest.Mock>> = {}) {
   const locator: Record<string, jest.Mock> = {
-    waitFor: jest.fn().mockResolvedValue(undefined),
     fill: jest.fn().mockResolvedValue(undefined),
     click: jest.fn().mockResolvedValue(undefined),
     press: jest.fn().mockResolvedValue(undefined),
-    all: jest.fn().mockResolvedValue([]),
+    nth: jest.fn(),
     locator: jest.fn(),
     getByRole: jest.fn(),
     getByTestId: jest.fn(),
@@ -19,6 +25,7 @@ function makeLocator(overrides: Partial<Record<string, jest.Mock>> = {}) {
     ...overrides,
   }
   locator.locator.mockReturnValue(locator)
+  locator.nth.mockReturnValue(locator)
   locator.getByRole.mockReturnValue(locator)
   locator.getByTestId.mockReturnValue(locator)
   locator.getByText.mockReturnValue(locator)
@@ -37,20 +44,14 @@ function makePage() {
 
 describe('EditActions', () => {
   it('clickEditOnCard() clicks the edit button at given index and waits for modal', async () => {
-    const editBtn0 = makeLocator()
-    const editBtn1 = makeLocator()
     const btnListLocator = makeLocator()
-    btnListLocator.all.mockResolvedValue([editBtn0, editBtn1])
 
     const gridLocator = makeLocator()
     gridLocator.locator.mockReturnValue(btnListLocator)
 
-    const modalLocator = makeLocator()
-
     const page = {
       getByTestId: jest.fn().mockImplementation((id: string) => {
         if (id === 'video-grid') return gridLocator
-        if (id === 'edit-modal') return modalLocator
         return makeLocator()
       }),
       getByRole: jest.fn().mockReturnValue(makeLocator()),
@@ -60,8 +61,8 @@ describe('EditActions', () => {
     const editActions = new EditActions(page as any)
     await editActions.clickEditOnCard(1)
 
-    expect(editBtn1.click).toHaveBeenCalled()
-    expect(modalLocator.waitFor).toHaveBeenCalledWith({ state: 'visible' })
+    expect(btnListLocator.nth).toHaveBeenCalledWith(1)
+    expect(btnListLocator.click).toHaveBeenCalled()
   })
 
   it('addTag() fills tag-input and presses Enter', async () => {
@@ -112,7 +113,6 @@ describe('EditActions', () => {
     await editActions.clickSave()
     expect(modalLocator.getByRole).toHaveBeenCalledWith('button', { name: 'Save' })
     expect(saveBtn.click).toHaveBeenCalled()
-    expect(modalLocator.waitFor).toHaveBeenCalledWith({ state: 'hidden' })
   })
 
   it('assertTagsSaved() waits for each tag text to be visible', async () => {
@@ -127,6 +127,5 @@ describe('EditActions', () => {
     await editActions.assertTagsSaved(['spanish', 'beginner'])
     expect(page.getByText).toHaveBeenCalledWith('spanish')
     expect(page.getByText).toHaveBeenCalledWith('beginner')
-    expect(tagLocator.waitFor).toHaveBeenCalledWith({ state: 'visible' })
   })
 })

--- a/tests/e2e/pages/__tests__/ImportActions.test.ts
+++ b/tests/e2e/pages/__tests__/ImportActions.test.ts
@@ -5,16 +5,21 @@
 
 import { ImportActions } from '../ImportActions'
 
+jest.mock('@playwright/test', () => ({
+  expect: jest.fn(() => ({
+    toBeVisible: jest.fn().mockResolvedValue(undefined),
+    toBeHidden: jest.fn().mockResolvedValue(undefined),
+    toContainText: jest.fn().mockResolvedValue(undefined),
+  })),
+}))
+
 function makeLocator(overrides: Partial<Record<string, jest.Mock>> = {}) {
   const locator: Record<string, jest.Mock> = {
-    waitFor: jest.fn().mockResolvedValue(undefined),
     fill: jest.fn().mockResolvedValue(undefined),
     click: jest.fn().mockResolvedValue(undefined),
     setInputFiles: jest.fn().mockResolvedValue(undefined),
-    filter: jest.fn(),
     ...overrides,
   }
-  locator.filter.mockReturnValue(locator)
   return locator
 }
 
@@ -29,12 +34,8 @@ function makePage() {
 
 describe('ImportActions', () => {
   it('clickImportButton() opens the import modal', async () => {
-    const hiddenLocator = makeLocator({
-      waitFor: jest.fn().mockResolvedValue(undefined),
-    })
-    const visibleLocator = makeLocator({
-      waitFor: jest.fn().mockResolvedValue(undefined),
-    })
+    const hiddenLocator = makeLocator()
+    const visibleLocator = makeLocator()
     const buttonLocator = makeLocator()
 
     let callCount = 0
@@ -87,18 +88,16 @@ describe('ImportActions', () => {
   })
 
   it('assertValidationError() waits for import-error to be visible', async () => {
-    const { page, locator } = makePage()
+    const { page } = makePage()
     const importActions = new ImportActions(page as any)
     await importActions.assertValidationError()
     expect(page.getByTestId).toHaveBeenCalledWith('import-error')
-    expect(locator.waitFor).toHaveBeenCalledWith({ state: 'visible' })
   })
 
   it('assertValidationError() filters by message text when provided', async () => {
-    const { page, locator } = makePage()
+    const { page } = makePage()
     const importActions = new ImportActions(page as any)
     await importActions.assertValidationError('YouTube URL is required')
-    expect(locator.filter).toHaveBeenCalledWith({ hasText: 'YouTube URL is required' })
-    expect(locator.waitFor).toHaveBeenCalledWith({ state: 'visible' })
+    expect(page.getByTestId).toHaveBeenCalledWith('import-error')
   })
 })


### PR DESCRIPTION
## Summary
- refactor E2E specs to fully isolate state with API route mocking for import/edit workflows
- replace brittle waits and class-based selectors with resilient web-first assertions and test ids
- improve page objects with web-first assertion helpers and nth-based locator usage
- update Playwright config with HTML reporter, retained traces on failure, and full parallel mode

## Validation
- pnpm build
- pnpm test:e2e