### PR TITLE
Refactor: Replace service locator with constructor injection at module level

### DIFF
--- a/src/app/api/videos/[id]/__tests__/route.test.ts
+++ b/src/app/api/videos/[id]/__tests__/route.test.ts
@@ -1,5 +1,6 @@
 // @jest-environment node
 import { DELETE, PATCH, GET } from '../route'
+import { videoStore, videoService } from '@/lib/server/composition'
 
 jest.mock('next/server', () => ({
   NextResponse: class MockNextResponse {
@@ -17,14 +18,14 @@ jest.mock('next/server', () => ({
   },
 }))
 
-const mockGetById = jest.fn()
-const mockDeleteVideo = jest.fn()
-const mockUpdateVideo = jest.fn()
-
 jest.mock('@/lib/server/composition', () => ({
-  getVideoStore: () => ({ getById: mockGetById }),
-  getVideoService: () => ({ deleteVideo: mockDeleteVideo, updateVideo: mockUpdateVideo }),
+  videoStore: { getById: jest.fn() },
+  videoService: { deleteVideo: jest.fn(), updateVideo: jest.fn() },
 }))
+
+const mockGetById = (videoStore.getById as jest.Mock)
+const mockDeleteVideo = (videoService.deleteVideo as jest.Mock)
+const mockUpdateVideo = (videoService.updateVideo as jest.Mock)
 
 function makeRequest() {
   return { method: 'DELETE', url: 'http://localhost/api/videos/video-1' } as unknown as Request

--- a/src/app/api/videos/[id]/route.ts
+++ b/src/app/api/videos/[id]/route.ts
@@ -1,6 +1,6 @@
 // @jest-environment node
 import { NextResponse } from 'next/server'
-import { getVideoStore, getVideoService } from '@/lib/server/composition'
+import { videoStore, videoService } from '@/lib/server/composition'
 import { UpdateVideoServiceParams } from '@/lib/video-service'
 import { UpdateVideoRequestSchema } from '@/lib/api-schemas'
 
@@ -12,7 +12,7 @@ export async function GET(
 ) {
   try {
     const { id } = await params
-    const video = getVideoStore().getById(id)
+    const video = videoStore.getById(id)
     if (!video) {
       return new NextResponse('Not Found', { status: 404 })
     }
@@ -29,7 +29,7 @@ export async function DELETE(
 ) {
   try {
     const { id } = await params
-    const deleted = await getVideoService().deleteVideo(id)
+    const deleted = await videoService.deleteVideo(id)
     if (!deleted) {
       return new NextResponse('Not Found', { status: 404 })
     }
@@ -66,7 +66,7 @@ export async function PATCH(
       serviceParams.transcript_buffer = Buffer.from(await transcriptFile.arrayBuffer())
     }
 
-    const updated = await getVideoService().updateVideo(id, serviceParams)
+    const updated = await videoService.updateVideo(id, serviceParams)
     if (!updated) {
       return NextResponse.json({ error: 'Video not found' }, { status: 404 })
     }

--- a/src/app/api/videos/__tests__/route.test.ts
+++ b/src/app/api/videos/__tests__/route.test.ts
@@ -2,12 +2,13 @@
  * @jest-environment node
  */
 import { GET } from '../route'
-
-const mockList = jest.fn()
+import { videoStore } from '@/lib/server/composition'
 
 jest.mock('@/lib/server/composition', () => ({
-  getVideoStore: () => ({ list: mockList }),
+  videoStore: { list: jest.fn() },
 }))
+
+const mockList = (videoStore.list as jest.Mock)
 
 const mockVideos = [
   {

--- a/src/app/api/videos/import/__tests__/route.test.ts
+++ b/src/app/api/videos/import/__tests__/route.test.ts
@@ -1,7 +1,13 @@
 // @jest-environment node
 
 jest.mock('@/lib/youtube')
-jest.mock('@/lib/server/composition', () => ({ getVideoService: jest.fn() }))
+jest.mock('@/lib/server/composition', () => ({
+  videoService: {
+    importVideo: jest.fn(),
+    updateVideo: jest.fn(),
+    deleteVideo: jest.fn(),
+  },
+}))
 
 jest.mock('next/server', () => ({
   NextResponse: {
@@ -14,17 +20,12 @@ jest.mock('next/server', () => ({
 
 import { POST } from '../route'
 import { fetchYoutubeMetadata } from '@/lib/youtube'
-import { getVideoService } from '@/lib/server/composition'
+import { videoService } from '@/lib/server/composition'
 import { ALLOWED_TRANSCRIPT_FORMATS } from '@/lib/api-schemas'
 
 const mockFetchYoutubeMetadata = fetchYoutubeMetadata as jest.MockedFunction<typeof fetchYoutubeMetadata>
-const mockGetVideoService = getVideoService as jest.MockedFunction<typeof getVideoService>
-
-const fakeService = {
-  importVideo: jest.fn(),
-  updateVideo: jest.fn(),
-  deleteVideo: jest.fn(),
-}
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockVideoService = videoService as any
 
 const fakeMetadata = {
   youtube_id: 'abc123',
@@ -63,9 +64,7 @@ describe('POST /api/videos/import', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     mockFetchYoutubeMetadata.mockResolvedValue(fakeMetadata)
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    mockGetVideoService.mockReturnValue(fakeService as any)
-    fakeService.importVideo.mockResolvedValue(fakeVideo)
+    mockVideoService.importVideo.mockResolvedValue(fakeVideo)
   })
 
   it('returns 400 when youtube_url is empty string', async () => {
@@ -110,7 +109,7 @@ describe('POST /api/videos/import', () => {
 
   it('returns 201 with empty tags array when no tags provided', async () => {
     const fakeVideoNoTags = { ...fakeVideo, tags: [] }
-    fakeService.importVideo.mockResolvedValue(fakeVideoNoTags)
+    mockVideoService.importVideo.mockResolvedValue(fakeVideoNoTags)
     const content = '1\n00:00:01,000 --> 00:00:02,000\nHello'
     const transcriptFile = Object.assign(
       new File([content], 'transcript.srt', { type: 'text/plain' }),
@@ -126,7 +125,7 @@ describe('POST /api/videos/import', () => {
     expect(res.status).toBe(201)
     const body = await res.json()
     expect(body.tags).toEqual([])
-    expect(fakeService.importVideo).toHaveBeenCalledWith(
+    expect(mockVideoService.importVideo).toHaveBeenCalledWith(
       expect.objectContaining({ tags: [] })
     )
   })
@@ -202,7 +201,7 @@ describe('POST /api/videos/import', () => {
     expect(res.status).toBe(201)
     const body = await res.json()
     expect(body).toEqual(fakeVideo)
-    expect(fakeService.importVideo).toHaveBeenCalledWith(
+    expect(mockVideoService.importVideo).toHaveBeenCalledWith(
       expect.objectContaining({
         youtube_url: 'https://www.youtube.com/watch?v=abc123',
         transcript_ext: 'srt',

--- a/src/app/api/videos/import/route.ts
+++ b/src/app/api/videos/import/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { fetchYoutubeMetadata } from '@/lib/youtube'
-import { getVideoService } from '@/lib/server/composition'
+import { videoService } from '@/lib/server/composition'
 import { ImportVideoRequestSchema } from '@/lib/api-schemas'
 
 export const runtime = 'nodejs'
@@ -33,8 +33,7 @@ export async function POST(request: NextRequest) {
     const fileExtension = transcriptFile.name.split('.').pop()?.toLowerCase() || ''
     const tags = tagsString.split(',').map((t) => t.trim()).filter((t) => t.length > 0)
 
-    const service = getVideoService()
-    const video = await service.importVideo({
+    const video = await videoService.importVideo({
       id: videoId,
       youtube_url: youtubeUrl,
       youtube_id: youtubeMetadata.youtube_id,

--- a/src/app/api/videos/route.ts
+++ b/src/app/api/videos/route.ts
@@ -1,11 +1,11 @@
 import { NextResponse } from 'next/server'
-import { getVideoStore } from '@/lib/server/composition'
+import { videoStore } from '@/lib/server/composition'
 
 export const runtime = 'nodejs'
 
 export async function GET() {
   try {
-    const videos = getVideoStore().list()
+    const videos = videoStore.list()
     return NextResponse.json(videos)
   } catch (error) {
     console.error('Videos API error:', error)

--- a/src/lib/server/composition.ts
+++ b/src/lib/server/composition.ts
@@ -10,30 +10,26 @@
  */
 import path from 'path'
 import { ensureDataDirs, openDb, initializeSchema } from '@/lib/db'
-import { VideoStore, SqliteVideoStore } from '@/lib/video-store'
-import { TranscriptStore, VideoService } from '@/lib/video-service'
+import { SqliteVideoStore } from '@/lib/video-store'
+import { VideoService } from '@/lib/video-service'
 import { writeTranscript, deleteTranscript } from '@/lib/transcripts'
 
-let videoStore: VideoStore | null = null
+function createContainer(dataDir: string) {
+  ensureDataDirs(dataDir)
+  const db = openDb(path.join(dataDir, 'lingoflow.db'))
+  initializeSchema(db)
 
-export function getVideoStore(): VideoStore {
-  if (!videoStore) {
-    const dataDir = process.env.LINGOFLOW_DATA_DIR ?? path.join(process.cwd(), '.lingoflow-data')
-    ensureDataDirs(dataDir)
-    const db = openDb(path.join(dataDir, 'lingoflow.db'))
-    initializeSchema(db)
-    videoStore = new SqliteVideoStore(db)
+  const store = new SqliteVideoStore(db)
+  const transcriptStore = {
+    write: (videoId: string, ext: string, buffer: Buffer) => writeTranscript(videoId, ext, buffer),
+    delete: (filePath: string) => deleteTranscript(filePath),
   }
-  return videoStore
+  const service = new VideoService(store, transcriptStore)
+
+  return { videoStore: store, videoService: service }
 }
 
-export function getTranscriptStore(): TranscriptStore {
-  return {
-    write: (videoId, ext, buffer) => writeTranscript(videoId, ext, buffer),
-    delete: (filePath) => deleteTranscript(filePath),
-  }
-}
+const dataDir = process.env.LINGOFLOW_DATA_DIR ?? path.join(process.cwd(), '.lingoflow-data')
+const { videoStore, videoService } = createContainer(dataDir)
 
-export function getVideoService(): VideoService {
-  return new VideoService(getVideoStore(), getTranscriptStore())
-}
+export { videoStore, videoService }


### PR DESCRIPTION
Closes #93

## Changes

- Removed mutable lazy singleton getters (`getVideoStore`, `getVideoService`, `getTranscriptStore`) from `composition.ts`
- Added `createContainer(dataDir)` factory that wires all dependencies once at module load time
- Exported module-level `videoStore` and `videoService` instances directly as named exports
- Updated all three route handlers (`/api/videos`, `/api/videos/[id]`, `/api/videos/import`) to import named exports instead of calling getter functions
- Updated all three test files to mock named exports directly (simple object mocks) instead of factory-returning-stub patterns