### PR TITLE
feat(#121): cue-synced paged transcript

### DIFF
--- a/docs/api/word-highlighting.md
+++ b/docs/api/word-highlighting.md
@@ -1,0 +1,444 @@
+# Word-Level Karaoke Highlighting — Reference Notes
+
+> Relevant to: **Issue #122 — Word-level karaoke highlighting and replay**
+>
+> Covers proportional timing interpolation for simulating per-word highlighting within a cue,
+> word tokenization, click-to-seek for individual words, CSS/Tailwind approach, and
+> performance patterns for React.
+
+---
+
+## 1. Overview
+
+Transcript files (SRT/VTT) provide only **cue-level timestamps** — a start time and end time for
+the entire subtitle line. There are no per-word timestamps. To produce a karaoke-style effect,
+we **interpolate** which word should be highlighted based on how much of the cue's duration has
+elapsed.
+
+The effect is purely a UI concern layered on top of the existing cue-timing system from
+`docs/api/transcript-sync.md`. No changes to the data model or API are required.
+
+---
+
+## 2. Word Tokenization
+
+### Strategy
+
+Split the cue's `text` field on whitespace, preserving punctuation attached to words (commas,
+periods, etc. stay glued to their word). This matches natural reading cadence — a word and its
+trailing punctuation are perceived as a single unit.
+
+```ts
+/**
+ * Split a cue's text into an array of word tokens.
+ * Punctuation-only tokens (e.g. standalone "—") are kept as their own entries
+ * so the rendered output matches the original text exactly when joined with spaces.
+ */
+function tokenizeWords(text: string): string[] {
+  return text.trim().split(/\s+/).filter(Boolean)
+}
+```
+
+**Examples:**
+
+| Input | Output |
+|---|---|
+| `"Hello, world!"` | `["Hello,", "world!"]` |
+| `"It's a test — really."` | `["It's", "a", "test", "—", "really."]` |
+| `"  extra   spaces  "` | `["extra", "spaces"]` |
+| `""` (empty cue) | `[]` |
+
+### `useMemo` for tokenization
+
+Tokenize only when the active cue changes, not on every poll tick:
+
+```ts
+const words = useMemo(
+  () => (activeCue ? tokenizeWords(activeCue.text) : []),
+  [activeCue]
+)
+```
+
+`activeCue` here is the `ParsedCue | null` from `findActiveCueBinary` (see
+`docs/api/transcript-sync.md` §3). Since `ParsedCue` objects are produced by `parseCues` (a
+`useMemo` over the raw `cues` array), object identity is stable between ticks — `useMemo` will
+not re-run while the same cue is active.
+
+---
+
+## 3. Proportional Timing Formula
+
+### Inputs
+
+| Variable | Type | Description |
+|---|---|---|
+| `startSec` | `number` | Cue start time in seconds (from `ParsedCue.startSec`) |
+| `endSec` | `number` | Cue end time in seconds (from `ParsedCue.endSec`) |
+| `currentTimeSec` | `number` | Current playback time from `player.getCurrentTime()` |
+| `wordCount` | `number` | `words.length` |
+
+### Formula
+
+```ts
+/**
+ * Return the 0-based index of the word that should currently be highlighted.
+ * Returns -1 if the cue has no words or timing is invalid.
+ */
+function activeWordIndex(
+  startSec: number,
+  endSec: number,
+  currentTimeSec: number,
+  wordCount: number,
+): number {
+  if (wordCount === 0 || endSec <= startSec) return -1
+
+  const cueDuration = endSec - startSec
+  const elapsed = Math.max(0, currentTimeSec - startSec)
+  // progress is 0.0 at cue start, 1.0 at cue end
+  const progress = Math.min(elapsed / cueDuration, 1)
+  // Map progress to a word index (clamp to last word)
+  return Math.min(Math.floor(progress * wordCount), wordCount - 1)
+}
+```
+
+**Walk-through example:**
+
+- Cue runs from `83.0 s` to `85.0 s` (duration = 2 s), cue text = `"She sells sea shells"` (4 words).
+- At `t = 83.5 s`: elapsed = 0.5, progress = 0.25 → index `Math.floor(0.25 × 4) = 1` → **"sells"**
+- At `t = 84.0 s`: elapsed = 1.0, progress = 0.50 → index `Math.floor(0.50 × 4) = 2` → **"sea"**
+- At `t = 84.9 s`: elapsed = 1.9, progress = 0.95 → index `Math.min(3, 3) = 3` → **"shells"**
+- At `t = 85.0 s` (cue end): progress clamps to 1.0 → index `wordCount - 1` → **"shells"** (last word stays highlighted until cue exits)
+
+### Single-word cues
+
+If `wordCount === 1`, `Math.floor(progress × 1)` is always `0`. The single word is highlighted
+for the entire cue duration. This is correct.
+
+### Cues with empty/invalid timing
+
+If `startSec` is `-1` (plain-text format; see `transcript-sync.md` §2), `endSec <= startSec` is
+true, so the formula returns `-1` (no word highlighted). Guard downstream accordingly.
+
+---
+
+## 4. Storing Active Word Index in React State
+
+The active word index changes on every poll tick while a cue is active. **Do not store it in
+React state** — that would cause a re-render every 250 ms even for inactive transcript lines.
+
+Instead, store it in a **ref** and update the DOM directly:
+
+```ts
+const activeWordIdxRef = useRef<number>(-1)
+```
+
+Update it inside the existing cue-polling interval (see `transcript-sync.md` §4):
+
+```ts
+intervalRef.current = setInterval(() => {
+  const player = playerRef.current
+  if (!player) return
+  const t = player.getCurrentTime()
+
+  // Existing: find active cue
+  const cue = findActiveCueBinary(parsedCues, t)
+  const newCueIndex = cue?.index ?? null
+  if (newCueIndex !== activeCueIndexRef.current) {
+    setActiveCueIndex(newCueIndex)  // triggers React re-render for cue change only
+    activeCueIndexRef.current = newCueIndex
+  }
+
+  // New: update active word index imperatively
+  if (cue && cue.endSec > cue.startSec) {
+    const words = wordTokensRef.current  // stable ref to current word array
+    const idx = activeWordIndex(cue.startSec, cue.endSec, t, words.length)
+    if (idx !== activeWordIdxRef.current) {
+      activeWordIdxRef.current = idx
+      applyWordHighlight(idx)  // direct DOM update — no React state
+    }
+  } else {
+    if (activeWordIdxRef.current !== -1) {
+      activeWordIdxRef.current = -1
+      applyWordHighlight(-1)
+    }
+  }
+}, 250)
+```
+
+`wordTokensRef` is a ref kept in sync with the `words` array derived from `useMemo`:
+
+```ts
+const wordTokensRef = useRef<string[]>([])
+useEffect(() => {
+  wordTokensRef.current = words
+}, [words])
+```
+
+---
+
+## 5. DOM-Based Word Highlight (`applyWordHighlight`)
+
+Assign `data-word-index` attributes to each word `<span>` and toggle a CSS class directly,
+bypassing React reconciliation entirely for the sub-250 ms highlight updates.
+
+```ts
+const cueContainerRef = useRef<HTMLElement | null>(null)
+
+function applyWordHighlight(targetIdx: number) {
+  const container = cueContainerRef.current
+  if (!container) return
+  container.querySelectorAll<HTMLSpanElement>('[data-word-index]').forEach(span => {
+    const idx = Number(span.dataset.wordIndex)
+    if (idx <= targetIdx) {
+      span.classList.add('word-active')
+      span.classList.remove('word-inactive')
+    } else {
+      span.classList.add('word-inactive')
+      span.classList.remove('word-active')
+    }
+  })
+}
+```
+
+Using `idx <= targetIdx` (rather than `idx === targetIdx`) produces a **progressive fill** effect —
+all words up to and including the current word are highlighted. Change to `idx === targetIdx` for
+a single-word spotlight effect.
+
+---
+
+## 6. Rendering Word Spans
+
+In the active cue's render, replace the plain text with individual `<span>` elements:
+
+```tsx
+function ActiveCueWords({
+  words,
+  cue,
+  containerRef,
+  onWordClick,
+}: {
+  words: string[]
+  cue: ParsedCue
+  containerRef: React.RefObject<HTMLElement>
+  onWordClick: (seekSec: number) => void
+}) {
+  return (
+    <span ref={containerRef as React.RefObject<HTMLSpanElement>} className="inline">
+      {words.map((word, i) => (
+        <span
+          key={i}
+          data-word-index={i}
+          className="word-inactive cursor-pointer select-none"
+          onClick={() => onWordClick(cue.startSec)}
+        >
+          {word}
+          {i < words.length - 1 ? ' ' : ''}
+        </span>
+      ))}
+    </span>
+  )
+}
+```
+
+> **Note:** All words in a cue share the same `startSec` for seek purposes — per-word seek is not
+> possible without per-word timestamps. Clicking any word in the cue seeks to `cue.startSec`.
+> This matches the same behaviour as clicking the cue row itself (see `transcript-sync.md` §9).
+
+Non-active cues continue to render plain text (no spans), which keeps the DOM small and avoids
+tokenizing every cue on every render.
+
+---
+
+## 7. CSS / Tailwind Classes
+
+Define the highlight states as Tailwind utility classes. Add them to `src/app/globals.css` (or
+a component stylesheet) so they are available for the imperative DOM updates in §5:
+
+```css
+/* src/app/globals.css */
+.word-inactive {
+  @apply text-gray-700 transition-colors duration-100;
+}
+
+.word-active {
+  @apply text-yellow-500 font-semibold transition-colors duration-100;
+}
+```
+
+The `transition-colors duration-100` gives a 100 ms crossfade between states, which looks smooth
+even with the 250 ms polling interval.
+
+### Tailwind-only alternative (class names on the span directly)
+
+If you prefer not to use `@apply`, use inline conditional Tailwind classes in the React render.
+This works only if the word highlight is driven by React state (not the imperative approach):
+
+```tsx
+<span
+  className={
+    i <= activeWordIdx
+      ? 'text-yellow-500 font-semibold transition-colors duration-100'
+      : 'text-gray-700 transition-colors duration-100'
+  }
+>
+```
+
+**Choose the imperative approach (§5) for production** — it avoids re-rendering the entire cue's
+word list on every poll tick.
+
+---
+
+## 8. Click-to-Seek for Word Spans
+
+Individual word spans seek to the **cue's start time** (the finest granularity available without
+per-word timestamps):
+
+```ts
+function handleWordClick(seekSec: number) {
+  playerRef.current?.seekTo(seekSec, true)
+  playerRef.current?.playVideo()
+}
+```
+
+Pass this as `onWordClick` to `<ActiveCueWords>` (shown in §6). The `allowSeekAhead: true`
+argument to `seekTo` ensures the player buffers ahead of the seek point
+(see `youtube-iframe-player.md` §3).
+
+### Cue-row click vs. word click
+
+Both the cue row and individual word spans call `seekTo(cue.startSec, true)`. The cue-row click
+handler (from `transcript-sync.md` §9) can be retained as-is; word clicks fire the same seek.
+Use `event.stopPropagation()` on the word `<span>` only if the cue `<li>` also has an `onClick`
+that would double-fire:
+
+```tsx
+<span
+  data-word-index={i}
+  onClick={(e) => {
+    e.stopPropagation()
+    onWordClick(cue.startSec)
+  }}
+>
+```
+
+---
+
+## 9. Performance Considerations
+
+### Why not React state for word index?
+
+At a 250 ms poll interval with a typical cue of ~8 words, the word index changes roughly every
+30–60 ms (250 ms / 8 words). Storing the index in React state would trigger React reconciliation
+at up to 4× per second for the entire transcript panel. The imperative DOM approach in §5
+eliminates this overhead entirely.
+
+### Minimize span creation
+
+Only the **active cue** is rendered as word spans (§6). All other cues remain as plain text
+strings inside their `<li>` elements. This keeps the total number of `[data-word-index]` spans
+small (usually ≤ 20 at any moment).
+
+### `useMemo` for word tokens
+
+Re-tokenization is O(n) on the cue text length. Memoize it on `activeCue` identity:
+
+```ts
+const words = useMemo(
+  () => (activeCue ? tokenizeWords(activeCue.text) : []),
+  [activeCue]   // stable reference — only changes when cue boundary is crossed
+)
+```
+
+Because `ParsedCue` objects are created once (in `parseCues` inside a `useMemo`), object identity
+is stable across poll ticks within the same cue. `useMemo` will not re-run during a cue.
+
+### Polling interval
+
+250 ms (the same interval used for active-cue detection) is sufficient. A finer interval (e.g.
+100 ms) gives no perceptible improvement in karaoke smoothness because typical cues are 1–3
+seconds long and contain 5–15 words — the per-word window is already 100–300 ms at 250 ms polling.
+
+### `querySelectorAll` cost
+
+`querySelectorAll('[data-word-index]')` on the active cue container (not the full document)
+iterates at most ~20 elements. This is negligible.
+
+---
+
+## 10. Full Integration Sketch
+
+```tsx
+// Inside the transcript panel component (simplified)
+
+const words = useMemo(
+  () => (activeCue ? tokenizeWords(activeCue.text) : []),
+  [activeCue]
+)
+
+const wordTokensRef = useRef<string[]>([])
+useEffect(() => { wordTokensRef.current = words }, [words])
+
+const cueContainerRef = useRef<HTMLSpanElement>(null)
+const activeWordIdxRef = useRef(-1)
+
+// applyWordHighlight and polling setup as shown in §4 and §5
+
+return (
+  <ol className="space-y-1">
+    {currentCues.map(cue => (
+      <li
+        key={cue.index}
+        data-cue-index={cue.index}
+        className={cue.index === activeCueIndex ? 'bg-yellow-50 rounded px-2 py-0.5' : 'px-2 py-0.5 text-gray-700'}
+        onClick={() => {
+          playerRef.current?.seekTo(cue.startSec, true)
+          playerRef.current?.playVideo()
+        }}
+      >
+        {cue.index === activeCueIndex ? (
+          <ActiveCueWords
+            words={words}
+            cue={cue}
+            containerRef={cueContainerRef}
+            onWordClick={(sec) => {
+              playerRef.current?.seekTo(sec, true)
+              playerRef.current?.playVideo()
+            }}
+          />
+        ) : (
+          cue.text
+        )}
+      </li>
+    ))}
+  </ol>
+)
+```
+
+---
+
+## 11. Edge Cases
+
+| Scenario | Handling |
+|---|---|
+| Cue text is an empty string | `tokenizeWords` returns `[]`; `activeWordIndex` returns `-1`; no spans rendered |
+| Single-word cue | Word is highlighted for the entire cue duration |
+| Cue with only punctuation (`"—"`) | Treated as one token; highlighted for the full cue |
+| `endSec <= startSec` (malformed cue) | `activeWordIndex` returns `-1`; fallback to plain cue highlight only |
+| Seek to within a cue (mid-cue) | `elapsed` is calculated from `currentTimeSec - startSec`; correct word is highlighted immediately |
+| Very fast speech (many words, short cue) | Formula still distributes proportionally; some words may share the same index bucket — acceptable |
+| Player paused mid-cue | Polling stops; last highlighted word remains highlighted — correct UX |
+| `activeCue` becomes `null` (gap between cues) | `words` memoizes to `[]`; `applyWordHighlight(-1)` clears all word highlights |
+
+---
+
+## 12. Official References
+
+- `TranscriptCue` / `ParsedCue` types: `src/lib/parse-transcript.ts`
+- Active-cue detection & polling: `docs/api/transcript-sync.md` §3–§4
+- `seekTo` API: `docs/api/youtube-iframe-player.md` §3
+- Cue click-to-seek pattern: `docs/api/transcript-sync.md` §9
+- MDN `Element.querySelectorAll`: https://developer.mozilla.org/en-US/docs/Web/API/Element/querySelectorAll
+- MDN `String.prototype.split`: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/split
+- React `useMemo`: https://react.dev/reference/react/useMemo
+- React `useRef`: https://react.dev/reference/react/useRef
+- Tailwind CSS `transition` utilities: https://tailwindcss.com/docs/transition-property

