### PR TITLE
Refactor: Zod-inferred canonical Video type as single source of truth

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "better-sqlite3": "^12.8.0",
     "next": "16.2.3",
     "react": "19.2.4",
-    "react-dom": "19.2.4"
+    "react-dom": "19.2.4",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@playwright/test": "^1.59.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       react-dom:
         specifier: 19.2.4
         version: 19.2.4(react@19.2.4)
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@playwright/test':
         specifier: ^1.59.1

--- a/src/hooks/useVideos.ts
+++ b/src/hooks/useVideos.ts
@@ -1,18 +1,7 @@
 import { useQuery, UseQueryResult } from '@tanstack/react-query'
+import { Video } from '@/lib/videos'
 
-export interface Video {
-  id: string
-  youtube_url: string
-  youtube_id: string
-  title: string
-  author_name: string
-  thumbnail_url: string
-  transcript_path: string
-  transcript_format: string
-  tags: string[]
-  created_at: string
-  updated_at: string
-}
+export type { Video }
 
 export function useVideos(): UseQueryResult<Video[], Error> {
   return useQuery({

--- a/src/lib/__tests__/videos.test.ts
+++ b/src/lib/__tests__/videos.test.ts
@@ -1,0 +1,88 @@
+import {
+  VideoSchema,
+  InsertVideoParamsSchema,
+  UpdateVideoParamsSchema,
+  type Video,
+  type InsertVideoParams,
+  type UpdateVideoParams,
+} from '../videos'
+
+const validVideo: Video = {
+  id: 'v1',
+  youtube_url: 'https://youtube.com/watch?v=abc',
+  youtube_id: 'abc',
+  title: 'Test Video',
+  author_name: 'Author',
+  thumbnail_url: 'https://img.youtube.com/vi/abc/0.jpg',
+  transcript_path: '/transcripts/v1.vtt',
+  transcript_format: 'vtt',
+  tags: ['tag1', 'tag2'],
+  created_at: '2024-01-01T00:00:00.000Z',
+  updated_at: '2024-01-01T00:00:00.000Z',
+}
+
+const validInsert: InsertVideoParams = {
+  id: 'v1',
+  youtube_url: 'https://youtube.com/watch?v=abc',
+  youtube_id: 'abc',
+  title: 'Test Video',
+  author_name: 'Author',
+  thumbnail_url: 'https://img.youtube.com/vi/abc/0.jpg',
+  transcript_path: '/transcripts/v1.vtt',
+  transcript_format: 'vtt',
+  tags: [],
+}
+
+describe('VideoSchema', () => {
+  it('parses a valid video object', () => {
+    expect(VideoSchema.parse(validVideo)).toEqual(validVideo)
+  })
+
+  it('rejects missing required fields', () => {
+    const { id, ...rest } = validVideo
+    expect(() => VideoSchema.parse(rest)).toThrow()
+  })
+
+  it('rejects non-array tags', () => {
+    expect(() => VideoSchema.parse({ ...validVideo, tags: 'bad' })).toThrow()
+  })
+})
+
+describe('InsertVideoParamsSchema', () => {
+  it('parses a valid insert params object', () => {
+    expect(InsertVideoParamsSchema.parse(validInsert)).toEqual(validInsert)
+  })
+
+  it('rejects missing required fields', () => {
+    const { title, ...rest } = validInsert
+    expect(() => InsertVideoParamsSchema.parse(rest)).toThrow()
+  })
+
+  it('does not include created_at or updated_at', () => {
+    const result = InsertVideoParamsSchema.safeParse({ ...validInsert, created_at: '2024-01-01' })
+    expect(result.success).toBe(true)
+    // Zod strips unknown keys only in strict mode; just confirm parse succeeds
+  })
+})
+
+describe('UpdateVideoParamsSchema', () => {
+  it('parses an empty object (all fields optional)', () => {
+    const result: UpdateVideoParams = UpdateVideoParamsSchema.parse({})
+    expect(result).toEqual({})
+  })
+
+  it('parses partial update with tags only', () => {
+    const result = UpdateVideoParamsSchema.parse({ tags: ['a', 'b'] })
+    expect(result.tags).toEqual(['a', 'b'])
+  })
+
+  it('parses partial update with transcript fields', () => {
+    const result = UpdateVideoParamsSchema.parse({ transcript_path: '/p.srt', transcript_format: 'srt' })
+    expect(result.transcript_path).toBe('/p.srt')
+    expect(result.transcript_format).toBe('srt')
+  })
+
+  it('rejects non-string transcript_path', () => {
+    expect(() => UpdateVideoParamsSchema.parse({ transcript_path: 123 })).toThrow()
+  })
+})

--- a/src/lib/videos.ts
+++ b/src/lib/videos.ts
@@ -1,0 +1,37 @@
+import { z } from 'zod'
+
+export const VideoSchema = z.object({
+  id: z.string(),
+  youtube_url: z.string(),
+  youtube_id: z.string(),
+  title: z.string(),
+  author_name: z.string(),
+  thumbnail_url: z.string(),
+  transcript_path: z.string(),
+  transcript_format: z.string(),
+  tags: z.array(z.string()),
+  created_at: z.string(),
+  updated_at: z.string(),
+})
+
+export const InsertVideoParamsSchema = z.object({
+  id: z.string(),
+  youtube_url: z.string(),
+  youtube_id: z.string(),
+  title: z.string(),
+  author_name: z.string(),
+  thumbnail_url: z.string(),
+  transcript_path: z.string(),
+  transcript_format: z.string(),
+  tags: z.array(z.string()),
+})
+
+export const UpdateVideoParamsSchema = z.object({
+  tags: z.array(z.string()).optional(),
+  transcript_path: z.string().optional(),
+  transcript_format: z.string().optional(),
+})
+
+export type Video = z.infer<typeof VideoSchema>
+export type InsertVideoParams = z.infer<typeof InsertVideoParamsSchema>
+export type UpdateVideoParams = z.infer<typeof UpdateVideoParamsSchema>


### PR DESCRIPTION
Closes #92

## Changes

- Create src/lib/videos.ts with Zod schemas as single source of truth
- Replace local Video interface in useVideos.ts with import from @/lib/videos
- Add src/lib/__tests__/videos.test.ts for schema validation
- Install zod dependency

## Test Results
126 passed, 1 pre-existing failure in youtube.test.ts (unrelated)