### PR TITLE
Fix PlayerPage unit tests for PlayerLoader

### DIFF
--- a/src/app/(app)/player/[id]/__tests__/page.test.tsx
+++ b/src/app/(app)/player/[id]/__tests__/page.test.tsx
@@ -1,56 +1,15 @@
 import { render, screen } from '@testing-library/react'
 import PlayerPage from '../page'
 
-jest.mock('@/lib/server/composition', () => ({
-  videoStore: { getById: jest.fn() },
+jest.mock('@/components/PlayerLoader', () => ({
+  __esModule: true,
+  default: ({ id }: { id: string }) => <div data-testid="player-loader">{id}</div>,
 }))
-
-jest.mock('@/components/PlayerClient', () => {
-  return function MockPlayerClient() {
-    return <div data-testid="player-client" />
-  }
-})
-
-jest.mock('next/navigation', () => ({
-  notFound: jest.fn(() => {
-    throw new Error('NEXT_NOT_FOUND')
-  }),
-}))
-
-import { videoStore } from '@/lib/server/composition'
-import { notFound } from 'next/navigation'
-
-const mockGetById = videoStore.getById as jest.Mock
-
-const mockVideo = {
-  id: 'video-1',
-  youtube_url: 'https://youtube.com/watch?v=abc',
-  youtube_id: 'abc',
-  title: 'Test Video',
-  author_name: 'Author',
-  thumbnail_url: 'https://img.example.com/thumb.jpg',
-  transcript_path: '/data/transcripts/video-1.srt',
-  transcript_format: 'srt',
-  tags: ['spanish'],
-  created_at: '2026-01-01T00:00:00Z',
-  updated_at: '2026-01-01T00:00:00Z',
-}
 
 describe('PlayerPage', () => {
-  afterEach(() => jest.clearAllMocks())
-
-  it('renders PlayerClient when video exists', async () => {
-    mockGetById.mockReturnValue(mockVideo)
+  it('renders PlayerLoader with the route id', async () => {
     const Page = await PlayerPage({ params: Promise.resolve({ id: 'video-1' }) })
     render(Page as React.ReactElement)
-    expect(screen.getByTestId('player-client')).toBeInTheDocument()
-  })
-
-  it('calls notFound when video does not exist', async () => {
-    mockGetById.mockReturnValue(undefined)
-    await expect(
-      PlayerPage({ params: Promise.resolve({ id: 'nonexistent' }) })
-    ).rejects.toThrow('NEXT_NOT_FOUND')
-    expect(notFound).toHaveBeenCalled()
+    expect(screen.getByTestId('player-loader')).toHaveTextContent('video-1')
   })
 })


### PR DESCRIPTION
## Summary
Updated player page unit tests to match the current player architecture.

### Root cause
PlayerPage now returns PlayerLoader and no longer reads from videoStore or calls notFound directly. The old tests still asserted the previous behavior, causing failures.

### Changes
- Removed outdated mocks for server composition, PlayerClient, and next/navigation
- Mocked PlayerLoader instead
- Updated assertion to verify the route id is passed to PlayerLoader

### Validation
- pnpm test passes
- pnpm test:e2e passes