### PR TITLE
feat(#120): playback progress indicator wired to player time

### DIFF
--- a/docs/api/transcript-sync.md
+++ b/docs/api/transcript-sync.md
@@ -1,0 +1,415 @@
+# Transcript Sync — Reference Notes
+
+> Relevant to: **Issue #121 — Cue-synced paged transcript**
+>
+> Covers the `TranscriptCue` interface, active-cue detection, page boundary logic, and
+> React patterns for keeping a paged transcript in sync with YouTube player playback time.
+
+---
+
+## 1. `TranscriptCue` Interface
+
+Defined in `src/lib/parse-transcript.ts` and returned by `GET /api/videos/:id/transcript`.
+
+```ts
+export interface TranscriptCue {
+  index: number      // 1-based sequential cue number
+  startTime: string  // SRT/VTT timestamp string, e.g. "00:01:23,456"
+  endTime: string    // SRT/VTT timestamp string, e.g. "00:01:25,890"
+  text: string       // Cue text (multi-line joined with a space)
+}
+```
+
+### Timestamp format
+
+Both `startTime` and `endTime` are **strings** in the form `HH:MM:SS,mmm` (SRT) or `HH:MM:SS.mmm`
+(VTT, treated identically by the parser). They are **not** numbers.
+
+The YouTube IFrame API's `getCurrentTime()` returns **seconds as a `number`**. You must convert
+cue timestamps to seconds before any comparison.
+
+```ts
+/** "HH:MM:SS,mmm" or "HH:MM:SS.mmm" → decimal seconds */
+export function parseTimestamp(ts: string): number {
+  const [hms, ms = '0'] = ts.replace(',', '.').split('.')
+  const [h, m, s] = hms.split(':').map(Number)
+  return h * 3600 + m * 60 + s + parseInt(ms, 10) / 1000
+}
+```
+
+**Example:** `"00:01:23,456"` → `83.456`
+
+For plain-text cues (unknown format), `startTime` and `endTime` are empty strings (`""`). Guard
+against this: treat a cue with an empty `startTime` as always inactive.
+
+### API response shape
+
+```ts
+// GET /api/videos/:id/transcript
+// Response body
+{ cues: TranscriptCue[] }
+```
+
+Fetched via React Query:
+
+```ts
+const { data } = useQuery({
+  queryKey: ['transcript', videoId],
+  queryFn: () => fetch(`/api/videos/${videoId}/transcript`).then(r => r.json()),
+})
+const cues: TranscriptCue[] = data?.cues ?? []
+```
+
+---
+
+## 2. Pre-processing: Parse Timestamps Once
+
+Parse all timestamps up-front (when cues are first loaded) rather than on every poll tick.
+Store the parsed values alongside the original cues.
+
+```ts
+interface ParsedCue extends TranscriptCue {
+  startSec: number
+  endSec: number
+}
+
+function parseCues(cues: TranscriptCue[]): ParsedCue[] {
+  return cues.map(c => ({
+    ...c,
+    startSec: c.startTime ? parseTimestamp(c.startTime) : -1,
+    endSec:   c.endTime   ? parseTimestamp(c.endTime)   : -1,
+  }))
+}
+```
+
+Use `useMemo` in the component so this runs only when `cues` changes:
+
+```ts
+const parsedCues = useMemo(() => parseCues(cues), [cues])
+```
+
+---
+
+## 3. Active-Cue Lookup
+
+Given the current playback time in seconds, find the cue that is currently "active"
+(i.e., `startSec <= currentTime < endSec`).
+
+### Option A — Linear scan (simple, fine for typical transcripts ≤ 2000 cues)
+
+```ts
+function findActiveCue(cues: ParsedCue[], currentTimeSec: number): ParsedCue | null {
+  for (let i = cues.length - 1; i >= 0; i--) {
+    if (cues[i].startSec <= currentTimeSec) {
+      // Return this cue if playback is still within it, or if no next cue exists
+      if (cues[i].endSec < 0 || currentTimeSec < cues[i].endSec) {
+        return cues[i]
+      }
+      // Gap between cues — no active cue
+      return null
+    }
+  }
+  return null
+}
+```
+
+Scanning backwards finds the most recent cue start quickly and exits early.
+
+### Option B — Binary search (O(log n), preferred for large transcripts)
+
+```ts
+function findActiveCueBinary(cues: ParsedCue[], currentTimeSec: number): ParsedCue | null {
+  let lo = 0
+  let hi = cues.length - 1
+  let result: ParsedCue | null = null
+
+  while (lo <= hi) {
+    const mid = (lo + hi) >>> 1
+    if (cues[mid].startSec <= currentTimeSec) {
+      result = cues[mid]
+      lo = mid + 1
+    } else {
+      hi = mid - 1
+    }
+  }
+
+  // result is the last cue whose startSec <= currentTime
+  // Verify the playback time is still within the cue's endSec
+  if (result && result.endSec >= 0 && currentTimeSec >= result.endSec) {
+    return null // in a gap between cues
+  }
+  return result
+}
+```
+
+**Precondition:** `cues` must be sorted by `startSec` ascending (they are, as produced by
+`parseTranscript`).
+
+---
+
+## 4. Polling for Active Cue
+
+Call the lookup inside a `setInterval` (250 ms is sufficient for human-readable cue granularity).
+Wire start/stop to the player's `onStateChange` event — the same pattern as progress polling.
+
+```ts
+const [activeCueIndex, setActiveCueIndex] = useState<number | null>(null)
+const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
+
+function startCuePolling() {
+  if (intervalRef.current) return
+  intervalRef.current = setInterval(() => {
+    const player = playerRef.current
+    if (!player) return
+    const t = player.getCurrentTime()
+    const cue = findActiveCueBinary(parsedCues, t)
+    setActiveCueIndex(cue?.index ?? null)
+  }, 250)
+}
+
+function stopCuePolling() {
+  if (intervalRef.current) {
+    clearInterval(intervalRef.current)
+    intervalRef.current = null
+  }
+}
+
+useEffect(() => () => stopCuePolling(), [])
+```
+
+Wire to `onStateChange`:
+
+```ts
+onStateChange: (e) => {
+  if (e.data === YT.PlayerState.PLAYING) {
+    startCuePolling()
+  } else {
+    stopCuePolling()
+  }
+}
+```
+
+---
+
+## 5. Paging: Dividing Cues into Pages
+
+Split `parsedCues` into fixed-size pages once (with `useMemo`). A page size of **10 cues** is a
+good default for readability; expose it as a prop or constant.
+
+```ts
+const PAGE_SIZE = 10
+
+const pages = useMemo(
+  () => chunk(parsedCues, PAGE_SIZE),
+  [parsedCues]
+)
+
+/** Utility: split an array into chunks of size n */
+function chunk<T>(arr: T[], n: number): T[][] {
+  const result: T[][] = []
+  for (let i = 0; i < arr.length; i += n) result.push(arr.slice(i, i + n))
+  return result
+}
+```
+
+The **page index** for a given cue index:
+
+```ts
+function pageForCue(cueIndex: number, pageSize: number): number {
+  return Math.floor((cueIndex - 1) / pageSize) // cueIndex is 1-based
+}
+```
+
+---
+
+## 6. Auto-Page-Advance
+
+Advance the page whenever the active cue moves to a different page. Use `useEffect` watching
+`activeCueIndex`:
+
+```ts
+const [currentPage, setCurrentPage] = useState(0)
+
+useEffect(() => {
+  if (activeCueIndex == null) return
+  const targetPage = pageForCue(activeCueIndex, PAGE_SIZE)
+  if (targetPage !== currentPage) {
+    setCurrentPage(targetPage)
+  }
+}, [activeCueIndex])
+```
+
+**Design considerations:**
+
+- **Debounce is not needed** — `activeCueIndex` is already driven by a 250 ms poll interval and
+  changes at most once per cue boundary.
+- **Seeking backward** is handled naturally: `pageForCue` computes the correct page from
+  wherever the playback lands.
+- If users **manually navigate pages** (previous/next buttons), set `currentPage` directly. The
+  auto-advance will resume on the next cue boundary crossing, so do not fight the user by
+  immediately jumping back.
+
+---
+
+## 7. Active-Cue Highlighting
+
+Pass `activeCueIndex` into the transcript page renderer and apply a highlight style:
+
+```tsx
+function TranscriptPage({
+  cues,
+  activeCueIndex,
+}: {
+  cues: ParsedCue[]
+  activeCueIndex: number | null
+}) {
+  return (
+    <ol className="space-y-1">
+      {cues.map(cue => (
+        <li
+          key={cue.index}
+          data-cue-index={cue.index}
+          className={
+            cue.index === activeCueIndex
+              ? 'bg-yellow-100 text-yellow-900 rounded px-2 py-0.5 font-medium'
+              : 'px-2 py-0.5 text-gray-700'
+          }
+        >
+          {cue.text}
+        </li>
+      ))}
+    </ol>
+  )
+}
+```
+
+---
+
+## 8. Auto-Scroll to Active Cue (within a Page)
+
+When the active cue changes, scroll it into view inside the transcript container. Use a `ref` map
+or a `data-cue-index` attribute with `querySelector`.
+
+### Pattern A — `scrollIntoView` (simple)
+
+```ts
+useEffect(() => {
+  if (activeCueIndex == null) return
+  const el = containerRef.current?.querySelector(
+    `[data-cue-index="${activeCueIndex}"]`
+  )
+  el?.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
+}, [activeCueIndex])
+```
+
+- `block: 'nearest'` scrolls only if the element is already out of view — prevents jarring jumps
+  when the active cue is already visible near the center.
+- `behavior: 'smooth'` gives a pleasant animation; use `'instant'` if the page also just changed
+  (to avoid double-animation confusion).
+
+### Pattern B — `IntersectionObserver` (detect visibility before scrolling)
+
+Use `IntersectionObserver` to scroll only when the active cue has left the visible area of the
+transcript container:
+
+```ts
+useEffect(() => {
+  if (activeCueIndex == null || !containerRef.current) return
+
+  const el = containerRef.current.querySelector(
+    `[data-cue-index="${activeCueIndex}"]`
+  ) as HTMLElement | null
+  if (!el) return
+
+  const observer = new IntersectionObserver(
+    ([entry]) => {
+      if (!entry.isIntersecting) {
+        el.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
+      }
+      observer.disconnect()
+    },
+    { root: containerRef.current, threshold: 1.0 }
+  )
+  observer.observe(el)
+
+  return () => observer.disconnect()
+}, [activeCueIndex])
+```
+
+- `threshold: 1.0` — fires when the element is fully out of view.
+- `root: containerRef.current` — scopes the intersection check to the transcript container,
+  not the viewport.
+
+**Prefer Pattern A** (`scrollIntoView` directly) in the initial implementation. It is simpler and
+covers the common case. Reach for `IntersectionObserver` only if scrollIntoView causes noticeable
+unnecessary motion.
+
+---
+
+## 9. Seeking on Cue Click
+
+Allow users to jump to a cue's start time by clicking it. Use the `seekTo` API from `YT.Player`:
+
+```tsx
+<li
+  key={cue.index}
+  data-cue-index={cue.index}
+  className={...}
+  onClick={() => {
+    playerRef.current?.seekTo(cue.startSec, true)
+    playerRef.current?.playVideo()
+  }}
+>
+  {cue.text}
+</li>
+```
+
+`seekTo(seconds, true)` — the second argument (`allowSeekAhead: true`) tells the player to
+request buffering ahead of the seek point.
+
+---
+
+## 10. Combined State Shape
+
+A minimal state interface for the transcript sync feature:
+
+```ts
+interface TranscriptSyncState {
+  parsedCues: ParsedCue[]      // memoised from raw cues
+  pages: ParsedCue[][]         // memoised pages
+  currentPage: number          // 0-based page index (display +1)
+  activeCueIndex: number | null // 1-based cue index, or null if in a gap
+}
+```
+
+Derived values (computed, not stored in state):
+
+```ts
+const currentCues = pages[currentPage] ?? []
+const totalPages = pages.length
+```
+
+---
+
+## 11. Edge Cases
+
+| Scenario | Handling |
+|---|---|
+| Cue with empty `startTime` (plain-text format) | `parseTimestamp` returns `-1`; binary search never matches it; cue is never active |
+| Gap between cues (silence / no subtitle) | `findActiveCueBinary` returns `null`; highlight disappears — expected |
+| Seek to a time before first cue | Returns `null` from lookup |
+| Seek to a time after last cue | `endSec` check on last cue; returns `null` if past its end |
+| Single-cue file | `pages` has one page; auto-advance is a no-op |
+| `cues` array is empty | `pages` is `[]`; render empty state placeholder |
+| Page manually advanced by user during playback | Auto-advance resumes on next cue boundary crossing |
+
+---
+
+## 12. Official References
+
+- `TranscriptCue` type: `src/lib/parse-transcript.ts`
+- Transcript API route: `src/app/api/videos/[id]/transcript/route.ts`
+- YouTube IFrame API (`getCurrentTime`, `seekTo`, `onStateChange`): `docs/api/youtube-iframe-player.md`
+- MDN `Element.scrollIntoView()`: https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView
+- MDN `IntersectionObserver`: https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver
+- MDN `Array.prototype.findIndex`: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/findIndex

--- a/docs/api/youtube-iframe-player.md
+++ b/docs/api/youtube-iframe-player.md
@@ -1,0 +1,395 @@
+# YouTube IFrame Player API — Reference Notes
+
+> Relevant to: **Issue #119 — Player shell with floating mini-player**, **Issue #120 — Playback progress indicator wired to player time**
+>
+> The current `PlayerClient.tsx` uses a plain `<iframe src="https://www.youtube.com/embed/...">` with no
+> programmatic control. Implementing a mini-player that can be paused when closed requires the
+> **YouTube IFrame Player API** (loaded via `https://www.youtube.com/iframe_api`).
+
+---
+
+## 1. Loading the API (no npm package needed)
+
+The API is loaded by injecting a `<script>` tag once. React pattern:
+
+```ts
+// Load once, then the global `YT` object becomes available
+useEffect(() => {
+  if (window.YT) return          // already loaded
+  const tag = document.createElement('script')
+  tag.src = 'https://www.youtube.com/iframe_api'
+  document.body.appendChild(tag)
+}, [])
+```
+
+The API calls `window.onYouTubeIframeAPIReady()` when ready. Use a ref-based callback or the
+`onReady` player event instead of the global to stay React-friendly.
+
+---
+
+## 2. Creating a Player instance
+
+```ts
+const player = new YT.Player(elementOrId, {
+  videoId: 'VIDEO_ID',
+  width: '100%',
+  height: '100%',
+  playerVars: {
+    autoplay: 1,   // 0 | 1
+    controls: 1,   // show native controls
+    rel: 0,        // don't show related videos
+    modestbranding: 1,
+  },
+  events: {
+    onReady: (e) => { /* e.target is the player */ },
+    onStateChange: (e) => { /* e.data is a YT.PlayerState value */ },
+    onError: (e) => { /* e.data is an error code */ },
+  },
+})
+```
+
+`YT.Player` **replaces** the target DOM element with the `<iframe>` — give it a plain `<div>` ref,
+not an existing `<iframe>`.
+
+---
+
+## 3. Key Playback Methods
+
+| Method | Description |
+|---|---|
+| `player.playVideo()` | Start / resume playback |
+| `player.pauseVideo()` | Pause playback |
+| `player.stopVideo()` | Stop and reset to start |
+| `player.seekTo(seconds, allowSeekAhead)` | Seek; set `allowSeekAhead: true` for buffering |
+| `player.getCurrentTime()` | Returns elapsed seconds (`number`) |
+| `player.getDuration()` | Total duration in seconds |
+| `player.getPlayerState()` | Returns a `YT.PlayerState` value (see §4) |
+| `player.mute()` / `player.unMute()` | Mute control |
+| `player.setVolume(0–100)` | Set volume |
+| `player.destroy()` | Remove player; call in cleanup `useEffect` |
+
+---
+
+## 4. Player State Values (`YT.PlayerState`)
+
+```ts
+YT.PlayerState.UNSTARTED  // -1
+YT.PlayerState.ENDED      //  0
+YT.PlayerState.PLAYING    //  1
+YT.PlayerState.PAUSED     //  2
+YT.PlayerState.BUFFERING   //  3
+YT.PlayerState.CUED        //  5
+```
+
+Use in the `onStateChange` event handler:
+
+```ts
+onStateChange: (e) => {
+  if (e.data === YT.PlayerState.ENDED) { /* handle end */ }
+}
+```
+
+For the progress indicator, respond to PLAYING to start polling and to PAUSED/ENDED/BUFFERING to stop:
+
+```ts
+onStateChange: (e) => {
+  if (e.data === YT.PlayerState.PLAYING) {
+    startProgressPolling()
+  } else {
+    stopProgressPolling()
+  }
+}
+```
+
+---
+
+## 5. TypeScript Types
+
+No first-party `@types/youtube` package exists in the repo. Add a minimal ambient declaration or
+install the community types:
+
+```bash
+pnpm add -D @types/youtube
+```
+
+This provides `YT.Player`, `YT.PlayerState`, `YT.PlayerEvent`, `YT.OnStateChangeEvent`, etc.
+
+Without the package, extend the global `Window` interface minimally:
+
+```ts
+// src/types/youtube.d.ts
+declare global {
+  interface Window {
+    YT: typeof YT
+    onYouTubeIframeAPIReady: () => void
+  }
+}
+```
+
+---
+
+## 6. Mini-Player: React Portal + Fixed Positioning
+
+### Why a Portal?
+
+The mini-player must render **outside** the `PlayerClient` subtree so it persists when the lesson
+shell unmounts or re-renders. Use `ReactDOM.createPortal` to mount it into `document.body`.
+
+```tsx
+import { createPortal } from 'react-dom'
+
+function MiniPlayer({ videoId, onClose }: { videoId: string; onClose: () => void }) {
+  return createPortal(
+    <div className="fixed bottom-4 right-4 z-50 w-80 aspect-video shadow-2xl rounded-xl overflow-hidden">
+      {/* YT.Player target div */}
+      <div ref={playerDivRef} className="w-full h-full" />
+      <button onClick={onClose} className="absolute top-2 right-2 ...">✕</button>
+    </div>,
+    document.body
+  )
+}
+```
+
+### Tailwind classes for the overlay
+
+```
+fixed bottom-4 right-4   — bottom-right anchor
+z-50                      — above all other content
+w-80 (320px)              — compact width
+aspect-video              — 16:9 ratio
+shadow-2xl rounded-xl     — visual polish
+overflow-hidden           — clip iframe to rounded corners
+```
+
+---
+
+## 7. Pause-on-Close Pattern
+
+When the user closes the mini-player call `player.pauseVideo()` **before** unmounting:
+
+```tsx
+function handleClose() {
+  playerRef.current?.pauseVideo()   // pause first
+  setMiniPlayerOpen(false)           // then unmount
+}
+```
+
+If `destroy()` is used instead, the iframe is removed and playback stops automatically, but the
+player instance cannot be reused — prefer `pauseVideo()` + hide for a toggle-able mini-player.
+
+---
+
+## 8. State Lift: Lesson Shell → Mini-Player
+
+The lesson page shell needs to:
+
+1. Keep `isMiniPlayerOpen: boolean` in React state (or a context if shared across routes).
+2. Pass `videoId` and `onClose` down to `<MiniPlayer>`.
+3. Replace the current `<iframe>` hero with a thumbnail + **Play** button.
+4. On Play click: `setIsMiniPlayerOpen(true)` — the portal renders and auto-plays.
+
+```tsx
+// Thumbnail hero (replaces inline iframe)
+<div className="relative aspect-video rounded-xl overflow-hidden cursor-pointer group"
+     onClick={() => setMiniPlayerOpen(true)}>
+  <img src={`https://img.youtube.com/vi/${video.youtube_id}/maxresdefault.jpg`}
+       alt={video.title} className="w-full h-full object-cover" />
+  <div className="absolute inset-0 flex items-center justify-center bg-black/30 group-hover:bg-black/40 transition">
+    <PlayIcon className="w-16 h-16 text-white drop-shadow-lg" />
+  </div>
+</div>
+
+{isMiniPlayerOpen && <MiniPlayer videoId={video.youtube_id} onClose={() => setMiniPlayerOpen(false)} />}
+```
+
+---
+
+## 9. YouTube Thumbnail URL Reference
+
+| Quality | URL Pattern |
+|---|---|
+| Max resolution | `https://img.youtube.com/vi/{VIDEO_ID}/maxresdefault.jpg` |
+| High quality | `https://img.youtube.com/vi/{VIDEO_ID}/hqdefault.jpg` |
+| Medium quality | `https://img.youtube.com/vi/{VIDEO_ID}/mqdefault.jpg` |
+
+`maxresdefault` may 404 for older videos; fall back to `hqdefault` with an `onError` handler on
+the `<img>` element.
+
+---
+
+- YouTube IFrame Player API: https://developers.google.com/youtube/iframe_api_reference
+- React `createPortal`: https://react.dev/reference/react-dom/createPortal
+- `@types/youtube` community types: https://www.npmjs.com/package/@types/youtube
+
+---
+
+## 11. Polling Playback Progress (for a Progress Indicator)
+
+`getCurrentTime()` and `getDuration()` are synchronous getters that can be called at any time after
+the player is ready. They do **not** emit events — you must poll them.
+
+### `getDuration()` caveat
+
+`getDuration()` returns `0` until the video metadata is loaded. Safe places to read it:
+
+- Inside the `onReady` callback (metadata is guaranteed to be available then).
+- After the first `PLAYING` state change.
+
+Never use it as the denominator for a progress percentage without a `> 0` guard.
+
+### Option A — `setInterval` (simpler, ~250 ms resolution is fine for a progress bar)
+
+```ts
+const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
+
+function startProgressPolling() {
+  if (intervalRef.current) return                // already running
+  intervalRef.current = setInterval(() => {
+    const player = playerRef.current
+    if (!player) return
+    const current = player.getCurrentTime()
+    const total   = player.getDuration()
+    if (total > 0) setProgress(current / total)  // 0–1 fraction
+  }, 250)
+}
+
+function stopProgressPolling() {
+  if (intervalRef.current) {
+    clearInterval(intervalRef.current)
+    intervalRef.current = null
+  }
+}
+
+// Clean up on unmount
+useEffect(() => () => stopProgressPolling(), [])
+```
+
+Wire `startProgressPolling` / `stopProgressPolling` to `onStateChange` (see §4).
+
+### Option B — `requestAnimationFrame` (smoother, matches display refresh)
+
+```ts
+const rafRef = useRef<number | null>(null)
+
+function tick() {
+  const player = playerRef.current
+  if (player) {
+    const current = player.getCurrentTime()
+    const total   = player.getDuration()
+    if (total > 0) setProgress(current / total)
+  }
+  rafRef.current = requestAnimationFrame(tick)
+}
+
+function startProgressPolling() {
+  if (rafRef.current) return
+  rafRef.current = requestAnimationFrame(tick)
+}
+
+function stopProgressPolling() {
+  if (rafRef.current) {
+    cancelAnimationFrame(rafRef.current)
+    rafRef.current = null
+  }
+}
+
+useEffect(() => () => stopProgressPolling(), [])
+```
+
+**Prefer `setInterval` at 250 ms** for a simple progress bar — rAF runs at 60 fps and causes
+unnecessary re-renders in React without additional throttling.
+
+### Full `onReady` + `onStateChange` wiring
+
+```ts
+events: {
+  onReady: (e) => {
+    const total = e.target.getDuration()
+    setDuration(total)      // store for display ("1:23 / 4:56")
+  },
+  onStateChange: (e) => {
+    if (e.data === YT.PlayerState.PLAYING) {
+      startProgressPolling()
+    } else {
+      stopProgressPolling()
+      // Snap to final position on ENDED
+      if (e.data === YT.PlayerState.ENDED) setProgress(1)
+    }
+  },
+}
+```
+
+---
+
+## 12. Read-Only Progress Bar UI
+
+The progress indicator for Issue #120 must be **read-only** — the user cannot scrub from it.
+Two HTML approaches:
+
+### Option A — `<progress>` element (semantic, accessible, recommended)
+
+```tsx
+<progress
+  value={progress}   // 0–1 fraction (or current seconds)
+  max={1}            // (or total duration seconds)
+  aria-label="Playback progress"
+  className="w-full h-2 appearance-none [&::-webkit-progress-bar]:rounded-full
+             [&::-webkit-progress-bar]:bg-gray-200
+             [&::-webkit-progress-value]:rounded-full
+             [&::-webkit-progress-value]:bg-blue-500"
+/>
+```
+
+- No interactivity by default — users cannot click or drag.
+- Screen readers announce it as a progress indicator automatically via the `progressbar` ARIA role.
+- Style the bar with Tailwind `[&::-webkit-progress-value]` / `[&::-moz-progress-bar]` pseudo-elements.
+
+### Option B — `<input type="range">` (disabled)
+
+```tsx
+<input
+  type="range"
+  min={0}
+  max={duration}          // total seconds from getDuration()
+  value={currentTime}     // seconds from getCurrentTime()
+  disabled                // prevents interaction; also sets aria-disabled="true"
+  readOnly                // belt-and-suspenders in React
+  onChange={() => {}}     // React controlled input — suppress warning
+  aria-label="Playback progress"
+  className="w-full accent-blue-500 cursor-default opacity-70"
+/>
+```
+
+- `disabled` stops pointer events and keyboard interaction.
+- Screen readers may announce it as a slider rather than a progress bar — less semantically correct.
+- **Prefer `<progress>`** unless you need the range thumb for visual styling.
+
+### Accessible time display
+
+Pair the bar with a visible time label for sighted users and as a text alternative:
+
+```tsx
+function formatTime(seconds: number): string {
+  const m = Math.floor(seconds / 60)
+  const s = Math.floor(seconds % 60)
+  return `${m}:${s.toString().padStart(2, '0')}`
+}
+
+<div className="flex items-center gap-2 text-sm text-gray-500">
+  <span aria-live="off">{formatTime(currentTime)}</span>
+  <progress value={progress} max={1} aria-label="Playback progress" className="flex-1 h-1.5" />
+  <span>{formatTime(duration)}</span>
+</div>
+```
+
+`aria-live="off"` prevents the time counter from flooding screen reader announcements.
+
+---
+
+## 13. Official References
+
+- YouTube IFrame Player API: https://developers.google.com/youtube/iframe_api_reference
+- React `createPortal`: https://react.dev/reference/react-dom/createPortal
+- `@types/youtube` community types: https://www.npmjs.com/package/@types/youtube
+- MDN `<progress>`: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/progress
+- MDN ARIA `progressbar` role: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/progressbar_role

--- a/docs/project/player-feature.md
+++ b/docs/project/player-feature.md
@@ -1,0 +1,727 @@
+# Player Feature — Codebase Reference
+
+> Reference document for implementing Issue #119 (Player shell with floating mini-player), Issue #120 (Playback progress indicator), and Issue #121 (Cue-synced paged transcript).
+
+---
+
+## 1. Current File Structure
+
+```
+src/
+  app/
+    (app)/
+      layout.tsx                    # App shell: Sidebar (w-64 fixed left) + TopBar (h-16 fixed top) + <main ml-64 pt-24>
+      player/
+        layout.tsx                  # Minimal passthrough layout — renders children with no extra wrapper
+        [id]/
+          page.tsx                  # Server component — awaits params, delegates to <PlayerLoader id={id} />
+          __tests__/
+            page.test.tsx           # Unit test — mocks PlayerLoader, verifies id prop is forwarded
+  components/
+    PlayerLoader.tsx                # 'use client' — fetches /api/videos/:id, handles loading/not-found/error states, renders <PlayerClient>
+    PlayerClient.tsx                # 'use client' — full lesson UI: inline YouTube iframe + right sidebar (transcript + vocabulary tabs)
+```
+
+### Full app layout tree (at runtime)
+```
+<AppLayout>            ← src/app/(app)/layout.tsx
+  <Sidebar />          ← fixed left-0, w-64, z-50
+  <TopBar />           ← fixed top-0, left-64, z-40, h-16
+  <main ml-64 pt-24>
+    <PlayerLayout>     ← src/app/(app)/player/layout.tsx (passthrough)
+      <PlayerPage>     ← server component
+        <PlayerLoader> ← fetches video over the client-side API
+          <PlayerClient> ← renders full lesson view
+```
+
+---
+
+## 2. The `Video` Type
+
+Defined in `src/lib/videos.ts` via Zod:
+
+```ts
+export interface Video {
+  id: string            // nanoid
+  youtube_url: string   // e.g. "https://www.youtube.com/watch?v=abc123"
+  youtube_id: string    // e.g. "abc123"
+  title: string
+  author_name: string
+  thumbnail_url: string // YouTube oEmbed thumbnail URL
+  transcript_path: string // relative path inside .lingoflow-data/transcripts/
+  transcript_format: string // "srt" | "vtt" | "txt"
+  tags: string[]        // deserialized from JSON in SQLite
+  created_at: string    // ISO 8601
+  updated_at: string    // ISO 8601
+}
+```
+
+Also relevant: `TranscriptCue` from `src/lib/parse-transcript.ts`:
+```ts
+export interface TranscriptCue {
+  index: number
+  startTime: string   // e.g. "00:01:23,456"
+  endTime: string
+  text: string
+}
+```
+
+---
+
+## 3. How the Current Player Page Works
+
+### Data flow
+1. `PlayerPage` (server component) — awaits `params: Promise<{ id: string }>`, passes `id` to `<PlayerLoader>`.
+2. `PlayerLoader` (`'use client'`) — on mount, fetches `GET /api/videos/:id`. Manages `status`: `'loading' | 'not-found' | 'error' | 'ready'`.
+3. `PlayerClient` (`'use client'`) — receives a `Video` prop. On mount, fetches `GET /api/videos/:id/transcript` to get `{ cues: TranscriptCue[] }`.
+
+### Current `PlayerClient` layout
+```
+<div class="min-h-screen flex flex-col lg:flex-row">
+  <section flex-1>                 ← main content
+    <iframe youtube embed />       ← 16:9 aspect-video, rounded-xl, full width
+    <title + author + tags />
+    <Save Lesson button />
+  </section>
+  <aside w-full lg:w-[420px]>     ← right sidebar
+    Transcript | Vocabulary tabs
+    Cue list (click to set activeCueIndex)
+    Vocab word cards (add/master actions)
+  </aside>
+</div>
+```
+
+The `activeCueIndex` is purely local state — there is **no** time-synced playback; the user clicks cues manually.
+
+---
+
+## 4. Files to Create / Modify for Issue #119
+
+### Goal
+Replace the inline YouTube `<iframe>` with a **thumbnail hero** (static image + Play button). Clicking Play opens a **fixed bottom-right mini-player** containing the iframe. Closing the mini-player pauses playback and returns the page to the hero view.
+
+### Files to **modify**
+
+| File | Change |
+|---|---|
+| `src/components/PlayerClient.tsx` | Replace `<iframe>` section with `<LessonHero>` component. Add state: `isMiniPlayerOpen: boolean`. Wire Play button → open mini-player. |
+| `src/app/(app)/player/layout.tsx` | Currently a passthrough. May need to remain as-is or be updated if mini-player needs a portal target outside `<main>`. The mini-player can use `fixed` positioning and lives inside `PlayerClient` directly — **no layout change required**. |
+
+### Files to **create**
+
+| File | Purpose |
+|---|---|
+| `src/components/LessonHero.tsx` | `'use client'` — Displays `video.thumbnail_url` as a full-width hero image with a centered Play button overlay and video metadata (title, author, tags). Receives `video: Video` and `onPlay: () => void`. |
+| `src/components/MiniPlayer.tsx` | `'use client'` — Fixed bottom-right overlay containing the YouTube `<iframe>`. Receives `youtubeId: string`, `title: string`, and `onClose: () => void`. Closing calls `onClose` and should pause the iframe (achieved by removing it from the DOM or appending `?autoplay=0` / clearing `src`). |
+
+### Files that do **not** need to change
+
+- `src/app/(app)/player/[id]/page.tsx` — server component, just passes `id` to `PlayerLoader`
+- `src/components/PlayerLoader.tsx` — fetches video and delegates; no visual change needed
+- All API routes — no API surface changes
+- `src/lib/videos.ts`, `src/lib/video-store.ts`, `src/lib/video-service.ts` — no data model changes
+
+---
+
+## 5. Patterns to Follow
+
+### Fixed overlay / modal pattern
+All modals (`DeleteVideoModal`, `EditVideoModal`, `ImportVideoModal`) use:
+```tsx
+<div className="fixed inset-0 bg-black/40 backdrop-blur-[6px] z-50 flex items-center justify-center"
+  onClick={onClose}>
+  <div onClick={(e) => e.stopPropagation()}>
+    {/* content */}
+  </div>
+</div>
+```
+The **MiniPlayer** should NOT use a full-screen backdrop. Instead it should use `fixed bottom-4 right-4` positioning with a high `z-index` (e.g. `z-50`) and a defined width (e.g. `w-80` or `w-96`) — similar to a toast/snackbar pattern rather than a modal.
+
+### z-index layering (existing)
+| Element | z-index |
+|---|---|
+| `Sidebar` | `z-50` |
+| `TopBar` | `z-40` |
+| Modals (fixed inset-0) | `z-50` |
+| **MiniPlayer (new)** | `z-50` (safe; no full-screen overlap) |
+
+### Closing the mini-player / pausing the iframe
+To pause a YouTube `<iframe>` on close, the simplest approach is to conditionally render the iframe only when `isMiniPlayerOpen === true`. When `MiniPlayer` unmounts (or `isMiniPlayerOpen` becomes false), the iframe is removed from the DOM, which stops playback.
+
+Alternatively, use `postMessage` to the iframe's `contentWindow`:
+```ts
+iframeRef.current?.contentWindow?.postMessage('{"event":"command","func":"pauseVideo","args":""}', '*')
+```
+This requires `?enablejsapi=1` in the embed URL.
+
+### Tailwind design tokens in use
+| Token | Usage |
+|---|---|
+| `bg-surface` | Page backgrounds |
+| `bg-surface-container-low` | Sidebar, aside panels |
+| `bg-surface-container-lowest/90` | Modal card backgrounds |
+| `text-on-surface` | Primary text |
+| `text-on-surface-variant` | Secondary / muted text |
+| `border-outline-variant/20` | Subtle borders |
+| `text-primary` | Brand accent color |
+| `rounded-xl` | Standard border radius for cards/modals |
+| `shadow-2xl` | Card/modal shadow |
+| `backdrop-blur-[24px]` | Frosted glass modal backgrounds |
+
+### TypeScript / Next.js conventions
+- `'use client'` at top of any component using hooks or event handlers
+- No `export const runtime = 'nodejs'` needed in `components/` (only in `app/api/` routes)
+- Use `@/components/...` and `@/lib/...` path aliases throughout
+- Props interfaces defined inline above the component or exported if reused
+
+### YouTube embed URL
+Current embed pattern in `PlayerClient`:
+```ts
+`https://www.youtube.com/embed/${video.youtube_id}`
+```
+For autoplay when mini-player opens, append `?autoplay=1`:
+```ts
+`https://www.youtube.com/embed/${video.youtube_id}?autoplay=1`
+```
+For the JS API (pause on close), append `?enablejsapi=1&autoplay=1`.
+
+---
+
+## 6. Suggested Component Interfaces
+
+```ts
+// src/components/LessonHero.tsx
+interface LessonHeroProps {
+  video: Video
+  onPlay: () => void
+}
+
+// src/components/MiniPlayer.tsx
+interface MiniPlayerProps {
+  youtubeId: string
+  title: string
+  onClose: () => void
+}
+```
+
+### State in `PlayerClient` (after refactor)
+```ts
+const [isMiniPlayerOpen, setIsMiniPlayerOpen] = useState(false)
+
+// Render:
+// - <LessonHero video={video} onPlay={() => setIsMiniPlayerOpen(true)} />  (always visible in main section)
+// - {isMiniPlayerOpen && <MiniPlayer youtubeId={video.youtube_id} title={video.title} onClose={() => setIsMiniPlayerOpen(false)} />}
+```
+
+---
+
+## 7. Test Files to Create / Update
+
+| File | What to test |
+|---|---|
+| `src/components/__tests__/LessonHero.test.tsx` | Renders thumbnail image, renders title/author, calls `onPlay` when Play button clicked |
+| `src/components/__tests__/MiniPlayer.test.tsx` | Renders iframe with correct `src`, calls `onClose` when close button clicked |
+| `src/components/__tests__/PlayerClient.test.tsx` (new or update) | Initially shows `LessonHero` (no iframe); after clicking Play shows `MiniPlayer`; after clicking close hides `MiniPlayer` |
+
+Use `// @jest-environment jsdom` (the default) for component tests — no override needed.
+Mock `fetch` for transcript calls as needed (already done implicitly in existing tests).
+
+---
+
+## 8. Progress Indicator — Issue #120
+
+### Goal
+Add a **read-only** playback progress bar to the lesson page (main content area, not inside the mini-player overlay). It must display elapsed time and total duration sourced from the live YouTube player. Scrubbing (clicking or dragging to seek) must NOT be supported.
+
+---
+
+### 8.1 Component Tree Placement
+
+The progress bar lives in `PlayerClient`'s main `<section>` area, rendered **below** `<LessonHero>` and only when the mini-player is open (i.e., playback has started):
+
+```
+<PlayerClient>
+  <section>                           ← main content
+    <LessonHero />                    ← always visible
+    {isMiniPlayerOpen && (
+      <PlaybackProgress              ← NEW — read-only bar
+        currentTime={playbackTime.current}
+        duration={playbackTime.duration}
+      />
+    )}
+  </section>
+
+  {isMiniPlayerOpen && (
+    <MiniPlayer                      ← fixed bottom-right overlay
+      youtubeId={...}
+      title={...}
+      onClose={...}
+      onTimeUpdate={handleTimeUpdate} ← NEW prop
+    />
+  )}
+
+  <aside> … </aside>
+</PlayerClient>
+```
+
+---
+
+### 8.2 How to Wire YouTube Player Time Into React State
+
+`MiniPlayer` already uses `?enablejsapi=1` in the embed URL. Extend it to load the **YouTube IFrame API script** (`https://www.youtube.com/iframe_api`) and create a `YT.Player` instance so that player methods (`getCurrentTime()`, `getDuration()`) become available.
+
+**Polling approach — inside `MiniPlayer`:**
+
+```ts
+// MiniPlayer.tsx (additions)
+useEffect(() => {
+  // 1. Inject the IFrame API script once
+  if (!window.YT) {
+    const script = document.createElement('script')
+    script.src = 'https://www.youtube.com/iframe_api'
+    document.head.appendChild(script)
+  }
+
+  let player: YT.Player
+  let pollInterval: ReturnType<typeof setInterval>
+
+  // 2. Wait for API ready, then bind to our iframe
+  const prevReady = window.onYouTubeIframeAPIReady
+  window.onYouTubeIframeAPIReady = () => {
+    prevReady?.()
+    player = new window.YT.Player(iframeRef.current!, {
+      events: {
+        onStateChange(event) {
+          if (event.data === window.YT.PlayerState.PLAYING) {
+            // 3. Poll every 250 ms while playing
+            clearInterval(pollInterval)
+            pollInterval = setInterval(() => {
+              const current = player.getCurrentTime()   // seconds (float)
+              const total = player.getDuration()        // seconds (float)
+              onTimeUpdate?.(current, total)
+            }, 250)
+          } else {
+            clearInterval(pollInterval)
+          }
+        },
+      },
+    })
+  }
+
+  // If API was already loaded, fire immediately
+  if (window.YT?.Player) {
+    window.onYouTubeIframeAPIReady()
+  }
+
+  return () => {
+    clearInterval(pollInterval)
+    player?.destroy()
+  }
+}, [youtubeId]) // re-bind if video changes
+```
+
+> **Important:** The `YT.Player` constructor targets the **existing** `<iframe>` element via `iframeRef.current` — it does NOT replace the element. The iframe's `src` must already contain `enablejsapi=1`, which it does in the current implementation.
+
+**TypeScript types for `window.YT`:**
+Install `@types/youtube` (dev dependency):
+```bash
+pnpm add -D @types/youtube
+```
+This provides `YT.Player`, `YT.PlayerState`, `YT.PlayerEvent`, etc.
+
+---
+
+### 8.3 Props / Callbacks Threading
+
+#### New prop on `MiniPlayer`
+```ts
+interface MiniPlayerProps {
+  youtubeId: string
+  title: string
+  onClose: () => void
+  onTimeUpdate?: (currentTime: number, duration: number) => void  // ← NEW (optional)
+}
+```
+
+#### New state in `PlayerClient`
+```ts
+const [playbackTime, setPlaybackTime] = useState({ current: 0, duration: 0 })
+
+function handleTimeUpdate(current: number, duration: number) {
+  setPlaybackTime({ current, duration })
+}
+```
+Pass `onTimeUpdate={handleTimeUpdate}` to `<MiniPlayer>`.
+
+When `isMiniPlayerOpen` becomes `false`, reset state so the progress bar returns to 0 on the next play:
+```ts
+function handleClose() {
+  setIsMiniPlayerOpen(false)
+  setPlaybackTime({ current: 0, duration: 0 })
+}
+```
+
+#### New component `PlaybackProgress`
+```ts
+// src/components/PlaybackProgress.tsx
+interface PlaybackProgressProps {
+  currentTime: number   // seconds
+  duration: number      // seconds (0 while metadata not loaded)
+}
+```
+Render a `<progress>` element (or a styled `<div>`) with `pointer-events-none` / no `onChange`/`onClick` handlers to enforce read-only. Display a formatted time string (e.g. `"1:23 / 4:56"`).
+
+```tsx
+// Minimal implementation pattern
+const pct = duration > 0 ? (currentTime / duration) * 100 : 0
+
+<div data-testid="playback-progress" className="w-full mt-4">
+  <div className="h-1.5 rounded-full bg-outline-variant/30 overflow-hidden">
+    <div
+      className="h-full bg-primary rounded-full transition-all duration-200"
+      style={{ width: `${pct}%` }}
+    />
+  </div>
+  <div className="flex justify-between text-xs text-on-surface-variant mt-1">
+    <span data-testid="current-time">{formatTime(currentTime)}</span>
+    <span data-testid="duration">{formatTime(duration)}</span>
+  </div>
+</div>
+```
+
+`formatTime(seconds: number): string` — helper that converts a float number of seconds to `"M:SS"` format.
+
+---
+
+### 8.4 Files to Create / Modify
+
+| File | Action | Change |
+|---|---|---|
+| `src/components/PlaybackProgress.tsx` | **Create** | Read-only progress bar + time display. Props: `currentTime`, `duration`. |
+| `src/components/MiniPlayer.tsx` | **Modify** | Add `onTimeUpdate?: (current: number, duration: number) => void` prop. Load YT IFrame API script, create `YT.Player` instance, poll `getCurrentTime()` / `getDuration()` at 250 ms when playing, clear interval on pause/stop/unmount. |
+| `src/components/PlayerClient.tsx` | **Modify** | Add `playbackTime` state (`{ current: number, duration: number }`). Add `handleTimeUpdate` callback. Pass `onTimeUpdate` to `<MiniPlayer>`. Render `<PlaybackProgress>` below `<LessonHero>` when `isMiniPlayerOpen` is true. Reset `playbackTime` to `{ current: 0, duration: 0 }` when mini-player closes. |
+| `package.json` / `pnpm-lock.yaml` | **Modify** | Add `@types/youtube` as a dev dependency (`pnpm add -D @types/youtube`). |
+
+No API route changes. No database changes. No changes to `LessonHero`, `PlayerLoader`, or `PlayerPage`.
+
+---
+
+### 8.5 Test Coverage Expectations
+
+| File | What to test |
+|---|---|
+| `src/components/__tests__/PlaybackProgress.test.tsx` | **New.** (1) Renders with `currentTime=0, duration=0` — bar width is 0%, both time labels show `"0:00"`. (2) Renders with `currentTime=90, duration=300` — bar width is 30%, labels show `"1:30"` / `"5:00"`. (3) No scrubbing: confirm the progress element has no `onClick` or `onChange` handler (or simply that clicking it does NOT change state — test this by clicking the bar and asserting `currentTime` label is unchanged). |
+| `src/components/__tests__/MiniPlayer.test.tsx` | **Update.** (1) Calls `onTimeUpdate` when the YT Player fires a polling tick (mock `window.YT.Player` and simulate `onStateChange` with `PLAYING`; fast-forward timers with `jest.useFakeTimers`). (2) Clears the interval on unmount. |
+| `src/components/__tests__/PlayerClient.test.tsx` | **Update.** (1) `PlaybackProgress` is not rendered before Play is clicked. (2) After clicking Play, `PlaybackProgress` is rendered with `currentTime=0`. (3) When `MiniPlayer` calls `onTimeUpdate(90, 300)`, `PlaybackProgress` shows `"1:30"` and `"5:00"`. (4) After closing the mini-player, `PlaybackProgress` is not rendered. |
+
+Use `jest.useFakeTimers()` and `jest.advanceTimersByTime(250)` to simulate polling intervals without real-time delays.
+
+Mock `window.YT` in tests:
+```ts
+const mockGetCurrentTime = jest.fn().mockReturnValue(90)
+const mockGetDuration = jest.fn().mockReturnValue(300)
+const mockPlayerInstance = { getCurrentTime: mockGetCurrentTime, getDuration: mockGetDuration, destroy: jest.fn() }
+window.YT = {
+  Player: jest.fn().mockImplementation((_el, opts) => {
+    opts.events.onStateChange({ data: window.YT.PlayerState.PLAYING })
+    return mockPlayerInstance
+  }),
+  PlayerState: { PLAYING: 1, PAUSED: 2, ENDED: 0 },
+} as unknown as typeof YT
+```
+
+---
+
+## 9. Cue-synced Paged Transcript — Issue #121
+
+### Goal
+
+Replace the manually-clicked cue list in the transcript sidebar with an **auto-advancing paged view** that:
+- Highlights the cue that is actively playing based on current playback time.
+- Groups cues into fixed-size pages (10 cues per page).
+- Automatically flips to the page containing the active cue as playback progresses.
+- Allows the user to manually navigate between pages.
+
+This feature builds directly on top of Issue #120: the `currentTime` value produced by the `onTimeUpdate` polling in `MiniPlayer` is the single source of truth driving cue selection and page advancement.
+
+---
+
+### 9.1 How Transcript Cues Are Fetched
+
+**Endpoint:** `GET /api/videos/:id/transcript`
+
+**Response shape:**
+```ts
+{ cues: TranscriptCue[] }
+```
+
+`TranscriptCue` (from `src/lib/parse-transcript.ts`):
+```ts
+export interface TranscriptCue {
+  index: number       // 1-based sequential index from the source file
+  startTime: string   // e.g. "00:01:23,456" (SRT) or "00:01:23.456" (VTT)
+  endTime: string     // same format
+  text: string        // display text for the cue
+}
+```
+
+**Fetching pattern (already in `PlayerClient`):**
+```ts
+useEffect(() => {
+  fetch(`/api/videos/${video.id}/transcript`)
+    .then((r) => r.json())
+    .then((data) => setCues(data.cues ?? []))
+    .catch(() => setCues([]))
+    .finally(() => setLoadingTranscript(false))
+}, [video.id])
+```
+No new hook or API changes are needed — `cues` is already available as state in `PlayerClient`.
+
+---
+
+### 9.2 Where the Transcript Panel Lives
+
+The transcript panel is the `activeTab === 'transcript'` branch inside `PlayerClient`'s `<aside>`. It already renders cues; the change is to replace the flat manual-click list with a `TranscriptPanel` component that receives `cues`, `activeCueIndex`, `currentPage`, and callbacks.
+
+Component tree after the refactor:
+```
+<PlayerClient>
+  <section>                              ← main content
+    <LessonHero />
+    {isMiniPlayerOpen && <PlaybackProgress ... />}   ← from Issue #120
+  </section>
+
+  {isMiniPlayerOpen && (
+    <MiniPlayer
+      onTimeUpdate={handleTimeUpdate}    ← from Issue #120
+      ...
+    />
+  )}
+
+  <aside>
+    [Transcript | Vocabulary tabs]
+    {activeTab === 'transcript' && (
+      <TranscriptPanel                   ← NEW — Issue #121
+        cues={cues}
+        activeCueIndex={activeCueIndex}
+        currentPage={currentPage}
+        onPageChange={setCurrentPage}
+        loading={loadingTranscript}
+      />
+    )}
+    {activeTab === 'vocabulary' && <VocabPanel ... />}
+  </aside>
+</PlayerClient>
+```
+
+---
+
+### 9.3 How Current Playback Time Flows to the Transcript Panel
+
+The full data-flow chain (each arrow is a prop or state update):
+
+```
+YT.Player (inside MiniPlayer)
+  → polls getCurrentTime() every 250 ms while playing
+  → calls onTimeUpdate(current, duration)          ← MiniPlayer prop
+
+PlayerClient.handleTimeUpdate(current, duration)
+  → setPlaybackTime({ current, duration })         ← Issue #120 state
+  → setActiveCueIndex(findActiveCueIndex(cues, current))  ← NEW — Issue #121
+  → setCurrentPage(Math.floor(activeCueIndex / CUES_PER_PAGE))  ← auto-advance page
+
+<TranscriptPanel
+  cues={cues}
+  activeCueIndex={activeCueIndex}
+  currentPage={currentPage}
+  onPageChange={setCurrentPage}
+/>
+```
+
+`activeCueIndex` and `currentPage` are separate pieces of state in `PlayerClient`. Only the **auto-advance** logic (inside `handleTimeUpdate`) updates `currentPage` automatically. The user can also change `currentPage` manually via `onPageChange`, without affecting `activeCueIndex`.
+
+---
+
+### 9.4 Active Cue Selection Algorithm
+
+#### Time string parsing
+
+`startTime` and `endTime` are strings in `"HH:MM:SS,mmm"` (SRT) or `"HH:MM:SS.mmm"` (VTT) format. Both are produced by `parseTranscript` and must be converted to seconds for comparison with the `currentTime` float (seconds) from the YT API.
+
+```ts
+// src/lib/parse-transcript.ts  (or a new src/lib/transcript-utils.ts)
+export function parseTimeToSeconds(timeStr: string): number {
+  if (!timeStr) return 0
+  // Accepts both comma and period as millisecond separator
+  const [hms, ms = '0'] = timeStr.split(/[,.]/)
+  const parts = hms.split(':').map(Number)
+  const [h = 0, m = 0, s = 0] = parts
+  return h * 3600 + m * 60 + s + parseInt(ms, 10) / 1000
+}
+```
+
+#### findActiveCueIndex
+
+```ts
+export function findActiveCueIndex(cues: TranscriptCue[], currentTime: number): number {
+  let lastBefore = -1
+  for (let i = 0; i < cues.length; i++) {
+    const start = parseTimeToSeconds(cues[i].startTime)
+    const end = parseTimeToSeconds(cues[i].endTime)
+    if (currentTime >= start && currentTime < end) return i
+    if (currentTime >= start) lastBefore = i
+  }
+  return lastBefore
+}
+```
+
+- Returns the index of the cue whose window `[startTime, endTime)` contains `currentTime`.
+- Falls back to the last cue whose `startTime ≤ currentTime` when no cue window matches (gap between cues).
+- Returns `-1` when `currentTime` is before all cues (before playback has reached any cue). In this case no cue is highlighted.
+- **Important:** cues with empty `startTime`/`endTime` (produced by the plain-text parser path in `parseTranscript`) all parse to `0`; they will not be meaningfully synced. This is acceptable — plain-text transcripts have no timing data.
+
+---
+
+### 9.5 Paging Strategy
+
+```ts
+const CUES_PER_PAGE = 10
+```
+
+| Variable | Derivation |
+|---|---|
+| `totalPages` | `Math.ceil(cues.length / CUES_PER_PAGE)` |
+| `currentPage` | `useState(0)` — 0-indexed |
+| Page `n` cues | `cues.slice(n * CUES_PER_PAGE, (n + 1) * CUES_PER_PAGE)` |
+| Active cue's page | `Math.floor(activeCueIndex / CUES_PER_PAGE)` |
+
+#### Auto-advance logic (inside `PlayerClient.handleTimeUpdate`)
+
+```ts
+function handleTimeUpdate(current: number, duration: number) {
+  setPlaybackTime({ current, duration })
+
+  const newActiveCueIndex = findActiveCueIndex(cues, current)
+  setActiveCueIndex(newActiveCueIndex)
+
+  if (newActiveCueIndex >= 0) {
+    const targetPage = Math.floor(newActiveCueIndex / CUES_PER_PAGE)
+    // Only auto-flip if the active cue moved to a different page
+    setCurrentPage((prev) => (targetPage !== prev ? targetPage : prev))
+  }
+}
+```
+
+Using the functional updater `setCurrentPage((prev) => ...)` avoids stale closure issues. The page only flips when the active cue genuinely crosses a boundary, not on every poll tick.
+
+#### Manual navigation
+
+`TranscriptPanel` renders Prev / Next buttons:
+```tsx
+<button onClick={() => onPageChange(Math.max(0, currentPage - 1))}
+  disabled={currentPage === 0}>← Prev</button>
+<span>{currentPage + 1} / {totalPages}</span>
+<button onClick={() => onPageChange(Math.min(totalPages - 1, currentPage + 1))}
+  disabled={currentPage === totalPages - 1}>Next →</button>
+```
+Manual navigation overrides auto-advance until the active cue crosses the next page boundary (at which point auto-advance reclaims control).
+
+#### Scroll-to-active cue
+
+Within the current page, the active cue should scroll into view. Use a `useEffect` that fires when `activeCueIndex` changes and the active cue is on the current page:
+```ts
+useEffect(() => {
+  activeCueRef.current?.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
+}, [activeCueIndex])
+```
+Attach `activeCueRef` to the rendered cue element whose index matches `activeCueIndex`.
+
+---
+
+### 9.6 Files to Create / Modify
+
+| File | Action | Description |
+|---|---|---|
+| `src/lib/parse-transcript.ts` | **Modify** | Export `parseTimeToSeconds(timeStr: string): number` and `findActiveCueIndex(cues: TranscriptCue[], currentTime: number): number`. Both are pure utilities that belong alongside the parser. |
+| `src/components/TranscriptPanel.tsx` | **Create** | `'use client'` — renders the paged, cue-highlighted transcript sidebar content. See interface below. |
+| `src/components/PlayerClient.tsx` | **Modify** | (1) Import and use `findActiveCueIndex` from `@/lib/parse-transcript`. (2) Add `currentPage` state (`useState(0)`). (3) Update `handleTimeUpdate` (from Issue #120) to also call `setActiveCueIndex` and auto-advance `currentPage`. (4) Replace the inline cue-list rendering inside the transcript tab with `<TranscriptPanel>`. |
+
+No changes needed to:
+- `src/components/MiniPlayer.tsx` — `onTimeUpdate` prop added in Issue #120 is already sufficient
+- `src/components/LessonHero.tsx` — no changes
+- `src/app/api/videos/[id]/transcript/route.ts` — API is already correct
+- Any DB, store, or service files
+
+---
+
+### 9.7 Component Interface
+
+```ts
+// src/components/TranscriptPanel.tsx
+const CUES_PER_PAGE = 10
+
+interface TranscriptPanelProps {
+  cues: TranscriptCue[]
+  activeCueIndex: number       // -1 means no active cue (before playback / no timing data)
+  currentPage: number          // 0-indexed
+  onPageChange: (page: number) => void
+  loading: boolean
+}
+```
+
+Rendering rules:
+- When `loading` is `true`: show a loading spinner / "Loading transcript…" text.
+- When `cues.length === 0` (and not loading): show the "No transcript available" empty state (as currently rendered in `PlayerClient`).
+- Otherwise: render the slice of cues for the current page, highlight the active one, show pagination controls.
+
+Cue styling follows the existing visual conventions already in `PlayerClient`:
+```tsx
+// Past cue (i + pageOffset < activeCueIndex)
+className="opacity-40 text-sm text-on-surface-variant px-3 py-2"
+
+// Active cue (i + pageOffset === activeCueIndex)
+className="bg-surface-container rounded-xl p-3 ring-1 ring-primary/10 border-l-4 border-primary"
+
+// Future cue
+className="opacity-60 text-sm text-on-surface px-3 py-2"
+```
+Where `pageOffset = currentPage * CUES_PER_PAGE`.
+
+---
+
+### 9.8 Test Coverage Expectations
+
+#### New utility tests
+
+| File | What to test |
+|---|---|
+| `src/lib/__tests__/parse-transcript.test.ts` | **Update.** (1) `parseTimeToSeconds("00:01:23,456")` → `83.456`. (2) `parseTimeToSeconds("00:01:23.456")` → `83.456`. (3) `parseTimeToSeconds("")` → `0`. (4) `findActiveCueIndex` returns correct index when `currentTime` falls inside a cue window. (5) Returns `lastBefore` index when `currentTime` is in a gap. (6) Returns `-1` when `currentTime` is before all cues. |
+
+#### New component tests
+
+| File | What to test |
+|---|---|
+| `src/components/__tests__/TranscriptPanel.test.tsx` | **New.** (1) Shows loading state when `loading=true`. (2) Shows empty state when `cues=[]` and `loading=false`. (3) Renders only `CUES_PER_PAGE` cues on each page. (4) The cue at `activeCueIndex` has `data-testid="cue-active"` or the expected active CSS class / `border-primary` class. (5) Prev button is disabled on page 0; Next button is disabled on last page. (6) Clicking Next calls `onPageChange(1)`. (7) Active cue on the current page is visible (scroll-into-view via ref — can assert that `scrollIntoView` mock was called). |
+
+#### Updated component tests
+
+| File | What to test |
+|---|---|
+| `src/components/__tests__/PlayerClient.test.tsx` | **Update.** (1) When `onTimeUpdate` is called with a time matching a cue, `activeCueIndex` is set and the active cue element is highlighted. Use `jest.useFakeTimers()` + mock `window.YT` from Issue #120 test patterns. (2) When `activeCueIndex` crosses a page boundary (e.g., goes from 9 to 10), page auto-advances and cues for page 2 are rendered. (3) `findActiveCueIndex` is called with correct args (can spy on the imported util). |
+
+Use `// @jest-environment jsdom` (default) for all component tests. Mock `fetch` for transcript responses as needed.
+
+---
+
+### 9.9 Data-testid Conventions for New Elements
+
+| Element | `data-testid` |
+|---|---|
+| `TranscriptPanel` root | `transcript-panel` |
+| Active cue | `cue-active` |
+| Non-active cue at index `i` | `cue-{i}` (where `i` is position within current page, 0-based) |
+| Prev page button | `transcript-prev-page` |
+| Next page button | `transcript-next-page` |
+| Page indicator | `transcript-page-indicator` |
+
+These follow the existing `data-testid` naming convention (`cue-{i}`, `tab-transcript`, etc.) already used in `PlayerClient`.

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@types/youtube": "^0.2.0",
     "eslint": "^9",
     "eslint-config-next": "16.2.3",
     "jest": "^30.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,9 @@ importers:
       '@types/react-dom':
         specifier: ^19
         version: 19.2.3(@types/react@19.2.14)
+      '@types/youtube':
+        specifier: ^0.2.0
+        version: 0.2.0
       eslint:
         specifier: ^9
         version: 9.39.4(jiti@1.21.7)
@@ -849,6 +852,9 @@ packages:
 
   '@types/yargs@17.0.35':
     resolution: {integrity: sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==}
+
+  '@types/youtube@0.2.0':
+    resolution: {integrity: sha512-Y+y6RKuqhurm5yWfUt3eT2QdHZNl09+OT86I2yOKGfJzTZCaR5eSf6m7zIGnlUHiUuYm4i/hUTDJ++E53OVh0g==}
 
   '@typescript-eslint/eslint-plugin@8.58.1':
     resolution: {integrity: sha512-eSkwoemjo76bdXl2MYqtxg51HNwUSkWfODUOQ3PaTLZGh9uIWWFZIjyjaJnex7wXDu+TRx+ATsnSxdN9YWfRTQ==}
@@ -4187,6 +4193,8 @@ snapshots:
   '@types/yargs@17.0.35':
     dependencies:
       '@types/yargs-parser': 21.0.3
+
+  '@types/youtube@0.2.0': {}
 
   '@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)':
     dependencies:

--- a/src/components/MiniPlayer.tsx
+++ b/src/components/MiniPlayer.tsx
@@ -1,21 +1,86 @@
 'use client'
 
-import { useRef } from 'react'
+import { useEffect, useRef } from 'react'
 
 interface MiniPlayerProps {
   youtubeId: string
   title: string
   onClose: () => void
+  onTimeUpdate?: (currentTime: number, duration: number) => void
 }
 
-export default function MiniPlayer({ youtubeId, title, onClose }: MiniPlayerProps) {
+export default function MiniPlayer({ youtubeId, title, onClose, onTimeUpdate }: MiniPlayerProps) {
   const iframeRef = useRef<HTMLIFrameElement>(null)
+  const playerRef = useRef<YT.Player | null>(null)
+  const pollIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  const onTimeUpdateRef = useRef(onTimeUpdate)
+  onTimeUpdateRef.current = onTimeUpdate
+
+  useEffect(() => {
+    let destroyed = false
+
+    function startPolling(player: YT.Player) {
+      if (pollIntervalRef.current) return
+      pollIntervalRef.current = setInterval(() => {
+        if (destroyed) return
+        const current = player.getCurrentTime()
+        const total = player.getDuration()
+        if (total > 0) onTimeUpdateRef.current?.(current, total)
+      }, 250)
+    }
+
+    function stopPolling() {
+      if (pollIntervalRef.current) {
+        clearInterval(pollIntervalRef.current)
+        pollIntervalRef.current = null
+      }
+    }
+
+    function initPlayer() {
+      if (!iframeRef.current) return
+      const player = new window.YT.Player(iframeRef.current, {
+        events: {
+          onStateChange(event: YT.OnStateChangeEvent) {
+            if (event.data === window.YT.PlayerState.PLAYING) {
+              startPolling(player)
+            } else {
+              stopPolling()
+              if (event.data === window.YT.PlayerState.ENDED) {
+                const total = player.getDuration()
+                if (total > 0) onTimeUpdateRef.current?.(total, total)
+              }
+            }
+          },
+        },
+      })
+      playerRef.current = player
+    }
+
+    if (window.YT?.Player) {
+      initPlayer()
+    } else {
+      const prevReady = window.onYouTubeIframeAPIReady
+      window.onYouTubeIframeAPIReady = () => {
+        prevReady?.()
+        if (!destroyed) initPlayer()
+      }
+      if (!document.querySelector('script[src="https://www.youtube.com/iframe_api"]')) {
+        const script = document.createElement('script')
+        script.src = 'https://www.youtube.com/iframe_api'
+        document.head.appendChild(script)
+      }
+    }
+
+    return () => {
+      destroyed = true
+      stopPolling()
+      playerRef.current?.destroy()
+      playerRef.current = null
+    }
+  }, [youtubeId])
 
   function handleClose() {
-    iframeRef.current?.contentWindow?.postMessage(
-      '{"event":"command","func":"pauseVideo","args":""}',
-      '*'
-    )
+    playerRef.current?.pauseVideo()
     onClose()
   }
 

--- a/src/components/PlaybackProgress.tsx
+++ b/src/components/PlaybackProgress.tsx
@@ -1,0 +1,32 @@
+'use client'
+
+interface PlaybackProgressProps {
+  currentTime: number // seconds
+  duration: number // seconds (0 while metadata not loaded)
+}
+
+function formatTime(seconds: number): string {
+  const m = Math.floor(seconds / 60)
+  const s = Math.floor(seconds % 60)
+  return `${m}:${s.toString().padStart(2, '0')}`
+}
+
+export default function PlaybackProgress({ currentTime, duration }: PlaybackProgressProps) {
+  const pct = duration > 0 ? (currentTime / duration) * 100 : 0
+
+  return (
+    <div data-testid="playback-progress" className="w-full mt-4">
+      <div className="h-1.5 rounded-full bg-outline-variant/30 overflow-hidden">
+        <div
+          className="h-full bg-primary rounded-full transition-all duration-200"
+          style={{ width: `${pct}%` }}
+          data-testid="progress-bar-fill"
+        />
+      </div>
+      <div className="flex justify-between text-xs text-on-surface-variant mt-1">
+        <span data-testid="current-time">{formatTime(currentTime)}</span>
+        <span data-testid="duration">{formatTime(duration)}</span>
+      </div>
+    </div>
+  )
+}

--- a/src/components/PlayerClient.tsx
+++ b/src/components/PlayerClient.tsx
@@ -5,6 +5,7 @@ import { Video } from '@/lib/videos'
 import { TranscriptCue } from '@/lib/parse-transcript'
 import LessonHero from '@/components/LessonHero'
 import MiniPlayer from '@/components/MiniPlayer'
+import PlaybackProgress from '@/components/PlaybackProgress'
 
 interface WordCard {
   word: string
@@ -28,6 +29,16 @@ export default function PlayerClient({ video }: { video: Video }) {
   const [activeTab, setActiveTab] = useState<'transcript' | 'vocabulary'>('transcript')
   const [vocabWords, setVocabWords] = useState<WordCard[]>([])
   const [isMiniPlayerOpen, setIsMiniPlayerOpen] = useState(false)
+  const [playbackTime, setPlaybackTime] = useState({ current: 0, duration: 0 })
+
+  function handleTimeUpdate(current: number, duration: number) {
+    setPlaybackTime({ current, duration })
+  }
+
+  function handleClose() {
+    setIsMiniPlayerOpen(false)
+    setPlaybackTime({ current: 0, duration: 0 })
+  }
 
   useEffect(() => {
     fetch(`/api/videos/${video.id}/transcript`)
@@ -57,13 +68,20 @@ export default function PlayerClient({ video }: { video: Video }) {
       {/* Main content */}
       <section className="flex-1 p-8 bg-surface dark:bg-slate-900 overflow-y-auto">
         <LessonHero video={video} onPlay={() => setIsMiniPlayerOpen(true)} />
+        {isMiniPlayerOpen && (
+          <PlaybackProgress
+            currentTime={playbackTime.current}
+            duration={playbackTime.duration}
+          />
+        )}
       </section>
 
       {isMiniPlayerOpen && (
         <MiniPlayer
           youtubeId={video.youtube_id}
           title={video.title}
-          onClose={() => setIsMiniPlayerOpen(false)}
+          onClose={handleClose}
+          onTimeUpdate={handleTimeUpdate}
         />
       )}
 

--- a/src/components/__tests__/MiniPlayer.test.tsx
+++ b/src/components/__tests__/MiniPlayer.test.tsx
@@ -1,5 +1,43 @@
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, act } from '@testing-library/react'
 import MiniPlayer from '../MiniPlayer'
+
+let capturedOnStateChange: ((event: { data: number }) => void) | null = null
+
+const mockGetCurrentTime = jest.fn().mockReturnValue(90)
+const mockGetDuration = jest.fn().mockReturnValue(300)
+const mockDestroy = jest.fn()
+const mockPauseVideo = jest.fn()
+
+beforeEach(() => {
+  jest.useFakeTimers()
+  capturedOnStateChange = null
+  mockGetCurrentTime.mockReturnValue(90)
+  mockGetDuration.mockReturnValue(300)
+  mockDestroy.mockReset()
+  mockPauseVideo.mockReset()
+
+  Object.defineProperty(window, 'YT', {
+    value: {
+      Player: jest.fn().mockImplementation((_el: unknown, opts: { events: { onStateChange: (e: { data: number }) => void } }) => {
+        capturedOnStateChange = opts.events.onStateChange
+        return {
+          getCurrentTime: mockGetCurrentTime,
+          getDuration: mockGetDuration,
+          destroy: mockDestroy,
+          pauseVideo: mockPauseVideo,
+        }
+      }),
+      PlayerState: { PLAYING: 1, PAUSED: 2, ENDED: 0, BUFFERING: 3, CUED: 5 },
+    },
+    writable: true,
+    configurable: true,
+  })
+})
+
+afterEach(() => {
+  jest.useRealTimers()
+  jest.resetAllMocks()
+})
 
 describe('MiniPlayer', () => {
   it('renders the iframe with correct YouTube embed src', () => {
@@ -33,4 +71,66 @@ describe('MiniPlayer', () => {
     render(<MiniPlayer youtubeId="abc123" title="My Video" onClose={jest.fn()} />)
     expect(screen.getByTestId('mini-player')).toBeInTheDocument()
   })
+
+  it('calls onTimeUpdate with current time and duration when polling', () => {
+    const onTimeUpdate = jest.fn()
+    render(
+      <MiniPlayer youtubeId="abc123" title="My Video" onClose={jest.fn()} onTimeUpdate={onTimeUpdate} />
+    )
+
+    // Simulate PLAYING state to start polling
+    act(() => {
+      capturedOnStateChange?.({ data: 1 }) // PLAYING
+    })
+
+    act(() => {
+      jest.advanceTimersByTime(250)
+    })
+
+    expect(onTimeUpdate).toHaveBeenCalledWith(90, 300)
+  })
+
+  it('stops polling when state changes to PAUSED', () => {
+    const onTimeUpdate = jest.fn()
+    render(
+      <MiniPlayer youtubeId="abc123" title="My Video" onClose={jest.fn()} onTimeUpdate={onTimeUpdate} />
+    )
+
+    act(() => {
+      capturedOnStateChange?.({ data: 1 }) // PLAYING
+    })
+    act(() => {
+      jest.advanceTimersByTime(250)
+    })
+    expect(onTimeUpdate).toHaveBeenCalledTimes(1)
+
+    act(() => {
+      capturedOnStateChange?.({ data: 2 }) // PAUSED
+    })
+    act(() => {
+      jest.advanceTimersByTime(500)
+    })
+    // No additional calls after pause
+    expect(onTimeUpdate).toHaveBeenCalledTimes(1)
+  })
+
+  it('clears the interval on unmount', () => {
+    const onTimeUpdate = jest.fn()
+    const { unmount } = render(
+      <MiniPlayer youtubeId="abc123" title="My Video" onClose={jest.fn()} onTimeUpdate={onTimeUpdate} />
+    )
+
+    act(() => {
+      capturedOnStateChange?.({ data: 1 }) // PLAYING
+    })
+
+    unmount()
+
+    act(() => {
+      jest.advanceTimersByTime(500)
+    })
+    // No calls after unmount
+    expect(onTimeUpdate).not.toHaveBeenCalled()
+  })
 })
+

--- a/src/components/__tests__/PlaybackProgress.test.tsx
+++ b/src/components/__tests__/PlaybackProgress.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import PlaybackProgress from '../PlaybackProgress'
+
+describe('PlaybackProgress', () => {
+  it('renders with zero time and zero duration', () => {
+    render(<PlaybackProgress currentTime={0} duration={0} />)
+    expect(screen.getByTestId('playback-progress')).toBeInTheDocument()
+    expect(screen.getByTestId('current-time')).toHaveTextContent('0:00')
+    expect(screen.getByTestId('duration')).toHaveTextContent('0:00')
+  })
+
+  it('renders bar fill at 0% when duration is 0', () => {
+    render(<PlaybackProgress currentTime={0} duration={0} />)
+    const fill = screen.getByTestId('progress-bar-fill')
+    expect(fill).toHaveStyle({ width: '0%' })
+  })
+
+  it('renders correct time labels for currentTime=90 duration=300', () => {
+    render(<PlaybackProgress currentTime={90} duration={300} />)
+    expect(screen.getByTestId('current-time')).toHaveTextContent('1:30')
+    expect(screen.getByTestId('duration')).toHaveTextContent('5:00')
+  })
+
+  it('renders bar fill at 30% for currentTime=90 duration=300', () => {
+    render(<PlaybackProgress currentTime={90} duration={300} />)
+    const fill = screen.getByTestId('progress-bar-fill')
+    expect(fill).toHaveStyle({ width: '30%' })
+  })
+
+  it('does not change displayed time when the progress bar area is clicked', () => {
+    render(<PlaybackProgress currentTime={90} duration={300} />)
+    fireEvent.click(screen.getByTestId('playback-progress'))
+    // Time labels should remain unchanged — no seek interaction
+    expect(screen.getByTestId('current-time')).toHaveTextContent('1:30')
+    expect(screen.getByTestId('duration')).toHaveTextContent('5:00')
+  })
+
+  it('formats single-digit seconds with leading zero', () => {
+    render(<PlaybackProgress currentTime={65} duration={125} />)
+    expect(screen.getByTestId('current-time')).toHaveTextContent('1:05')
+    expect(screen.getByTestId('duration')).toHaveTextContent('2:05')
+  })
+})

--- a/src/components/__tests__/PlayerClient.test.tsx
+++ b/src/components/__tests__/PlayerClient.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
 import PlayerClient from '../PlayerClient'
 import { Video } from '@/lib/videos'
 
@@ -16,7 +16,24 @@ const mockVideo: Video = {
   updated_at: '2026-01-01T00:00:00Z',
 }
 
+// Mock MiniPlayer to expose onTimeUpdate for testing.
+// Variable MUST start with "mock" to satisfy babel-jest's hoisting rules for jest.mock factories.
+var mockCapturedOnTimeUpdate: ((current: number, duration: number) => void) | undefined
+
+jest.mock('@/components/MiniPlayer', () => ({
+  __esModule: true,
+  default: ({ onClose, onTimeUpdate }: { onClose: () => void; onTimeUpdate?: (c: number, d: number) => void }) => {
+    mockCapturedOnTimeUpdate = onTimeUpdate
+    return (
+      <div data-testid="mini-player">
+        <button data-testid="mini-player-close" onClick={onClose}>Close</button>
+      </div>
+    )
+  },
+}))
+
 beforeEach(() => {
+  mockCapturedOnTimeUpdate = undefined
   global.fetch = jest.fn().mockResolvedValue({
     ok: true,
     json: async () => ({ cues: [] }),
@@ -67,4 +84,42 @@ describe('PlayerClient', () => {
       expect(global.fetch).toHaveBeenCalledWith('/api/videos/video-1/transcript')
     })
   })
+
+  it('does not render PlaybackProgress before play is clicked', () => {
+    render(<PlayerClient video={mockVideo} />)
+    expect(screen.queryByTestId('playback-progress')).not.toBeInTheDocument()
+  })
+
+  it('renders PlaybackProgress with 0 times after clicking play', () => {
+    render(<PlayerClient video={mockVideo} />)
+    fireEvent.click(screen.getByTestId('play-button'))
+    expect(screen.getByTestId('playback-progress')).toBeInTheDocument()
+    expect(screen.getByTestId('current-time')).toHaveTextContent('0:00')
+  })
+
+  it('updates PlaybackProgress when onTimeUpdate is called', () => {
+    render(<PlayerClient video={mockVideo} />)
+    fireEvent.click(screen.getByTestId('play-button'))
+
+    act(() => {
+      mockCapturedOnTimeUpdate?.(90, 300)
+    })
+
+    expect(screen.getByTestId('current-time')).toHaveTextContent('1:30')
+    expect(screen.getByTestId('duration')).toHaveTextContent('5:00')
+  })
+
+  it('hides PlaybackProgress after closing the mini-player', () => {
+    render(<PlayerClient video={mockVideo} />)
+    fireEvent.click(screen.getByTestId('play-button'))
+
+    act(() => {
+      mockCapturedOnTimeUpdate?.(90, 300)
+    })
+    expect(screen.getByTestId('playback-progress')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByTestId('mini-player-close'))
+    expect(screen.queryByTestId('playback-progress')).not.toBeInTheDocument()
+  })
 })
+

--- a/src/types/youtube.d.ts
+++ b/src/types/youtube.d.ts
@@ -1,0 +1,11 @@
+// Augment the global Window interface with YouTube IFrame API properties
+declare global {
+  interface Window {
+    YT: typeof YT & {
+      PlayerState: typeof YT.PlayerState
+    }
+    onYouTubeIframeAPIReady: (() => void) | undefined
+  }
+}
+
+export {}


### PR DESCRIPTION
## Summary

Implements issue #120 — read-only playback progress indicator wired to the YouTube player. Builds on top of the player shell from #119.

## Changes

### New: `src/components/PlaybackProgress.tsx`
- Read-only progress bar component (`currentTime`, `duration` props)
- Renders a styled fill bar (% driven by currentTime/duration) and formatted time labels (e.g. `1:30 / 5:00`)
- No click/drag interaction — purely display, no seek

### Updated: `src/components/MiniPlayer.tsx`
- Upgraded from `postMessage` to full `YT.Player` JS API
- Loads YouTube IFrame API script once; binds to existing iframe via `YT.Player` constructor
- Polls `getCurrentTime()` / `getDuration()` every 250 ms while PLAYING; clears interval on PAUSED/ENDED/unmount
- New optional prop: `onTimeUpdate?(currentTime: number, duration: number): void`
- Calls `player.pauseVideo()` on close (replaces postMessage approach)

### Updated: `src/components/PlayerClient.tsx`
- New `playbackTime: { current, duration }` state
- `handleTimeUpdate` callback wired to `<MiniPlayer onTimeUpdate>`
- `<PlaybackProgress>` rendered below `<LessonHero>` when mini-player is open
- Resets `playbackTime` to zeros on close

### New: `src/types/youtube.d.ts`
- Augments `Window` with `YT` and `onYouTubeIframeAPIReady` for TypeScript

### Dev dependency: `@types/youtube 0.2.0`

## Tests
- **`PlaybackProgress.test.tsx`** (new, 6 cases): zero state, 30% fill, `1:30`/`5:00` labels, leading-zero format, click no-op
- **`MiniPlayer.test.tsx`** (+3 cases): `onTimeUpdate` fires on polling tick, stops on PAUSED, interval cleared on unmount
- **`PlayerClient.test.tsx`** (+4 cases): no progress before play, progress shown after play, updates when callback fires, hidden after close

**All 240 tests pass. Build (TypeScript strict) passes.**

Closes #120