### PR TITLE
Refactor: Zod schemas as single source of truth for API request validation

### DIFF
--- a/src/app/api/videos/[id]/route.ts
+++ b/src/app/api/videos/[id]/route.ts
@@ -2,6 +2,7 @@
 import { NextResponse } from 'next/server'
 import { getVideoStore, getVideoService } from '@/lib/server/composition'
 import { UpdateVideoServiceParams } from '@/lib/video-service'
+import { UpdateVideoRequestSchema } from '@/lib/api-schemas'
 
 export const runtime = 'nodejs'
 
@@ -47,29 +48,21 @@ export async function PATCH(
     const { id } = await params
 
     const formData = await request.formData()
-    const tagsRaw = formData.get('tags')
-    const transcriptFile = formData.get('transcript') as File | null
 
-    if (typeof tagsRaw !== 'string') {
-      return NextResponse.json({ error: 'Invalid tags field' }, { status: 400 })
+    const result = UpdateVideoRequestSchema.safeParse({
+      tags: formData.get('tags'),
+      transcript: formData.get('transcript'),
+    })
+
+    if (!result.success) {
+      return NextResponse.json({ error: result.error.issues[0].message }, { status: 400 })
     }
 
-    let tags: string[]
-    try {
-      tags = JSON.parse(tagsRaw)
-      if (!Array.isArray(tags)) throw new Error()
-    } catch {
-      return NextResponse.json({ error: 'Tags must be a JSON array' }, { status: 400 })
-    }
-
+    const { tags, transcript: transcriptFile } = result.data
     const serviceParams: UpdateVideoServiceParams = { tags }
 
     if (transcriptFile && transcriptFile.size > 0) {
-      const ext = transcriptFile.name.split('.').pop()?.toLowerCase() || ''
-      if (!['srt', 'vtt', 'txt'].includes(ext)) {
-        return NextResponse.json({ error: 'Invalid file extension. Allowed: srt, vtt, txt' }, { status: 400 })
-      }
-      serviceParams.transcript_ext = ext
+      serviceParams.transcript_ext = transcriptFile.name.split('.').pop()?.toLowerCase() || ''
       serviceParams.transcript_buffer = Buffer.from(await transcriptFile.arrayBuffer())
     }
 

--- a/src/app/api/videos/import/__tests__/route.test.ts
+++ b/src/app/api/videos/import/__tests__/route.test.ts
@@ -12,9 +12,10 @@ jest.mock('next/server', () => ({
   },
 }))
 
-import { POST, ALLOWED_EXTENSIONS } from '../route'
+import { POST } from '../route'
 import { fetchYoutubeMetadata } from '@/lib/youtube'
 import { getVideoService } from '@/lib/server/composition'
+import { ALLOWED_TRANSCRIPT_FORMATS } from '@/lib/api-schemas'
 
 const mockFetchYoutubeMetadata = fetchYoutubeMetadata as jest.MockedFunction<typeof fetchYoutubeMetadata>
 const mockGetVideoService = getVideoService as jest.MockedFunction<typeof getVideoService>
@@ -130,8 +131,8 @@ describe('POST /api/videos/import', () => {
     )
   })
 