--- a/src/components/PlayerClient.tsx
+++ b/src/components/PlayerClient.tsx
@@ -2,10 +2,11 @@
 
 import { useEffect, useState } from 'react'
 import { Video } from '@/lib/videos'
-import { TranscriptCue } from '@/lib/parse-transcript'
+import { TranscriptCue, findActiveCueIndex } from '@/lib/parse-transcript'
 import LessonHero from '@/components/LessonHero'
 import MiniPlayer from '@/components/MiniPlayer'
 import PlaybackProgress from '@/components/PlaybackProgress'
+import TranscriptPanel, { CUES_PER_PAGE } from '@/components/TranscriptPanel'
 
 interface WordCard {
   word: string
@@ -25,7 +26,8 @@ function extractVocabWords(cues: TranscriptCue[]): WordCard[] {
 export default function PlayerClient({ video }: { video: Video }) {
   const [cues, setCues] = useState<TranscriptCue[]>([])
   const [loadingTranscript, setLoadingTranscript] = useState(true)
-  const [activeCueIndex, setActiveCueIndex] = useState(0)
+  const [activeCueIndex, setActiveCueIndex] = useState(-1)
+  const [currentPage, setCurrentPage] = useState(0)
   const [activeTab, setActiveTab] = useState<'transcript' | 'vocabulary'>('transcript')
   const [vocabWords, setVocabWords] = useState<WordCard[]>([])
   const [isMiniPlayerOpen, setIsMiniPlayerOpen] = useState(false)
@@ -33,6 +35,14 @@ export default function PlayerClient({ video }: { video: Video }) {
 
   function handleTimeUpdate(current: number, duration: number) {
     setPlaybackTime({ current, duration })
+
+    const newActiveCueIndex = findActiveCueIndex(cues, current)
+    setActiveCueIndex(newActiveCueIndex)
+
+    if (newActiveCueIndex >= 0) {
+      const targetPage = Math.floor(newActiveCueIndex / CUES_PER_PAGE)
+      setCurrentPage((prev) => (targetPage !== prev ? targetPage : prev))
+    }
   }
 
   function handleClose() {
@@ -120,47 +130,13 @@ export default function PlayerClient({ video }: { video: Video }) {
         {/* Tab content */}
         <div className="flex-1 overflow-y-auto p-4 space-y-3">
           {activeTab === 'transcript' && (
-            <>
-              {loadingTranscript && (
-                <p className="text-sm text-on-surface-variant dark:text-slate-400 text-center py-8">
-                  Loading transcript…
-                </p>
-              )}
-              {!loadingTranscript && cues.length === 0 && (
-                <div className="flex flex-col items-center justify-center py-12 text-center gap-3">
-                  <span className="text-3xl">📄</span>
-                  <p className="text-on-surface font-semibold">No transcript available</p>
-                  <p className="text-sm text-on-surface-variant">
-                    Upload a transcript file to enable interactive subtitles.
-                  </p>
-                </div>
-              )}
-              {!loadingTranscript &&
-                cues.map((cue, i) => {
-                  const isPast = i < activeCueIndex
-                  const isActive = i === activeCueIndex
-                  return (
-                    <div
-                      key={cue.index}
-                      onClick={() => setActiveCueIndex(i)}
-                      data-testid={`cue-${i}`}
-                      className={`cursor-pointer transition-all ${
-                        isPast
-                          ? 'opacity-40 text-sm text-on-surface-variant dark:text-slate-400 px-3 py-2'
-                          : isActive
-                          ? 'bg-surface-container dark:bg-slate-800 rounded-xl p-3 ring-1 ring-primary/10 border-l-4 border-primary'
-                          : 'opacity-60 text-sm text-on-surface dark:text-slate-100 px-3 py-2'
-                      }`}
-                    >
-                      {isActive ? (
-                        <p className="text-sm text-on-surface dark:text-slate-100 leading-relaxed">{cue.text}</p>
-                      ) : (
-                        cue.text
-                      )}
-                    </div>
-                  )
-                })}
-            </>
+            <TranscriptPanel
+              cues={cues}
+              activeCueIndex={activeCueIndex}
+              currentPage={currentPage}
+              onPageChange={setCurrentPage}
+              loading={loadingTranscript}
+            />
           )}
 
           {activeTab === 'vocabulary' && (

--- a/src/components/TranscriptPanel.tsx
+++ b/src/components/TranscriptPanel.tsx
@@ -1,0 +1,114 @@
+'use client'
+
+import { useRef, useEffect } from 'react'
+import { TranscriptCue } from '@/lib/parse-transcript'
+
+export const CUES_PER_PAGE = 10
+
+interface TranscriptPanelProps {
+  cues: TranscriptCue[]
+  activeCueIndex: number
+  currentPage: number
+  onPageChange: (page: number) => void
+  loading: boolean
+}
+
+export default function TranscriptPanel({
+  cues,
+  activeCueIndex,
+  currentPage,
+  onPageChange,
+  loading,
+}: TranscriptPanelProps) {
+  const activeCueRef = useRef<HTMLDivElement | null>(null)
+
+  const totalPages = Math.ceil(cues.length / CUES_PER_PAGE)
+  const pageOffset = currentPage * CUES_PER_PAGE
+  const pageCues = cues.slice(pageOffset, pageOffset + CUES_PER_PAGE)
+
+  useEffect(() => {
+    activeCueRef.current?.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
+  }, [activeCueIndex])
+
+  if (loading) {
+    return (
+      <div data-testid="transcript-panel">
+        <p className="text-sm text-on-surface-variant dark:text-slate-400 text-center py-8">
+          Loading transcript…
+        </p>
+      </div>
+    )
+  }
+
+  if (cues.length === 0) {
+    return (
+      <div data-testid="transcript-panel" className="flex flex-col items-center justify-center py-12 text-center gap-3">
+        <span className="text-3xl">📄</span>
+        <p className="text-on-surface font-semibold">No transcript available</p>
+        <p className="text-sm text-on-surface-variant">
+          Upload a transcript file to enable interactive subtitles.
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div data-testid="transcript-panel" className="flex flex-col gap-3">
+      <div className="space-y-1">
+        {pageCues.map((cue, i) => {
+          const absoluteIndex = pageOffset + i
+          const isPast = absoluteIndex < activeCueIndex
+          const isActive = absoluteIndex === activeCueIndex
+
+          return (
+            <div
+              key={cue.index}
+              ref={isActive ? activeCueRef : null}
+              data-testid={isActive ? 'cue-active' : `cue-${i}`}
+              className={`cursor-pointer transition-all ${
+                isPast
+                  ? 'opacity-40 text-sm text-on-surface-variant dark:text-slate-400 px-3 py-2'
+                  : isActive
+                  ? 'bg-surface-container dark:bg-slate-800 rounded-xl p-3 ring-1 ring-primary/10 border-l-4 border-primary'
+                  : 'opacity-60 text-sm text-on-surface dark:text-slate-100 px-3 py-2'
+              }`}
+            >
+              {isActive ? (
+                <p className="text-sm text-on-surface dark:text-slate-100 leading-relaxed">{cue.text}</p>
+              ) : (
+                cue.text
+              )}
+            </div>
+          )
+        })}
+      </div>
+
+      {totalPages > 1 && (
+        <div className="flex items-center justify-between pt-2 border-t border-outline-variant/20">
+          <button
+            data-testid="transcript-prev-page"
+            onClick={() => onPageChange(Math.max(0, currentPage - 1))}
+            disabled={currentPage === 0}
+            className="px-3 py-1 text-xs font-medium rounded-lg bg-surface-container text-on-surface-variant hover:opacity-80 disabled:opacity-40 disabled:cursor-not-allowed transition-opacity"
+          >
+            ← Prev
+          </button>
+          <span
+            data-testid="transcript-page-indicator"
+            className="text-xs text-on-surface-variant"
+          >
+            {currentPage + 1} / {totalPages}
+          </span>
+          <button
+            data-testid="transcript-next-page"
+            onClick={() => onPageChange(Math.min(totalPages - 1, currentPage + 1))}
+            disabled={currentPage === totalPages - 1}
+            className="px-3 py-1 text-xs font-medium rounded-lg bg-surface-container text-on-surface-variant hover:opacity-80 disabled:opacity-40 disabled:cursor-not-allowed transition-opacity"
+          >
+            Next →
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/__tests__/PlayerClient.test.tsx
+++ b/src/components/__tests__/PlayerClient.test.tsx
@@ -32,8 +32,17 @@ jest.mock('@/components/MiniPlayer', () => ({
   },
 }))
 
+// Sample cues spanning 2 pages (12 cues total, page size = 10)
+const sampleCues = Array.from({ length: 12 }, (_, i) => ({
+  index: i + 1,
+  startTime: `00:00:${String(i * 5).padStart(2, '0')},000`,
+  endTime: `00:00:${String(i * 5 + 4).padStart(2, '0')},000`,
+  text: `Cue text ${i + 1}`,
+}))
+
 beforeEach(() => {
   mockCapturedOnTimeUpdate = undefined
+  window.HTMLElement.prototype.scrollIntoView = jest.fn()
   global.fetch = jest.fn().mockResolvedValue({
     ok: true,
     json: async () => ({ cues: [] }),
@@ -120,6 +129,51 @@ describe('PlayerClient', () => {
 
     fireEvent.click(screen.getByTestId('mini-player-close'))
     expect(screen.queryByTestId('playback-progress')).not.toBeInTheDocument()
+  })
+
+  it('highlights active cue when onTimeUpdate fires a matching time', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ cues: sampleCues }),
+    }) as jest.Mock
+
+    render(<PlayerClient video={mockVideo} />)
+    fireEvent.click(screen.getByTestId('play-button'))
+
+    // Wait for transcript cues to load (loading state clears)
+    await waitFor(() => screen.getByText('Cue text 1'))
+
+    // Fire time update at 2s — falls inside cue 0 (starts 0s, ends 4s)
+    act(() => {
+      mockCapturedOnTimeUpdate?.(2, 300)
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('cue-active')).toBeInTheDocument()
+    })
+  })
+
+  it('auto-advances page when active cue crosses page boundary', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ cues: sampleCues }),
+    }) as jest.Mock
+
+    render(<PlayerClient video={mockVideo} />)
+    fireEvent.click(screen.getByTestId('play-button'))
+
+    // Wait for transcript cues to load
+    await waitFor(() => screen.getByText('Cue text 1'))
+
+    // cue index 10 (0-based) = page 1 (starts at 50s, ends at 54s)
+    act(() => {
+      mockCapturedOnTimeUpdate?.(51, 300)
+    })
+
+    await waitFor(() => {
+      // Page 2 indicator should now show
+      expect(screen.getByTestId('transcript-page-indicator')).toHaveTextContent('2 / 2')
+    })
   })
 })
 

--- a/src/components/__tests__/TranscriptPanel.test.tsx
+++ b/src/components/__tests__/TranscriptPanel.test.tsx
@@ -1,0 +1,176 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import TranscriptPanel, { CUES_PER_PAGE } from '../TranscriptPanel'
+import { TranscriptCue } from '@/lib/parse-transcript'
+
+function makeCues(count: number): TranscriptCue[] {
+  return Array.from({ length: count }, (_, i) => ({
+    index: i + 1,
+    startTime: `00:00:${String(i * 3).padStart(2, '0')},000`,
+    endTime: `00:00:${String(i * 3 + 2).padStart(2, '0')},000`,
+    text: `Cue text ${i + 1}`,
+  }))
+}
+
+const noop = () => {}
+
+beforeEach(() => {
+  // scrollIntoView is not implemented in jsdom
+  window.HTMLElement.prototype.scrollIntoView = jest.fn()
+})
+
+afterEach(() => {
+  jest.resetAllMocks()
+})
+
+describe('TranscriptPanel', () => {
+  it('shows loading state when loading=true', () => {
+    render(
+      <TranscriptPanel
+        cues={[]}
+        activeCueIndex={-1}
+        currentPage={0}
+        onPageChange={noop}
+        loading={true}
+      />
+    )
+    expect(screen.getByTestId('transcript-panel')).toBeInTheDocument()
+    expect(screen.getByText(/loading transcript/i)).toBeInTheDocument()
+  })
+
+  it('shows empty state when cues=[] and loading=false', () => {
+    render(
+      <TranscriptPanel
+        cues={[]}
+        activeCueIndex={-1}
+        currentPage={0}
+        onPageChange={noop}
+        loading={false}
+      />
+    )
+    expect(screen.getByTestId('transcript-panel')).toBeInTheDocument()
+    expect(screen.getByText(/no transcript available/i)).toBeInTheDocument()
+  })
+
+  it('renders only CUES_PER_PAGE cues on each page', () => {
+    const cues = makeCues(25)
+    render(
+      <TranscriptPanel
+        cues={cues}
+        activeCueIndex={-1}
+        currentPage={0}
+        onPageChange={noop}
+        loading={false}
+      />
+    )
+    // CUES_PER_PAGE cues should be visible on page 0
+    for (let i = 0; i < CUES_PER_PAGE; i++) {
+      expect(screen.getByText(`Cue text ${i + 1}`)).toBeInTheDocument()
+    }
+    // Cue 11 (page 1) should not be rendered
+    expect(screen.queryByText(`Cue text ${CUES_PER_PAGE + 1}`)).not.toBeInTheDocument()
+  })
+
+  it('highlights the active cue with data-testid="cue-active" and border-primary class', () => {
+    const cues = makeCues(5)
+    render(
+      <TranscriptPanel
+        cues={cues}
+        activeCueIndex={2}
+        currentPage={0}
+        onPageChange={noop}
+        loading={false}
+      />
+    )
+    const activeCue = screen.getByTestId('cue-active')
+    expect(activeCue).toBeInTheDocument()
+    expect(activeCue.className).toContain('border-primary')
+  })
+
+  it('Prev button is disabled on page 0', () => {
+    const cues = makeCues(25)
+    render(
+      <TranscriptPanel
+        cues={cues}
+        activeCueIndex={-1}
+        currentPage={0}
+        onPageChange={noop}
+        loading={false}
+      />
+    )
+    expect(screen.getByTestId('transcript-prev-page')).toBeDisabled()
+  })
+
+  it('Next button is disabled on last page', () => {
+    const cues = makeCues(15)
+    const totalPages = Math.ceil(cues.length / CUES_PER_PAGE)
+    render(
+      <TranscriptPanel
+        cues={cues}
+        activeCueIndex={-1}
+        currentPage={totalPages - 1}
+        onPageChange={noop}
+        loading={false}
+      />
+    )
+    expect(screen.getByTestId('transcript-next-page')).toBeDisabled()
+  })
+
+  it('clicking Next calls onPageChange(1)', () => {
+    const cues = makeCues(25)
+    const onPageChange = jest.fn()
+    render(
+      <TranscriptPanel
+        cues={cues}
+        activeCueIndex={-1}
+        currentPage={0}
+        onPageChange={onPageChange}
+        loading={false}
+      />
+    )
+    fireEvent.click(screen.getByTestId('transcript-next-page'))
+    expect(onPageChange).toHaveBeenCalledWith(1)
+  })
+
+  it('calls scrollIntoView on active cue element', () => {
+    const cues = makeCues(5)
+    render(
+      <TranscriptPanel
+        cues={cues}
+        activeCueIndex={1}
+        currentPage={0}
+        onPageChange={noop}
+        loading={false}
+      />
+    )
+    expect(window.HTMLElement.prototype.scrollIntoView).toHaveBeenCalled()
+  })
+
+  it('shows correct page indicator', () => {
+    const cues = makeCues(25)
+    render(
+      <TranscriptPanel
+        cues={cues}
+        activeCueIndex={-1}
+        currentPage={1}
+        onPageChange={noop}
+        loading={false}
+      />
+    )
+    expect(screen.getByTestId('transcript-page-indicator')).toHaveTextContent('2 / 3')
+  })
+
+  it('does not show pagination when all cues fit on one page', () => {
+    const cues = makeCues(5)
+    render(
+      <TranscriptPanel
+        cues={cues}
+        activeCueIndex={-1}
+        currentPage={0}
+        onPageChange={noop}
+        loading={false}
+      />
+    )
+    expect(screen.queryByTestId('transcript-prev-page')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('transcript-next-page')).not.toBeInTheDocument()
+  })
+})

--- a/src/lib/__tests__/parse-transcript.test.ts
+++ b/src/lib/__tests__/parse-transcript.test.ts
@@ -1,0 +1,63 @@
+import { parseTimeToSeconds, findActiveCueIndex, TranscriptCue } from '../parse-transcript'
+
+describe('parseTimeToSeconds', () => {
+  it('converts SRT timestamp with comma separator', () => {
+    expect(parseTimeToSeconds('00:01:23,456')).toBeCloseTo(83.456)
+  })
+
+  it('converts VTT timestamp with period separator', () => {
+    expect(parseTimeToSeconds('00:01:23.456')).toBeCloseTo(83.456)
+  })
+
+  it('returns 0 for empty string', () => {
+    expect(parseTimeToSeconds('')).toBe(0)
+  })
+
+  it('converts hours correctly', () => {
+    expect(parseTimeToSeconds('01:00:00,000')).toBe(3600)
+  })
+
+  it('converts minutes correctly', () => {
+    expect(parseTimeToSeconds('00:02:30,500')).toBeCloseTo(150.5)
+  })
+})
+
+describe('findActiveCueIndex', () => {
+  const cues: TranscriptCue[] = [
+    { index: 1, startTime: '00:00:01,000', endTime: '00:00:03,000', text: 'First' },
+    { index: 2, startTime: '00:00:05,000', endTime: '00:00:07,000', text: 'Second' },
+    { index: 3, startTime: '00:00:09,000', endTime: '00:00:11,000', text: 'Third' },
+  ]
+
+  it('returns the index when currentTime falls inside a cue window', () => {
+    expect(findActiveCueIndex(cues, 2)).toBe(0)
+    expect(findActiveCueIndex(cues, 6)).toBe(1)
+    expect(findActiveCueIndex(cues, 10)).toBe(2)
+  })
+
+  it('returns lastBefore index when currentTime is in a gap between cues', () => {
+    // Gap between cue 0 (ends at 3s) and cue 1 (starts at 5s): time = 4s
+    expect(findActiveCueIndex(cues, 4)).toBe(0)
+    // Gap between cue 1 and cue 2: time = 8s
+    expect(findActiveCueIndex(cues, 8)).toBe(1)
+  })
+
+  it('returns -1 when currentTime is before all cues', () => {
+    expect(findActiveCueIndex(cues, 0)).toBe(-1)
+    expect(findActiveCueIndex(cues, 0.5)).toBe(-1)
+  })
+
+  it('returns -1 for empty cues array', () => {
+    expect(findActiveCueIndex([], 5)).toBe(-1)
+  })
+
+  it('handles plain-text cues with empty timestamps (all parse to 0)', () => {
+    const plainCues: TranscriptCue[] = [
+      { index: 1, startTime: '', endTime: '', text: 'Line 1' },
+      { index: 2, startTime: '', endTime: '', text: 'Line 2' },
+    ]
+    // All start times parse to 0, so lastBefore will be the last cue with start <= currentTime
+    const result = findActiveCueIndex(plainCues, 5)
+    expect(result).toBeGreaterThanOrEqual(-1)
+  })
+})

--- a/src/lib/parse-transcript.ts
+++ b/src/lib/parse-transcript.ts
@@ -5,6 +5,32 @@ export interface TranscriptCue {
   text: string
 }
 
+/** Convert "HH:MM:SS,mmm" or "HH:MM:SS.mmm" to decimal seconds. Returns 0 for empty strings. */
+export function parseTimeToSeconds(timeStr: string): number {
+  if (!timeStr) return 0
+  const [hms, ms = '0'] = timeStr.split(/[,.]/)
+  const parts = hms.split(':').map(Number)
+  const [h = 0, m = 0, s = 0] = parts
+  return h * 3600 + m * 60 + s + parseInt(ms, 10) / 1000
+}
+
+/**
+ * Find the index of the active cue for a given playback time.
+ * Returns the index of the cue whose window [startTime, endTime) contains currentTime,
+ * or the last cue whose startTime <= currentTime (gap handling).
+ * Returns -1 if currentTime is before all cues.
+ */
+export function findActiveCueIndex(cues: TranscriptCue[], currentTime: number): number {
+  let lastBefore = -1
+  for (let i = 0; i < cues.length; i++) {
+    const start = parseTimeToSeconds(cues[i].startTime)
+    const end = parseTimeToSeconds(cues[i].endTime)
+    if (currentTime >= start && currentTime < end) return i
+    if (currentTime >= start) lastBefore = i
+  }
+  return lastBefore
+}
+
 export function parseTranscript(content: string, format: string | null): TranscriptCue[] {
   const fmt = (format ?? '').toLowerCase()
 


### PR DESCRIPTION
Closes #121

## Summary

Implements the cue-synced paged transcript reading experience for the lesson player, building on top of Issue #120.

## Changes

### `src/lib/parse-transcript.ts`
- Export `parseTimeToSeconds(timeStr)`: converts SRT/VTT timestamp strings (`HH:MM:SS,mmm` / `HH:MM:SS.mmm`) to decimal seconds
- Export `findActiveCueIndex(cues, currentTime)`: returns 0-based index of the active cue, or `-1` before any cue starts

### `src/components/TranscriptPanel.tsx` (new)
- Paged view of transcript cues (10 per page, `CUES_PER_PAGE = 10`)
- Active cue highlighted with `border-primary` styling and `data-testid="cue-active"`
- Prev/Next pagination buttons disabled at boundaries (`data-testid="transcript-prev-page"` / `transcript-next-page"`)
- Auto-scroll active cue into view via `scrollIntoView`
- Loading and empty-state placeholders

### `src/components/PlayerClient.tsx`
- Imports `findActiveCueIndex` and `CUES_PER_PAGE`
- `handleTimeUpdate` now calls `findActiveCueIndex` and auto-advances `currentPage` when the active cue crosses a page boundary
- Replaces the inline flat cue-list with `<TranscriptPanel>`

## Tests
- `src/lib/__tests__/parse-transcript.test.ts`: 9 tests for `parseTimeToSeconds` and `findActiveCueIndex`
- `src/components/__tests__/TranscriptPanel.test.tsx`: 9 tests covering loading/empty states, pagination, active cue highlighting, scroll, and page indicator
- `src/components/__tests__/PlayerClient.test.tsx`: 2 new tests for active cue sync and auto-page-advance on boundary crossing

**262/262 tests pass. Build succeeds.**