### PR TITLE
e2e: make PlayerPage waits more robust; remove PR comment step

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -68,26 +68,4 @@ jobs:
           path: test-results/
           retention-days: 30
 
-      - name: Comment on merged PR on failure
-        if: failure()
-        continue-on-error: true
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const prs = await github.rest.pulls.list({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: 'closed',
-              sort: 'updated',
-              direction: 'desc',
-              per_page: 10
-            })
-            const pr = prs.data.find(p => p.merge_commit_sha === context.sha)
-            if (pr) {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: pr.number,
-                body: `❌ E2E tests failed after merge. [View run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`
-              })
-            }
+

--- a/tests/e2e/pages/PlayerPage.ts
+++ b/tests/e2e/pages/PlayerPage.ts
@@ -22,14 +22,16 @@ export class PlayerPage {
     this.vocabTab = page.getByTestId('tab-vocabulary')
   }
 
-  /** Navigates to the player page for the given video id and waits for network idle. */
+  /** Navigates to the player page for the given video id and waits for the player client to attach. */
   async navigateTo(id: string): Promise<void> {
-    await this.page.goto(`/player/${id}`, { waitUntil: 'networkidle' })
+    await this.page.goto(`/player/${id}`)
+    await expect(this.playerClient).toBeAttached({ timeout: 30_000 })
   }
 
-  /** Asserts the player client container is visible. */
+  /** Asserts the player client container is attached and visible. */
   async assertLoaded(): Promise<void> {
-    await expect(this.playerClient).toBeVisible()
+    await expect(this.playerClient).toBeAttached({ timeout: 30_000 })
+    await expect(this.playerClient).toBeVisible({ timeout: 30_000 })
   }
 
   /** Clicks the Vocabulary tab. */


### PR DESCRIPTION
Makes PlayerPage waits more robust by waiting for attachment and visibility with 30s timeouts. Removes the 'Comment on merged PR on failure' step to avoid GitHub API permission errors.