### PR TITLE
feat(#119): Player shell with floating mini-player

### DIFF
--- a/src/components/LessonHero.tsx
+++ b/src/components/LessonHero.tsx
@@ -1,0 +1,81 @@
+'use client'
+
+import { useState } from 'react'
+import { Video } from '@/lib/videos'
+
+interface LessonHeroProps {
+  video: Video
+  onPlay: () => void
+}
+
+export default function LessonHero({ video, onPlay }: LessonHeroProps) {
+  const [imgSrc, setImgSrc] = useState(
+    `https://img.youtube.com/vi/${video.youtube_id}/maxresdefault.jpg`
+  )
+
+  return (
+    <div data-testid="lesson-hero">
+      <div
+        className="relative aspect-video rounded-xl overflow-hidden shadow-2xl mb-6 bg-black cursor-pointer group"
+        onClick={onPlay}
+        role="button"
+        aria-label="Play video"
+        data-testid="hero-play-area"
+      >
+        <img
+          src={imgSrc}
+          alt={video.title}
+          className="w-full h-full object-cover"
+          onError={() =>
+            setImgSrc(`https://img.youtube.com/vi/${video.youtube_id}/hqdefault.jpg`)
+          }
+          data-testid="hero-thumbnail"
+        />
+        <div className="absolute inset-0 flex items-center justify-center bg-black/30 group-hover:bg-black/40 transition">
+          <button
+            onClick={(e) => {
+              e.stopPropagation()
+              onPlay()
+            }}
+            aria-label="Play"
+            data-testid="play-button"
+            className="flex items-center justify-center w-20 h-20 rounded-full bg-white/20 hover:bg-white/30 backdrop-blur-sm transition"
+          >
+            <svg
+              className="w-10 h-10 text-white drop-shadow-lg ml-1"
+              fill="currentColor"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <path d="M8 5v14l11-7z" />
+            </svg>
+          </button>
+        </div>
+      </div>
+
+      <div className="flex items-start justify-between gap-4 mb-6">
+        <div>
+          {video.tags.length > 0 && (
+            <div className="flex gap-2 mb-2 flex-wrap">
+              {video.tags.map((tag) => (
+                <span
+                  key={tag}
+                  className="px-3 py-1 text-xs font-bold rounded-full bg-surface-container-highest text-on-surface-variant"
+                >
+                  {tag}
+                </span>
+              ))}
+            </div>
+          )}
+          <h1 className="text-2xl font-extrabold text-on-surface dark:text-slate-100 font-headline">
+            {video.title}
+          </h1>
+          <p className="text-on-surface-variant dark:text-slate-400 mt-1">{video.author_name}</p>
+        </div>
+        <button className="flex items-center gap-2 px-6 py-3 bg-gradient-to-br from-primary to-primary-container text-white rounded-xl font-bold hover:scale-[1.02] transition-transform whitespace-nowrap">
+          Save Lesson
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/MiniPlayer.tsx
+++ b/src/components/MiniPlayer.tsx
@@ -1,0 +1,46 @@
+'use client'
+
+import { useRef } from 'react'
+
+interface MiniPlayerProps {
+  youtubeId: string
+  title: string
+  onClose: () => void
+}
+
+export default function MiniPlayer({ youtubeId, title, onClose }: MiniPlayerProps) {
+  const iframeRef = useRef<HTMLIFrameElement>(null)
+
+  function handleClose() {
+    iframeRef.current?.contentWindow?.postMessage(
+      '{"event":"command","func":"pauseVideo","args":""}',
+      '*'
+    )
+    onClose()
+  }
+
+  return (
+    <div
+      data-testid="mini-player"
+      className="fixed bottom-4 right-4 z-50 w-80 aspect-video shadow-2xl rounded-xl overflow-hidden bg-black"
+    >
+      <iframe
+        ref={iframeRef}
+        src={`https://www.youtube.com/embed/${youtubeId}?autoplay=1&enablejsapi=1&rel=0&modestbranding=1`}
+        className="w-full h-full"
+        allow="autoplay; encrypted-media; fullscreen"
+        allowFullScreen
+        title={title}
+        data-testid="mini-player-iframe"
+      />
+      <button
+        onClick={handleClose}
+        aria-label="Close mini player"
+        data-testid="mini-player-close"
+        className="absolute top-2 right-2 flex items-center justify-center w-7 h-7 rounded-full bg-black/60 hover:bg-black/80 text-white text-sm transition"
+      >
+        ✕
+      </button>
+    </div>
+  )
+}

--- a/src/components/PlayerClient.tsx
+++ b/src/components/PlayerClient.tsx
@@ -3,6 +3,8 @@
 import { useEffect, useState } from 'react'
 import { Video } from '@/lib/videos'
 import { TranscriptCue } from '@/lib/parse-transcript'
+import LessonHero from '@/components/LessonHero'
+import MiniPlayer from '@/components/MiniPlayer'
 
 interface WordCard {
   word: string
@@ -25,6 +27,7 @@ export default function PlayerClient({ video }: { video: Video }) {
   const [activeCueIndex, setActiveCueIndex] = useState(0)
   const [activeTab, setActiveTab] = useState<'transcript' | 'vocabulary'>('transcript')
   const [vocabWords, setVocabWords] = useState<WordCard[]>([])
+  const [isMiniPlayerOpen, setIsMiniPlayerOpen] = useState(false)
 
   useEffect(() => {
     fetch(`/api/videos/${video.id}/transcript`)
@@ -53,33 +56,16 @@ export default function PlayerClient({ video }: { video: Video }) {
     <div data-testid="player-client" className="min-h-screen flex flex-col lg:flex-row bg-surface dark:bg-slate-900">
       {/* Main content */}
       <section className="flex-1 p-8 bg-surface dark:bg-slate-900 overflow-y-auto">
-        <div className="aspect-video rounded-xl overflow-hidden shadow-2xl mb-6 bg-black">
-          <iframe
-            src={`https://www.youtube.com/embed/${video.youtube_id}`}
-            className="w-full h-full"
-            allowFullScreen
-            title={video.title}
-          />
-        </div>
-
-        <div className="flex items-start justify-between gap-4 mb-6">
-          <div>
-            <div className="flex gap-2 mb-2">
-              <span className="px-3 py-1 text-xs font-bold rounded-full bg-secondary-container text-on-secondary-container">
-                Intermediate
-              </span>
-              <span className="px-3 py-1 text-xs font-bold rounded-full bg-surface-container-highest text-on-surface-variant">
-                Language Learning
-              </span>
-            </div>
-            <h1 className="text-2xl font-extrabold text-on-surface dark:text-slate-100 font-headline">{video.title}</h1>
-            <p className="text-on-surface-variant dark:text-slate-400 mt-1">{video.author_name}</p>
-          </div>
-          <button className="flex items-center gap-2 px-6 py-3 bg-gradient-to-br from-primary to-primary-container text-white rounded-xl font-bold hover:scale-[1.02] transition-transform">
-            Save Lesson
-          </button>
-        </div>
+        <LessonHero video={video} onPlay={() => setIsMiniPlayerOpen(true)} />
       </section>
+
+      {isMiniPlayerOpen && (
+        <MiniPlayer
+          youtubeId={video.youtube_id}
+          title={video.title}
+          onClose={() => setIsMiniPlayerOpen(false)}
+        />
+      )}
 
       {/* Right transcript/vocab sidebar */}
       <aside className="w-full lg:w-[420px] bg-surface-container-low dark:bg-slate-950/50 flex flex-col border-t lg:border-t-0 lg:border-l border-outline-variant/30 dark:border-slate-700 overflow-hidden min-h-[400px] lg:min-h-screen">

--- a/src/components/__tests__/LessonHero.test.tsx
+++ b/src/components/__tests__/LessonHero.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import LessonHero from '../LessonHero'
+import { Video } from '@/lib/videos'
+
+const mockVideo: Video = {
+  id: 'video-1',
+  youtube_url: 'https://www.youtube.com/watch?v=abc123',
+  youtube_id: 'abc123',
+  title: 'Test Video Title',
+  author_name: 'Test Author',
+  thumbnail_url: 'https://example.com/thumb.jpg',
+  transcript_path: 'transcripts/video-1.srt',
+  transcript_format: 'srt',
+  tags: ['french', 'beginner'],
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+}
+
+describe('LessonHero', () => {
+  it('renders the thumbnail image with maxresdefault URL', () => {
+    render(<LessonHero video={mockVideo} onPlay={jest.fn()} />)
+    const img = screen.getByTestId('hero-thumbnail')
+    expect(img).toHaveAttribute(
+      'src',
+      'https://img.youtube.com/vi/abc123/maxresdefault.jpg'
+    )
+    expect(img).toHaveAttribute('alt', 'Test Video Title')
+  })
+
+  it('renders the video title', () => {
+    render(<LessonHero video={mockVideo} onPlay={jest.fn()} />)
+    expect(screen.getByText('Test Video Title')).toBeInTheDocument()
+  })
+
+  it('renders the author name', () => {
+    render(<LessonHero video={mockVideo} onPlay={jest.fn()} />)
+    expect(screen.getByText('Test Author')).toBeInTheDocument()
+  })
+
+  it('renders all tags', () => {
+    render(<LessonHero video={mockVideo} onPlay={jest.fn()} />)
+    expect(screen.getByText('french')).toBeInTheDocument()
+    expect(screen.getByText('beginner')).toBeInTheDocument()
+  })
+
+  it('does not render tag chips when tags array is empty', () => {
+    render(<LessonHero video={{ ...mockVideo, tags: [] }} onPlay={jest.fn()} />)
+    expect(screen.queryByText('french')).not.toBeInTheDocument()
+  })
+
+  it('calls onPlay when the play button is clicked', () => {
+    const onPlay = jest.fn()
+    render(<LessonHero video={mockVideo} onPlay={onPlay} />)
+    fireEvent.click(screen.getByTestId('play-button'))
+    expect(onPlay).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls onPlay when the hero area is clicked', () => {
+    const onPlay = jest.fn()
+    render(<LessonHero video={mockVideo} onPlay={onPlay} />)
+    fireEvent.click(screen.getByTestId('hero-play-area'))
+    expect(onPlay).toHaveBeenCalled()
+  })
+
+  it('falls back to hqdefault thumbnail on image error', () => {
+    render(<LessonHero video={mockVideo} onPlay={jest.fn()} />)
+    const img = screen.getByTestId('hero-thumbnail')
+    fireEvent.error(img)
+    expect(img).toHaveAttribute(
+      'src',
+      'https://img.youtube.com/vi/abc123/hqdefault.jpg'
+    )
+  })
+})

--- a/src/components/__tests__/MiniPlayer.test.tsx
+++ b/src/components/__tests__/MiniPlayer.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import MiniPlayer from '../MiniPlayer'
+
+describe('MiniPlayer', () => {
+  it('renders the iframe with correct YouTube embed src', () => {
+    render(<MiniPlayer youtubeId="abc123" title="My Video" onClose={jest.fn()} />)
+    const iframe = screen.getByTestId('mini-player-iframe')
+    expect(iframe).toHaveAttribute(
+      'src',
+      'https://www.youtube.com/embed/abc123?autoplay=1&enablejsapi=1&rel=0&modestbranding=1'
+    )
+  })
+
+  it('renders the iframe with the correct title', () => {
+    render(<MiniPlayer youtubeId="abc123" title="My Video" onClose={jest.fn()} />)
+    const iframe = screen.getByTestId('mini-player-iframe')
+    expect(iframe).toHaveAttribute('title', 'My Video')
+  })
+
+  it('calls onClose when the close button is clicked', () => {
+    const onClose = jest.fn()
+    render(<MiniPlayer youtubeId="abc123" title="My Video" onClose={onClose} />)
+    fireEvent.click(screen.getByTestId('mini-player-close'))
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders the close button with accessible label', () => {
+    render(<MiniPlayer youtubeId="abc123" title="My Video" onClose={jest.fn()} />)
+    expect(screen.getByLabelText('Close mini player')).toBeInTheDocument()
+  })
+
+  it('has the mini-player data-testid', () => {
+    render(<MiniPlayer youtubeId="abc123" title="My Video" onClose={jest.fn()} />)
+    expect(screen.getByTestId('mini-player')).toBeInTheDocument()
+  })
+})

--- a/src/components/__tests__/PlayerClient.test.tsx
+++ b/src/components/__tests__/PlayerClient.test.tsx
@@ -1,0 +1,70 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import PlayerClient from '../PlayerClient'
+import { Video } from '@/lib/videos'
+
+const mockVideo: Video = {
+  id: 'video-1',
+  youtube_url: 'https://www.youtube.com/watch?v=abc123',
+  youtube_id: 'abc123',
+  title: 'Test Lesson',
+  author_name: 'Test Channel',
+  thumbnail_url: 'https://example.com/thumb.jpg',
+  transcript_path: 'transcripts/video-1.srt',
+  transcript_format: 'srt',
+  tags: ['french'],
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+}
+
+beforeEach(() => {
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({ cues: [] }),
+  }) as jest.Mock
+})
+
+afterEach(() => {
+  jest.resetAllMocks()
+})
+
+describe('PlayerClient', () => {
+  it('initially shows the lesson hero and not the mini-player', async () => {
+    render(<PlayerClient video={mockVideo} />)
+    expect(screen.getByTestId('lesson-hero')).toBeInTheDocument()
+    expect(screen.queryByTestId('mini-player')).not.toBeInTheDocument()
+  })
+
+  it('shows mini-player after clicking play', async () => {
+    render(<PlayerClient video={mockVideo} />)
+    fireEvent.click(screen.getByTestId('play-button'))
+    expect(screen.getByTestId('mini-player')).toBeInTheDocument()
+  })
+
+  it('hides mini-player after clicking close', async () => {
+    render(<PlayerClient video={mockVideo} />)
+    fireEvent.click(screen.getByTestId('play-button'))
+    expect(screen.getByTestId('mini-player')).toBeInTheDocument()
+    fireEvent.click(screen.getByTestId('mini-player-close'))
+    expect(screen.queryByTestId('mini-player')).not.toBeInTheDocument()
+  })
+
+  it('still shows the lesson hero while mini-player is open', () => {
+    render(<PlayerClient video={mockVideo} />)
+    fireEvent.click(screen.getByTestId('play-button'))
+    expect(screen.getByTestId('lesson-hero')).toBeInTheDocument()
+    expect(screen.getByTestId('mini-player')).toBeInTheDocument()
+  })
+
+  it('renders the transcript tab area', async () => {
+    render(<PlayerClient video={mockVideo} />)
+    expect(screen.getByTestId('tab-transcript')).toBeInTheDocument()
+    expect(screen.getByTestId('tab-vocabulary')).toBeInTheDocument()
+  })
+
+  it('fetches transcript on mount', async () => {
+    render(<PlayerClient video={mockVideo} />)
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith('/api/videos/video-1/transcript')
+    })
+  })
+})


### PR DESCRIPTION
Closes #119

## Summary

Replaces the inline YouTube iframe in the player page with a thumbnail hero + floating mini-player pattern.

## Changes

### New components
- LessonHero: thumbnail hero with Play button, title, author, tags; hqdefault fallback
- MiniPlayer: fixed bottom-right overlay, autoplay + enablejsapi, pauses on close via postMessage

### Modified
- PlayerClient: replaced inline iframe with LessonHero + isMiniPlayerOpen state + MiniPlayer

### Tests (19 new)
- LessonHero.test.tsx, MiniPlayer.test.tsx, PlayerClient.test.tsx

## Results
- 227 tests passed (24 suites)
- pnpm build pass