### PR TITLE
Fix E2E workflow pnpm workspace and PR comment permissions

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+  pull-requests: read
+  issues: write
+
 jobs:
   e2e:
     name: Playwright E2E Suite
@@ -66,6 +71,7 @@ jobs:
 
       - name: Comment on merged PR on failure
         if: failure()
+        continue-on-error: true
         uses: actions/github-script@v7
         with:
           script: |

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
+packages:
+  - '.'
+
 allowBuilds:
   better-sqlite3: true
   sharp: false


### PR DESCRIPTION
Summary: add packages dot to pnpm-workspace.yaml, add explicit workflow permissions, and make failure comment step non-blocking to avoid notification failures breaking the job.