-  it('exports ALLOWED_EXTENSIONS with srt, vtt, txt', () => {
-    expect(ALLOWED_EXTENSIONS).toEqual(['srt', 'vtt', 'txt'])
+  it('exports ALLOWED_TRANSCRIPT_FORMATS with srt, vtt, txt', () => {
+    expect(ALLOWED_TRANSCRIPT_FORMATS).toEqual(['srt', 'vtt', 'txt'])
   })
 
   it('returns 400 when youtube_url is missing', async () => {

--- a/src/app/api/videos/import/route.ts
+++ b/src/app/api/videos/import/route.ts
@@ -1,38 +1,25 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { fetchYoutubeMetadata } from '@/lib/youtube'
 import { getVideoService } from '@/lib/server/composition'
+import { ImportVideoRequestSchema } from '@/lib/api-schemas'
 
 export const runtime = 'nodejs'
-
-export const ALLOWED_EXTENSIONS = ['srt', 'vtt', 'txt'] as const
-export type AllowedExtension = typeof ALLOWED_EXTENSIONS[number]
-
-function getFileExtension(filename: string): string {
-  return filename.split('.').pop()?.toLowerCase() || ''
-}
 
 export async function POST(request: NextRequest) {
   try {
     const formData = await request.formData()
-    const youtubeUrlEntry = formData.get('youtube_url')
-    const transcriptEntry = formData.get('transcript')
-    const tagsEntry = formData.get('tags')
 
-    if (typeof youtubeUrlEntry !== 'string' || youtubeUrlEntry.trim() === '' || !(transcriptEntry instanceof File)) {
-      return NextResponse.json({ error: 'Missing required fields: youtube_url and transcript' }, { status: 400 })
-    }
-    if (tagsEntry !== null && typeof tagsEntry !== 'string') {
-      return NextResponse.json({ error: 'Invalid tags field' }, { status: 400 })
+    const result = ImportVideoRequestSchema.safeParse({
+      youtube_url: formData.get('youtube_url'),
+      transcript: formData.get('transcript'),
+      tags: formData.get('tags'),
+    })
+
+    if (!result.success) {
+      return NextResponse.json({ error: result.error.issues[0].message }, { status: 400 })
     }
 
-    const youtubeUrl = youtubeUrlEntry.trim()
-    const transcriptFile = transcriptEntry
-    const tagsString = typeof tagsEntry === 'string' ? tagsEntry : ''
-
-    const fileExtension = getFileExtension(transcriptFile.name)
-    if (!ALLOWED_EXTENSIONS.includes(fileExtension as AllowedExtension)) {
-      return NextResponse.json({ error: `Invalid file extension. Allowed: ${ALLOWED_EXTENSIONS.join(', ')}` }, { status: 400 })
-    }
+    const { youtube_url: youtubeUrl, transcript: transcriptFile, tags: tagsString } = result.data
 
     let youtubeMetadata
     try {
@@ -43,6 +30,7 @@ export async function POST(request: NextRequest) {
 
     const videoId = crypto.randomUUID()
     const fileBuffer = Buffer.from(await transcriptFile.arrayBuffer())
+    const fileExtension = transcriptFile.name.split('.').pop()?.toLowerCase() || ''
     const tags = tagsString.split(',').map((t) => t.trim()).filter((t) => t.length > 0)
 
     const service = getVideoService()

--- a/src/lib/__tests__/api-schemas.test.ts
+++ b/src/lib/__tests__/api-schemas.test.ts
@@ -1,0 +1,231 @@
+import {
+  ALLOWED_TRANSCRIPT_FORMATS,
+  ImportVideoRequestSchema,
+  UpdateVideoRequestSchema,
+} from '../api-schemas'
+
+describe('ALLOWED_TRANSCRIPT_FORMATS', () => {
+  it('contains srt, vtt, and txt', () => {
+    expect(ALLOWED_TRANSCRIPT_FORMATS).toEqual(['srt', 'vtt', 'txt'])
+  })
+})
+
+describe('ImportVideoRequestSchema', () => {
+  function makeFile(name: string, content = 'data'): File {
+    return new File([content], name, { type: 'text/plain' })
+  }
+
+  it('parses valid input with tags', () => {
+    const result = ImportVideoRequestSchema.safeParse({
+      youtube_url: 'https://www.youtube.com/watch?v=abc123',
+      transcript: makeFile('transcript.srt'),
+      tags: 'language, english',
+    })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.youtube_url).toBe('https://www.youtube.com/watch?v=abc123')
+      expect(result.data.tags).toBe('language, english')
+      expect(result.data.transcript.name).toBe('transcript.srt')
+    }
+  })
+
+  it('parses valid input without tags (defaults to empty string)', () => {
+    const result = ImportVideoRequestSchema.safeParse({
+      youtube_url: 'https://www.youtube.com/watch?v=abc123',
+      transcript: makeFile('transcript.vtt'),
+      tags: null,
+    })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.tags).toBe('')
+    }
+  })
+
+  it('trims youtube_url whitespace', () => {
+    const result = ImportVideoRequestSchema.safeParse({
+      youtube_url: '  https://www.youtube.com/watch?v=abc123  ',
+      transcript: makeFile('transcript.txt'),
+    })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.youtube_url).toBe('https://www.youtube.com/watch?v=abc123')
+    }
+  })
+
+  it('fails when youtube_url is empty', () => {
+    const result = ImportVideoRequestSchema.safeParse({
+      youtube_url: '   ',
+      transcript: makeFile('transcript.srt'),
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0].message).toBe(
+        'Missing required fields: youtube_url and transcript'
+      )
+    }
+  })
+
+  it('fails when transcript is not a File', () => {
+    const result = ImportVideoRequestSchema.safeParse({
+      youtube_url: 'https://www.youtube.com/watch?v=abc123',
+      transcript: null,
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0].message).toBe(
+        'Missing required fields: youtube_url and transcript'
+      )
+    }
+  })
+
+  it('fails for invalid transcript extension', () => {
+    const result = ImportVideoRequestSchema.safeParse({
+      youtube_url: 'https://www.youtube.com/watch?v=abc123',
+      transcript: makeFile('transcript.pdf'),
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0].message).toBe(
+        'Invalid file extension. Allowed: srt, vtt, txt'
+      )
+    }
+  })
+
+  it('fails when transcript filename has no extension', () => {
+    const result = ImportVideoRequestSchema.safeParse({
+      youtube_url: 'https://www.youtube.com/watch?v=abc123',
+      transcript: makeFile(''),
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0].message).toMatch(/Invalid file extension/)
+    }
+  })
+
+  it('fails when tags is a non-string (File)', () => {
+    const result = ImportVideoRequestSchema.safeParse({
+      youtube_url: 'https://www.youtube.com/watch?v=abc123',
+      transcript: makeFile('transcript.srt'),
+      tags: new File(['t'], 'tags.txt'),
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0].message).toBe('Invalid tags field')
+    }
+  })
+
+  it('accepts all allowed extensions', () => {
+    for (const ext of ALLOWED_TRANSCRIPT_FORMATS) {
+      const result = ImportVideoRequestSchema.safeParse({
+        youtube_url: 'https://www.youtube.com/watch?v=abc123',
+        transcript: makeFile(`transcript.${ext}`),
+      })
+      expect(result.success).toBe(true)
+    }
+  })
+})
+
+describe('UpdateVideoRequestSchema', () => {
+  function makeFile(name: string): File {
+    return new File(['content'], name, { type: 'text/plain' })
+  }
+
+  function makeEmptyFile(name: string): File {
+    return new File([], name, { type: 'application/octet-stream' })
+  }
+
+  it('parses valid tags JSON array', () => {
+    const result = UpdateVideoRequestSchema.safeParse({
+      tags: JSON.stringify(['spanish', 'advanced']),
+    })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.tags).toEqual(['spanish', 'advanced'])
+    }
+  })
+
+  it('parses empty tags array', () => {
+    const result = UpdateVideoRequestSchema.safeParse({ tags: '[]' })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.tags).toEqual([])
+    }
+  })
+
+  it('fails when tags is missing (null)', () => {
+    const result = UpdateVideoRequestSchema.safeParse({ tags: null })
+    expect(result.success).toBe(false)
+  })
+
+  it('fails when tags is not a JSON array (object)', () => {
+    const result = UpdateVideoRequestSchema.safeParse({ tags: '{"key":"val"}' })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0].message).toBe('Tags must be a JSON array')
+    }
+  })
+
+  it('fails when tags is invalid JSON', () => {
+    const result = UpdateVideoRequestSchema.safeParse({ tags: 'not-json' })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0].message).toBe('Tags must be a JSON array')
+    }
+  })
+
+  it('fails when tags is a JSON string (not array)', () => {
+    const result = UpdateVideoRequestSchema.safeParse({ tags: '"just-a-string"' })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0].message).toBe('Tags must be a JSON array')
+    }
+  })
+
+  it('accepts no transcript (null)', () => {
+    const result = UpdateVideoRequestSchema.safeParse({
+      tags: '["t1"]',
+      transcript: null,
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts valid transcript file', () => {
+    const result = UpdateVideoRequestSchema.safeParse({
+      tags: '["t1"]',
+      transcript: makeFile('subtitles.srt'),
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('fails for invalid transcript extension', () => {
+    const result = UpdateVideoRequestSchema.safeParse({
+      tags: '["t1"]',
+      transcript: makeFile('subtitles.pdf'),
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0].message).toBe(
+        'Invalid file extension. Allowed: srt, vtt, txt'
+      )
+    }
+  })
+
+  it('accepts transcript file with size 0 even with invalid extension (skipped)', () => {
+    const zeroFile = makeEmptyFile('file.pdf')
+    const result = UpdateVideoRequestSchema.safeParse({
+      tags: '["t1"]',
+      transcript: zeroFile,
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts all allowed transcript extensions', () => {
+    for (const ext of ALLOWED_TRANSCRIPT_FORMATS) {
+      const result = UpdateVideoRequestSchema.safeParse({
+        tags: '["t1"]',
+        transcript: makeFile(`subtitles.${ext}`),
+      })
+      expect(result.success).toBe(true)
+    }
+  })
+})

--- a/src/lib/api-schemas.ts
+++ b/src/lib/api-schemas.ts
@@ -1,0 +1,70 @@
+import { z } from 'zod'
+
+export const ALLOWED_TRANSCRIPT_FORMATS = ['srt', 'vtt', 'txt'] as const
+export type AllowedTranscriptFormat = typeof ALLOWED_TRANSCRIPT_FORMATS[number]
+
+function getFileExtension(filename: string): string {
+  return filename.split('.').pop()?.toLowerCase() || ''
+}
+
+/** Accepts actual File instances and duck-typed file-like objects (e.g. test mocks). */
+function isFileLike(v: unknown): v is File {
+  return (
+    v instanceof File ||
+    (typeof v === 'object' &&
+      v !== null &&
+      typeof (v as Record<string, unknown>).name === 'string')
+  )
+}
+
+const transcriptFileSchema = z
+  .custom<File>(isFileLike, 'Missing required fields: youtube_url and transcript')
+  .refine(
+    (f) => ALLOWED_TRANSCRIPT_FORMATS.includes(getFileExtension(f.name) as AllowedTranscriptFormat),
+    `Invalid file extension. Allowed: ${ALLOWED_TRANSCRIPT_FORMATS.join(', ')}`
+  )
+
+export const ImportVideoRequestSchema = z.object({
+  youtube_url: z.preprocess(
+    (v) => (v === null || v === undefined ? '' : v),
+    z.string().trim().min(1, 'Missing required fields: youtube_url and transcript')
+  ),
+  transcript: transcriptFileSchema,
+  tags: z
+    .custom<string | null | undefined>(
+      (v) => v === null || v === undefined || typeof v === 'string',
+      'Invalid tags field'
+    )
+    .transform((v) => (typeof v === 'string' ? v : '')),
+})
+
+export const UpdateVideoRequestSchema = z.object({
+  tags: z
+    .string()
+    .refine(
+      (v) => {
+        try {
+          return Array.isArray(JSON.parse(v))
+        } catch {
+          return false
+        }
+      },
+      'Tags must be a JSON array'
+    )
+    .transform((v) => JSON.parse(v) as string[]),
+  transcript: z
+    .custom<File | null | undefined>(
+      (v) => v === null || v === undefined || isFileLike(v)
+    )
+    .optional()
+    .nullable()
+    .refine(
+      (f) => {
+        if (!f || (f as File).size === 0) return true
+        return ALLOWED_TRANSCRIPT_FORMATS.includes(
+          getFileExtension((f as File).name) as AllowedTranscriptFormat
+        )
+      },
+      `Invalid file extension. Allowed: ${ALLOWED_TRANSCRIPT_FORMATS.join(', ')}`
+    ),
+})


### PR DESCRIPTION
Closes #90

## Summary
- Creates `src/lib/api-schemas.ts` with `ALLOWED_TRANSCRIPT_FORMATS`, `ImportVideoRequestSchema`, and `UpdateVideoRequestSchema`
- Replaces all inline validation in `import/route.ts` and `[id]/route.ts` PATCH handler with `safeParse`
- Removes duplicated `ALLOWED_EXTENSIONS` constant and manual extension/tags validation from both routes
- Adds 21 unit tests in `src/lib/__tests__/api-schemas.test.ts`
- Updates affected route tests to use the new schema exports