### PR TITLE
feat(#122): Word-level karaoke highlighting and replay

### DIFF
--- a/docs/project/player-feature.md
+++ b/docs/project/player-feature.md
@@ -725,3 +725,411 @@ Use `// @jest-environment jsdom` (default) for all component tests. Mock `fetch`
 | Page indicator | `transcript-page-indicator` |
 
 These follow the existing `data-testid` naming convention (`cue-{i}`, `tab-transcript`, etc.) already used in `PlayerClient`.
+
+---
+
+## 10. Word-level Karaoke Highlighting — Issue #122
+
+### Goal
+
+Within the **active** transcript cue, progressively highlight each word as playback moves through the cue using proportional timing interpolation. Allow clicking any cue (active or not) to seek playback to that cue's start timestamp.
+
+This feature builds on Issue #121: `currentTime` is already threaded into `PlayerClient` via `onTimeUpdate`, and `TranscriptPanel` already receives the active cue index. Issue #122 extends `TranscriptPanel` to also receive `currentTime` for in-cue word highlighting, and wires a `seekTo` imperative handle from `MiniPlayer` up through `PlayerClient` to `TranscriptPanel`.
+
+---
+
+### 10.1 Word Tokenization
+
+Add a `tokenizeWords` utility to `src/lib/parse-transcript.ts` (alongside the existing `parseTimeToSeconds` and `findActiveCueIndex`):
+
+```ts
+// src/lib/parse-transcript.ts
+export function tokenizeWords(text: string): string[] {
+  return text.split(/\s+/).filter(Boolean)
+}
+```
+
+**Design decisions:**
+- Split on whitespace only — punctuation stays attached to the adjacent word (e.g., `"hello,"` is one token). This avoids stripping meaning from abbreviations, hyphenated words, and contractions.
+- The `filter(Boolean)` removes empty strings from leading/trailing whitespace or multiple consecutive spaces.
+- The result is `string[]` — raw display tokens, not normalized. The component renders each token as-is.
+
+---
+
+### 10.2 Proportional Word Index Formula
+
+For the active cue, the highlighted word index is computed from the current playback position within the cue:
+
+```ts
+const cueStart = parseTimeToSeconds(activeCue.startTime)
+const cueEnd   = parseTimeToSeconds(activeCue.endTime)
+const cueDuration = cueEnd - cueStart
+
+const elapsed  = currentTime - cueStart
+const fraction = cueDuration > 0 ? Math.min(Math.max(elapsed / cueDuration, 0), 1) : 0
+
+const highlightedIndex = Math.min(
+  Math.floor(fraction * words.length),
+  words.length - 1
+)
+```
+
+**Edge cases:**
+- `cueDuration === 0` (plain-text cues with empty timestamps) → `fraction` is `0` → first word is highlighted. Acceptable: plain-text transcripts have no timing data.
+- `elapsed < 0` (clock skew or the cue just became active) → clamped to `0` → first word highlighted.
+- `elapsed >= cueDuration` → clamped to `1.0` → last word highlighted.
+- Single-word cue → `highlightedIndex` always `0`.
+
+---
+
+### 10.3 `CueText` Sub-component (New)
+
+Extract the word-level rendering for the active cue into a dedicated component:
+
+```ts
+// src/components/CueText.tsx
+interface CueTextProps {
+  text: string
+  cueStart: number       // parseTimeToSeconds(cue.startTime) — seconds
+  cueEnd: number         // parseTimeToSeconds(cue.endTime) — seconds
+  currentTime: number    // absolute playback time in seconds (from PlayerClient state)
+  onWordClick?: (seekTime: number) => void  // called with cueStart for all words
+}
+```
+
+**Rendering rules:**
+- Words **before** `highlightedIndex`: muted / past styling (`opacity-50 text-on-surface-variant`)
+- Word **at** `highlightedIndex`: active / karaoke styling (`bg-primary text-on-primary rounded px-0.5`)
+- Words **after** `highlightedIndex`: default styling (`text-on-surface`)
+
+```tsx
+// Minimal implementation
+'use client'
+
+import { tokenizeWords, parseTimeToSeconds } from '@/lib/parse-transcript'
+
+export default function CueText({ text, cueStart, cueEnd, currentTime, onWordClick }: CueTextProps) {
+  const words = tokenizeWords(text)
+  const cueDuration = cueEnd - cueStart
+  const elapsed     = currentTime - cueStart
+  const fraction    = cueDuration > 0 ? Math.min(Math.max(elapsed / cueDuration, 0), 1) : 0
+  const highlightedIndex = Math.min(Math.floor(fraction * words.length), words.length - 1)
+
+  return (
+    <p
+      data-testid="cue-text"
+      className="text-sm text-on-surface dark:text-slate-100 leading-relaxed flex flex-wrap gap-x-1"
+    >
+      {words.map((word, i) => (
+        <span
+          key={i}
+          data-testid={`word-${i}`}
+          onClick={() => onWordClick?.(cueStart)}
+          className={`cursor-pointer rounded transition-colors ${
+            i < highlightedIndex
+              ? 'opacity-50 text-on-surface-variant dark:text-slate-400'
+              : i === highlightedIndex
+              ? 'bg-primary text-on-primary px-0.5'
+              : 'text-on-surface dark:text-slate-100'
+          }`}
+        >
+          {word}
+        </span>
+      ))}
+    </p>
+  )
+}
+```
+
+> **Why `onWordClick` always receives `cueStart`:** SRT/VTT transcripts only have cue-level timestamps — individual words have no timestamps. Seeking to the cue's start time is the most useful UX: it rewinds to the beginning of the sentence being clicked.
+
+---
+
+### 10.4 `TranscriptPanel` Changes
+
+Add two new **optional** props to `TranscriptPanel`:
+
+```ts
+interface TranscriptPanelProps {
+  cues: TranscriptCue[]
+  activeCueIndex: number
+  currentPage: number
+  onPageChange: (page: number) => void
+  loading: boolean
+  currentTime?: number                    // NEW — absolute playback time (seconds); drives CueText
+  onSeek?: (seconds: number) => void      // NEW — called when a cue or word is clicked
+}
+```
+
+Both props are optional so `TranscriptPanel` remains usable before `MiniPlayer` is open (when there is no live `currentTime`).
+
+**Changes inside the component:**
+
+1. **Active cue rendering** — replace the current `<p>{cue.text}</p>` inside the active branch with `<CueText>`:
+   ```tsx
+   {isActive ? (
+     <CueText
+       text={cue.text}
+       cueStart={parseTimeToSeconds(cue.startTime)}
+       cueEnd={parseTimeToSeconds(cue.endTime)}
+       currentTime={currentTime ?? 0}
+       onWordClick={onSeek}
+     />
+   ) : (
+     cue.text
+   )}
+   ```
+
+2. **Click-to-seek on all cue rows** — add `onClick` to the cue `<div>`:
+   ```tsx
+   <div
+     key={cue.index}
+     ref={isActive ? activeCueRef : null}
+     data-testid={isActive ? 'cue-active' : `cue-${i}`}
+     onClick={() => onSeek?.(parseTimeToSeconds(cue.startTime))}
+     className={`cursor-pointer transition-all ...`}
+   >
+   ```
+   When `onSeek` is not provided, clicking is a no-op (the handler is absent / does nothing). No `cursor-pointer` style change is needed — it is already in the existing class list.
+
+3. **Import additions** needed in `TranscriptPanel.tsx`:
+   ```ts
+   import { parseTimeToSeconds } from '@/lib/parse-transcript'
+   import CueText from '@/components/CueText'
+   ```
+
+---
+
+### 10.5 `MiniPlayer` — Expose `seekTo` via Imperative Handle
+
+`MiniPlayer` currently creates a `YT.Player` instance inside a `useEffect` in a local variable. To expose `seekTo` externally:
+
+1. Store the player in a **ref** (`playerRef`) instead of a local variable so it survives re-renders and is accessible via `useImperativeHandle`.
+2. Convert `MiniPlayer` to `forwardRef` and expose a `MiniPlayerHandle`.
+
+```ts
+// src/components/MiniPlayer.tsx — additions
+
+export interface MiniPlayerHandle {
+  seekTo: (seconds: number) => void
+}
+
+// Convert default export to forwardRef:
+const MiniPlayer = forwardRef<MiniPlayerHandle, MiniPlayerProps>(
+  function MiniPlayer({ youtubeId, title, onClose, onTimeUpdate }, ref) {
+    const iframeRef = useRef<HTMLIFrameElement>(null)
+    const playerRef = useRef<YT.Player | null>(null)  // ← new ref for YT.Player instance
+
+    useImperativeHandle(ref, () => ({
+      seekTo(seconds: number) {
+        playerRef.current?.seekTo(seconds, true)
+      },
+    }))
+
+    useEffect(() => {
+      // ... existing YT IFrame API setup, but:
+      //   - assign player to playerRef.current instead of a local `player` variable
+      //   - use playerRef.current.getCurrentTime() / getDuration() in the poll interval
+
+      return () => {
+        clearInterval(pollInterval)
+        playerRef.current?.destroy()
+        playerRef.current = null
+      }
+    }, [youtubeId])
+
+    // ... existing JSX unchanged
+  }
+)
+
+export default MiniPlayer
+```
+
+> **Important:** Only the `player` local variable inside `useEffect` needs to move to `playerRef.current`. All other `useEffect` logic (API script injection, `onYouTubeIframeAPIReady`, polling interval) remains identical.
+
+---
+
+### 10.6 `PlayerClient` Changes
+
+```ts
+// Additions to src/components/PlayerClient.tsx
+
+import MiniPlayer, { MiniPlayerHandle } from '@/components/MiniPlayer'
+
+// Inside component:
+const miniPlayerRef = useRef<MiniPlayerHandle>(null)
+
+function handleSeek(seconds: number) {
+  miniPlayerRef.current?.seekTo(seconds)
+}
+```
+
+Thread `ref` and `currentTime` / `onSeek` through to children:
+
+```tsx
+// MiniPlayer — add ref:
+<MiniPlayer
+  ref={miniPlayerRef}
+  youtubeId={video.youtube_id}
+  title={video.title}
+  onClose={handleClose}
+  onTimeUpdate={handleTimeUpdate}
+/>
+
+// TranscriptPanel — add new props:
+<TranscriptPanel
+  cues={cues}
+  activeCueIndex={activeCueIndex}
+  currentPage={currentPage}
+  onPageChange={setCurrentPage}
+  loading={loadingTranscript}
+  currentTime={playbackTime.current}   // ← NEW
+  onSeek={handleSeek}                  // ← NEW
+/>
+```
+
+---
+
+### 10.7 Files to Create / Modify
+
+| File | Action | Change |
+|---|---|---|
+| `src/lib/parse-transcript.ts` | **Modify** | Export `tokenizeWords(text: string): string[]`. |
+| `src/components/CueText.tsx` | **Create** | `'use client'` — renders the active cue text as individually-styled word spans with karaoke highlighting. Props: `text`, `cueStart`, `cueEnd`, `currentTime`, `onWordClick?`. |
+| `src/components/TranscriptPanel.tsx` | **Modify** | Add optional `currentTime?: number` and `onSeek?: (seconds: number) => void` props. Import `parseTimeToSeconds` and `CueText`. Use `<CueText>` for the active cue. Add `onClick` to all cue rows. |
+| `src/components/MiniPlayer.tsx` | **Modify** | Store `YT.Player` in `playerRef` (useRef). Export `MiniPlayerHandle` interface. Convert to `forwardRef`. Add `useImperativeHandle` exposing `seekTo`. |
+| `src/components/PlayerClient.tsx` | **Modify** | Import `MiniPlayerHandle`. Add `miniPlayerRef = useRef<MiniPlayerHandle>(null)`. Add `handleSeek`. Pass `ref={miniPlayerRef}` to `<MiniPlayer>`. Pass `currentTime` and `onSeek` to `<TranscriptPanel>`. |
+
+No API route changes. No DB or store changes. No changes to `LessonHero`, `PlaybackProgress`, `PlayerLoader`, or `PlayerPage`.
+
+---
+
+### 10.8 Data-testid Conventions for New Elements
+
+| Element | `data-testid` |
+|---|---|
+| `CueText` root `<p>` | `cue-text` |
+| Word span at position `i` (0-based) | `word-{i}` |
+
+Existing `data-testid` values from Issue #121 (`cue-active`, `cue-{i}`, `transcript-panel`, etc.) are unchanged.
+
+---
+
+### 10.9 Test Coverage Expectations
+
+#### New utility tests — `tokenizeWords`
+
+Add to `src/lib/__tests__/parse-transcript.test.ts`:
+
+| Scenario | Assertion |
+|---|---|
+| `tokenizeWords("hello, world!")` | `["hello,", "world!"]` — punctuation stays attached |
+| `tokenizeWords("  spaces  ")` | `["spaces"]` — leading/trailing whitespace trimmed |
+| `tokenizeWords("")` | `[]` — empty string returns empty array |
+| `tokenizeWords("single")` | `["single"]` — single word |
+| `tokenizeWords("it's a test")` | `["it's", "a", "test"]` — contractions preserved |
+
+#### New pure formula tests (co-locate in parse-transcript test or CueText test)
+
+| Scenario | Assertion |
+|---|---|
+| `currentTime === cueStart` | `highlightedIndex === 0` (first word) |
+| `currentTime` is exactly halfway through cue | `highlightedIndex === Math.floor(words.length / 2)` |
+| `currentTime >= cueEnd` | `highlightedIndex === words.length - 1` (last word) |
+| `cueStart === cueEnd === 0` (plain-text cue, no timing) | `highlightedIndex === 0` (no crash) |
+| `currentTime < cueStart` | `highlightedIndex === 0` (clamped; no negative index) |
+
+#### New component tests — `CueText`
+
+File: `src/components/__tests__/CueText.test.tsx`
+
+| Scenario | Assertion |
+|---|---|
+| Renders all words as `data-testid="word-{i}"` spans | All tokens present in DOM |
+| First word highlighted at `currentTime === cueStart` | `word-0` has `bg-primary` class; `word-1` (if exists) does not |
+| Middle word highlighted at midpoint | Correct span has `bg-primary`; surrounding spans do not |
+| Clicking any word calls `onWordClick` with `cueStart` | Mock `onWordClick`; click `word-2`; assert called with `cueStart` value |
+| `onWordClick` not provided → no error on click | Click a span; no exception thrown |
+| Empty text | Renders `<p data-testid="cue-text">` with no child spans |
+
+#### Updated component tests — `TranscriptPanel`
+
+File: `src/components/__tests__/TranscriptPanel.test.tsx`
+
+| Scenario | Assertion |
+|---|---|
+| Clicking a non-active cue calls `onSeek` with `parseTimeToSeconds(cue.startTime)` | Mock `onSeek`; click `cue-0` div; assert called with correct seconds value |
+| Clicking active cue word calls `onSeek` with cue start time | Mock `onSeek`; click `word-0` inside `cue-active`; assert called |
+| When `onSeek` is not provided, clicking a cue does not throw | No error when clicking without `onSeek` prop |
+| Active cue renders `CueText` (not plain text) when `currentTime` is provided | `data-testid="cue-text"` is present in DOM when `activeCueIndex >= 0` and `currentTime` prop set |
+| Active cue renders plain `<p>` text when `currentTime` is not provided (no prop) | `data-testid="cue-text"` absent; cue text still visible as string |
+
+#### Updated component tests — `MiniPlayer`
+
+File: `src/components/__tests__/MiniPlayer.test.tsx`
+
+| Scenario | Assertion |
+|---|---|
+| `seekTo` ref method calls `player.seekTo(seconds, true)` | Render with `ref`; call `ref.current.seekTo(42)`; assert mock `player.seekTo` was called with `(42, true)` |
+| `playerRef.current` is nullified on unmount | After unmount, calling `seekTo` does not throw (ref is `null`) |
+
+Use the existing `window.YT` mock pattern from Section 8.5:
+```ts
+const mockSeekTo = jest.fn()
+const mockPlayerInstance = {
+  getCurrentTime: jest.fn().mockReturnValue(10),
+  getDuration: jest.fn().mockReturnValue(120),
+  seekTo: mockSeekTo,
+  destroy: jest.fn(),
+}
+window.YT = {
+  Player: jest.fn().mockImplementation((_el, opts) => {
+    opts.events.onStateChange({ data: window.YT.PlayerState.PLAYING })
+    return mockPlayerInstance
+  }),
+  PlayerState: { PLAYING: 1, PAUSED: 2, ENDED: 0 },
+} as unknown as typeof YT
+```
+
+#### Updated component tests — `PlayerClient`
+
+File: `src/components/__tests__/PlayerClient.test.tsx`
+
+| Scenario | Assertion |
+|---|---|
+| Clicking a non-active cue row calls `miniPlayerRef.current.seekTo` | Spy on `MiniPlayerHandle.seekTo`; click `cue-0`; assert seekTo called with correct time |
+| Clicking a word in the active cue calls `seekTo` with the active cue's start time | Click `word-1` inside `cue-active`; assert `seekTo` called |
+| `TranscriptPanel` receives `currentTime` matching `playbackTime.current` | After `onTimeUpdate(45, 300)` fires, `TranscriptPanel`'s `currentTime` prop is `45` (verify via the highlighted word in an active cue) |
+
+> **Testing `forwardRef` components:** Render `MiniPlayer` with `React.createRef<MiniPlayerHandle>()` and pass it as `ref`. After render (and timer flushes for the YT API setup), call `ref.current.seekTo(42)` to exercise the imperative handle.
+
+---
+
+### 10.10 Full Data-flow Summary (Issues #120 + #121 + #122)
+
+```
+YT.Player (inside MiniPlayer)
+  → polls getCurrentTime() every 250 ms while playing
+  → calls onTimeUpdate(current, duration)          ← MiniPlayer prop
+
+PlayerClient.handleTimeUpdate(current, duration)
+  → setPlaybackTime({ current, duration })         ← #120: drives PlaybackProgress
+  → setActiveCueIndex(findActiveCueIndex(cues, current))  ← #121: drives cue highlight
+  → setCurrentPage(...)                            ← #121: auto-advances page
+
+<TranscriptPanel
+  activeCueIndex={activeCueIndex}
+  currentPage={currentPage}
+  currentTime={playbackTime.current}               ← #122: drives CueText word highlight
+  onSeek={handleSeek}                              ← #122: click-to-seek
+/>
+  → active cue renders <CueText
+      cueStart=... cueEnd=... currentTime=...      ← #122: proportional word highlight
+      onWordClick={onSeek}
+    />
+
+User clicks word / cue
+  → onSeek(cueStartSeconds)
+  → miniPlayerRef.current.seekTo(cueStartSeconds) ← #122: imperative handle
+  → playerRef.current.seekTo(seconds, true)       ← YT.Player seek
+```

--- a/src/components/CueText.tsx
+++ b/src/components/CueText.tsx
@@ -1,0 +1,45 @@
+'use client'
+
+import { tokenizeWords } from '@/lib/parse-transcript'
+
+interface CueTextProps {
+  text: string
+  cueStart: number
+  cueEnd: number
+  currentTime: number
+  onWordClick?: (seekTime: number) => void
+}
+
+export default function CueText({ text, cueStart, cueEnd, currentTime, onWordClick }: CueTextProps) {
+  const words = tokenizeWords(text)
+  const cueDuration = cueEnd - cueStart
+  const elapsed = currentTime - cueStart
+  const fraction = cueDuration > 0 ? Math.min(Math.max(elapsed / cueDuration, 0), 1) : 0
+  const highlightedIndex = words.length > 0
+    ? Math.min(Math.floor(fraction * words.length), words.length - 1)
+    : -1
+
+  return (
+    <p
+      data-testid="cue-text"
+      className="text-sm text-on-surface dark:text-slate-100 leading-relaxed flex flex-wrap gap-x-1"
+    >
+      {words.map((word, i) => (
+        <span
+          key={i}
+          data-testid={`word-${i}`}
+          onClick={() => onWordClick?.(cueStart)}
+          className={`cursor-pointer rounded transition-colors ${
+            i < highlightedIndex
+              ? 'opacity-50 text-on-surface-variant dark:text-slate-400'
+              : i === highlightedIndex
+              ? 'bg-primary text-on-primary px-0.5'
+              : 'text-on-surface dark:text-slate-100'
+          }`}
+        >
+          {word}
+        </span>
+      ))}
+    </p>
+  )
+}

--- a/src/components/MiniPlayer.tsx
+++ b/src/components/MiniPlayer.tsx
@@ -1,6 +1,10 @@
 'use client'
 
-import { useEffect, useRef } from 'react'
+import { forwardRef, useEffect, useImperativeHandle, useRef } from 'react'
+
+export interface MiniPlayerHandle {
+  seekTo: (seconds: number) => void
+}
 
 interface MiniPlayerProps {
   youtubeId: string
@@ -9,12 +13,19 @@ interface MiniPlayerProps {
   onTimeUpdate?: (currentTime: number, duration: number) => void
 }
 
-export default function MiniPlayer({ youtubeId, title, onClose, onTimeUpdate }: MiniPlayerProps) {
+const MiniPlayer = forwardRef<MiniPlayerHandle, MiniPlayerProps>(
+  function MiniPlayer({ youtubeId, title, onClose, onTimeUpdate }, ref) {
   const iframeRef = useRef<HTMLIFrameElement>(null)
   const playerRef = useRef<YT.Player | null>(null)
   const pollIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
   const onTimeUpdateRef = useRef(onTimeUpdate)
   onTimeUpdateRef.current = onTimeUpdate
+
+  useImperativeHandle(ref, () => ({
+    seekTo(seconds: number) {
+      playerRef.current?.seekTo(seconds, true)
+    },
+  }))
 
   useEffect(() => {
     let destroyed = false
@@ -108,4 +119,6 @@ export default function MiniPlayer({ youtubeId, title, onClose, onTimeUpdate }: 
       </button>
     </div>
   )
-}
+})
+
+export default MiniPlayer

--- a/src/components/PlayerClient.tsx
+++ b/src/components/PlayerClient.tsx
@@ -1,10 +1,10 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Video } from '@/lib/videos'
 import { TranscriptCue, findActiveCueIndex } from '@/lib/parse-transcript'
 import LessonHero from '@/components/LessonHero'
-import MiniPlayer from '@/components/MiniPlayer'
+import MiniPlayer, { MiniPlayerHandle } from '@/components/MiniPlayer'
 import PlaybackProgress from '@/components/PlaybackProgress'
 import TranscriptPanel, { CUES_PER_PAGE } from '@/components/TranscriptPanel'
 
@@ -32,6 +32,7 @@ export default function PlayerClient({ video }: { video: Video }) {
   const [vocabWords, setVocabWords] = useState<WordCard[]>([])
   const [isMiniPlayerOpen, setIsMiniPlayerOpen] = useState(false)
   const [playbackTime, setPlaybackTime] = useState({ current: 0, duration: 0 })
+  const miniPlayerRef = useRef<MiniPlayerHandle>(null)
 
   function handleTimeUpdate(current: number, duration: number) {
     setPlaybackTime({ current, duration })
@@ -48,6 +49,10 @@ export default function PlayerClient({ video }: { video: Video }) {
   function handleClose() {
     setIsMiniPlayerOpen(false)
     setPlaybackTime({ current: 0, duration: 0 })
+  }
+
+  function handleSeek(seconds: number) {
+    miniPlayerRef.current?.seekTo(seconds)
   }
 
   useEffect(() => {
@@ -88,6 +93,7 @@ export default function PlayerClient({ video }: { video: Video }) {
 
       {isMiniPlayerOpen && (
         <MiniPlayer
+          ref={miniPlayerRef}
           youtubeId={video.youtube_id}
           title={video.title}
           onClose={handleClose}
@@ -136,6 +142,8 @@ export default function PlayerClient({ video }: { video: Video }) {
               currentPage={currentPage}
               onPageChange={setCurrentPage}
               loading={loadingTranscript}
+              currentTime={playbackTime.current}
+              onSeek={handleSeek}
             />
           )}
 

--- a/src/components/TranscriptPanel.tsx
+++ b/src/components/TranscriptPanel.tsx
@@ -1,7 +1,8 @@
 'use client'
 
 import { useRef, useEffect } from 'react'
-import { TranscriptCue } from '@/lib/parse-transcript'
+import { TranscriptCue, parseTimeToSeconds } from '@/lib/parse-transcript'
+import CueText from '@/components/CueText'
 
 export const CUES_PER_PAGE = 10
 
@@ -11,6 +12,8 @@ interface TranscriptPanelProps {
   currentPage: number
   onPageChange: (page: number) => void
   loading: boolean
+  currentTime?: number
+  onSeek?: (seconds: number) => void
 }
 
 export default function TranscriptPanel({
@@ -19,6 +22,8 @@ export default function TranscriptPanel({
   currentPage,
   onPageChange,
   loading,
+  currentTime,
+  onSeek,
 }: TranscriptPanelProps) {
   const activeCueRef = useRef<HTMLDivElement | null>(null)
 
@@ -65,6 +70,7 @@ export default function TranscriptPanel({
               key={cue.index}
               ref={isActive ? activeCueRef : null}
               data-testid={isActive ? 'cue-active' : `cue-${i}`}
+              onClick={() => onSeek?.(parseTimeToSeconds(cue.startTime))}
               className={`cursor-pointer transition-all ${
                 isPast
                   ? 'opacity-40 text-sm text-on-surface-variant dark:text-slate-400 px-3 py-2'
@@ -73,7 +79,15 @@ export default function TranscriptPanel({
                   : 'opacity-60 text-sm text-on-surface dark:text-slate-100 px-3 py-2'
               }`}
             >
-              {isActive ? (
+              {isActive && currentTime !== undefined ? (
+                <CueText
+                  text={cue.text}
+                  cueStart={parseTimeToSeconds(cue.startTime)}
+                  cueEnd={parseTimeToSeconds(cue.endTime)}
+                  currentTime={currentTime}
+                  onWordClick={onSeek}
+                />
+              ) : isActive ? (
                 <p className="text-sm text-on-surface dark:text-slate-100 leading-relaxed">{cue.text}</p>
               ) : (
                 cue.text

--- a/src/components/__tests__/CueText.test.tsx
+++ b/src/components/__tests__/CueText.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import CueText from '../CueText'
+
+describe('CueText', () => {
+  const defaultProps = {
+    text: 'She sells sea shells',
+    cueStart: 10,
+    cueEnd: 14,
+    currentTime: 10,
+  }
+
+  it('renders all words as word-{i} spans', () => {
+    render(<CueText {...defaultProps} />)
+    expect(screen.getByTestId('word-0')).toHaveTextContent('She')
+    expect(screen.getByTestId('word-1')).toHaveTextContent('sells')
+    expect(screen.getByTestId('word-2')).toHaveTextContent('sea')
+    expect(screen.getByTestId('word-3')).toHaveTextContent('shells')
+  })
+
+  it('renders cue-text testid on root element', () => {
+    render(<CueText {...defaultProps} />)
+    expect(screen.getByTestId('cue-text')).toBeInTheDocument()
+  })
+
+  it('highlights first word at currentTime === cueStart', () => {
+    render(<CueText {...defaultProps} currentTime={10} />)
+    expect(screen.getByTestId('word-0')).toHaveClass('bg-primary')
+    expect(screen.getByTestId('word-1')).not.toHaveClass('bg-primary')
+  })
+
+  it('highlights middle word at cue midpoint', () => {
+    // cue 10→14 (4s), midpoint = 12s → floor(0.5 * 4) = 2 → word-2
+    render(<CueText {...defaultProps} currentTime={12} />)
+    expect(screen.getByTestId('word-2')).toHaveClass('bg-primary')
+    expect(screen.getByTestId('word-0')).not.toHaveClass('bg-primary')
+    expect(screen.getByTestId('word-3')).not.toHaveClass('bg-primary')
+  })
+
+  it('calls onWordClick with cueStart when any word is clicked', () => {
+    const onWordClick = jest.fn()
+    render(<CueText {...defaultProps} onWordClick={onWordClick} />)
+    fireEvent.click(screen.getByTestId('word-2'))
+    expect(onWordClick).toHaveBeenCalledWith(10)
+  })
+
+  it('does not throw when onWordClick is not provided and a word is clicked', () => {
+    render(<CueText {...defaultProps} />)
+    expect(() => fireEvent.click(screen.getByTestId('word-0'))).not.toThrow()
+  })
+
+  it('renders empty cue-text with no child spans for empty text', () => {
+    render(<CueText text="" cueStart={0} cueEnd={5} currentTime={0} />)
+    expect(screen.getByTestId('cue-text')).toBeInTheDocument()
+    expect(screen.queryByTestId('word-0')).not.toBeInTheDocument()
+  })
+})

--- a/src/components/__tests__/MiniPlayer.test.tsx
+++ b/src/components/__tests__/MiniPlayer.test.tsx
@@ -1,5 +1,6 @@
+import React from 'react'
 import { render, screen, fireEvent, act } from '@testing-library/react'
-import MiniPlayer from '../MiniPlayer'
+import MiniPlayer, { MiniPlayerHandle } from '../MiniPlayer'
 
 let capturedOnStateChange: ((event: { data: number }) => void) | null = null
 
@@ -134,3 +135,74 @@ describe('MiniPlayer', () => {
   })
 })
 
+
+describe('MiniPlayer — seekTo imperative handle', () => {
+  it('exposes seekTo via forwardRef and calls player.seekTo(seconds, true)', () => {
+    const mockSeekTo = jest.fn()
+    Object.defineProperty(window, 'YT', {
+      value: {
+        Player: jest.fn().mockImplementation((_el: unknown, opts: { events: { onStateChange: (e: { data: number }) => void } }) => {
+          capturedOnStateChange = opts.events.onStateChange
+          return {
+            getCurrentTime: mockGetCurrentTime,
+            getDuration: mockGetDuration,
+            destroy: mockDestroy,
+            pauseVideo: mockPauseVideo,
+            seekTo: mockSeekTo,
+          }
+        }),
+        PlayerState: { PLAYING: 1, PAUSED: 2, ENDED: 0, BUFFERING: 3, CUED: 5 },
+      },
+      writable: true,
+      configurable: true,
+    })
+
+    const ref = React.createRef<MiniPlayerHandle>()
+    render(
+      <MiniPlayer
+        ref={ref}
+        youtubeId="test123"
+        title="Test"
+        onClose={jest.fn()}
+      />
+    )
+
+    ref.current?.seekTo(42)
+    expect(mockSeekTo).toHaveBeenCalledWith(42, true)
+  })
+
+  it('does not throw when seekTo is called after unmount (ref is null)', () => {
+    const mockSeekTo = jest.fn()
+    Object.defineProperty(window, 'YT', {
+      value: {
+        Player: jest.fn().mockImplementation((_el: unknown, opts: { events: { onStateChange: (e: { data: number }) => void } }) => {
+          capturedOnStateChange = opts.events.onStateChange
+          return {
+            getCurrentTime: mockGetCurrentTime,
+            getDuration: mockGetDuration,
+            destroy: mockDestroy,
+            pauseVideo: mockPauseVideo,
+            seekTo: mockSeekTo,
+          }
+        }),
+        PlayerState: { PLAYING: 1, PAUSED: 2, ENDED: 0, BUFFERING: 3, CUED: 5 },
+      },
+      writable: true,
+      configurable: true,
+    })
+
+    const ref = React.createRef<MiniPlayerHandle>()
+    const { unmount } = render(
+      <MiniPlayer
+        ref={ref}
+        youtubeId="test123"
+        title="Test"
+        onClose={jest.fn()}
+      />
+    )
+
+    unmount()
+    // After unmount, ref.current is null — optional chain ensures no throw
+    expect(() => ref.current?.seekTo(42)).not.toThrow()
+  })
+})

--- a/src/components/__tests__/PlayerClient.test.tsx
+++ b/src/components/__tests__/PlayerClient.test.tsx
@@ -16,21 +16,28 @@ const mockVideo: Video = {
   updated_at: '2026-01-01T00:00:00Z',
 }
 
-// Mock MiniPlayer to expose onTimeUpdate for testing.
+// Mock MiniPlayer to expose onTimeUpdate and seekTo for testing.
 // Variable MUST start with "mock" to satisfy babel-jest's hoisting rules for jest.mock factories.
 var mockCapturedOnTimeUpdate: ((current: number, duration: number) => void) | undefined
+var mockSeekTo: jest.Mock = jest.fn()
 
-jest.mock('@/components/MiniPlayer', () => ({
-  __esModule: true,
-  default: ({ onClose, onTimeUpdate }: { onClose: () => void; onTimeUpdate?: (c: number, d: number) => void }) => {
-    mockCapturedOnTimeUpdate = onTimeUpdate
-    return (
-      <div data-testid="mini-player">
-        <button data-testid="mini-player-close" onClick={onClose}>Close</button>
-      </div>
-    )
-  },
-}))
+jest.mock('@/components/MiniPlayer', () => {
+  const React = require('react')
+  return {
+    __esModule: true,
+    default: React.forwardRef(
+      ({ onClose, onTimeUpdate }: { onClose: () => void; onTimeUpdate?: (c: number, d: number) => void }, ref: React.Ref<{ seekTo: (s: number) => void }>) => {
+        mockCapturedOnTimeUpdate = onTimeUpdate
+        React.useImperativeHandle(ref, () => ({ seekTo: mockSeekTo }))
+        return (
+          <div data-testid="mini-player">
+            <button data-testid="mini-player-close" onClick={onClose}>Close</button>
+          </div>
+        )
+      }
+    ),
+  }
+})
 
 // Sample cues spanning 2 pages (12 cues total, page size = 10)
 const sampleCues = Array.from({ length: 12 }, (_, i) => ({
@@ -42,6 +49,7 @@ const sampleCues = Array.from({ length: 12 }, (_, i) => ({
 
 beforeEach(() => {
   mockCapturedOnTimeUpdate = undefined
+  mockSeekTo = jest.fn()
   window.HTMLElement.prototype.scrollIntoView = jest.fn()
   global.fetch = jest.fn().mockResolvedValue({
     ok: true,
@@ -177,3 +185,60 @@ describe('PlayerClient', () => {
   })
 })
 
+
+describe('PlayerClient — seek wiring', () => {
+  const cuesWithTiming = Array.from({ length: 5 }, (_, i) => ({
+    index: i + 1,
+    startTime: `00:00:${String(i * 5).padStart(2, '0')},000`,
+    endTime: `00:00:${String(i * 5 + 4).padStart(2, '0')},000`,
+    text: `Word1 Word2 Word3`,
+  }))
+
+  beforeEach(() => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ cues: cuesWithTiming }),
+    }) as jest.Mock
+  })
+
+  it('clicking a non-active cue calls seekTo with correct time', async () => {
+    render(<PlayerClient video={mockVideo} />)
+    fireEvent.click(screen.getByTestId('play-button'))
+    await waitFor(() => screen.getByTestId('cue-0'))
+
+    // cue-0 startTime = 0s
+    fireEvent.click(screen.getByTestId('cue-0'))
+    expect(mockSeekTo).toHaveBeenCalledWith(0)
+  })
+
+  it('clicking a word in the active cue calls seekTo with the cue start time', async () => {
+    render(<PlayerClient video={mockVideo} />)
+    fireEvent.click(screen.getByTestId('play-button'))
+    await waitFor(() => screen.getByTestId('cue-0'))
+
+    // Activate cue 0 (starts at 0s, ends at 4s) with currentTime=1
+    act(() => {
+      mockCapturedOnTimeUpdate?.(1, 120)
+    })
+
+    await waitFor(() => screen.getByTestId('cue-active'))
+
+    // word-1 inside active cue → should seek to cue 0 start (0s)
+    fireEvent.click(screen.getByTestId('word-1'))
+    expect(mockSeekTo).toHaveBeenCalledWith(0)
+  })
+
+  it('passes currentTime to TranscriptPanel (verified via highlighted word in active cue)', async () => {
+    render(<PlayerClient video={mockVideo} />)
+    fireEvent.click(screen.getByTestId('play-button'))
+    await waitFor(() => screen.getByTestId('cue-0'))
+
+    act(() => {
+      mockCapturedOnTimeUpdate?.(2, 120)
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('cue-text')).toBeInTheDocument()
+    })
+  })
+})

--- a/src/components/__tests__/TranscriptPanel.test.tsx
+++ b/src/components/__tests__/TranscriptPanel.test.tsx
@@ -174,3 +174,86 @@ describe('TranscriptPanel', () => {
     expect(screen.queryByTestId('transcript-next-page')).not.toBeInTheDocument()
   })
 })
+
+describe('TranscriptPanel — click-to-seek and CueText integration', () => {
+  it('calls onSeek with correct seconds when a non-active cue is clicked', () => {
+    const cues = makeCues(5)
+    const onSeek = jest.fn()
+    render(
+      <TranscriptPanel
+        cues={cues}
+        activeCueIndex={2}
+        currentPage={0}
+        onPageChange={noop}
+        loading={false}
+        onSeek={onSeek}
+      />
+    )
+    // cue-0 has startTime 00:00:00,000 → 0 seconds
+    fireEvent.click(screen.getByTestId('cue-0'))
+    expect(onSeek).toHaveBeenCalledWith(0)
+  })
+
+  it('does not throw when onSeek is not provided and a cue is clicked', () => {
+    const cues = makeCues(3)
+    render(
+      <TranscriptPanel
+        cues={cues}
+        activeCueIndex={-1}
+        currentPage={0}
+        onPageChange={noop}
+        loading={false}
+      />
+    )
+    expect(() => fireEvent.click(screen.getByTestId('cue-0'))).not.toThrow()
+  })
+
+  it('renders CueText (data-testid="cue-text") for active cue when currentTime is provided', () => {
+    const cues = makeCues(5)
+    render(
+      <TranscriptPanel
+        cues={cues}
+        activeCueIndex={1}
+        currentPage={0}
+        onPageChange={noop}
+        loading={false}
+        currentTime={4}
+      />
+    )
+    expect(screen.getByTestId('cue-text')).toBeInTheDocument()
+  })
+
+  it('renders plain text (no cue-text) for active cue when currentTime is not provided', () => {
+    const cues = makeCues(5)
+    render(
+      <TranscriptPanel
+        cues={cues}
+        activeCueIndex={1}
+        currentPage={0}
+        onPageChange={noop}
+        loading={false}
+      />
+    )
+    expect(screen.queryByTestId('cue-text')).not.toBeInTheDocument()
+    expect(screen.getByTestId('cue-active')).toHaveTextContent('Cue text 2')
+  })
+
+  it('calls onSeek when a word inside the active cue is clicked', () => {
+    const cues = makeCues(5)
+    const onSeek = jest.fn()
+    render(
+      <TranscriptPanel
+        cues={cues}
+        activeCueIndex={1}
+        currentPage={0}
+        onPageChange={noop}
+        loading={false}
+        currentTime={4}
+        onSeek={onSeek}
+      />
+    )
+    fireEvent.click(screen.getByTestId('word-0'))
+    // cue index 1 startTime = 00:00:03,000 → 3 seconds
+    expect(onSeek).toHaveBeenCalledWith(3)
+  })
+})

--- a/src/lib/__tests__/parse-transcript.test.ts
+++ b/src/lib/__tests__/parse-transcript.test.ts
@@ -1,4 +1,4 @@
-import { parseTimeToSeconds, findActiveCueIndex, TranscriptCue } from '../parse-transcript'
+import { parseTimeToSeconds, findActiveCueIndex, tokenizeWords, TranscriptCue } from '../parse-transcript'
 
 describe('parseTimeToSeconds', () => {
   it('converts SRT timestamp with comma separator', () => {
@@ -59,5 +59,58 @@ describe('findActiveCueIndex', () => {
     // All start times parse to 0, so lastBefore will be the last cue with start <= currentTime
     const result = findActiveCueIndex(plainCues, 5)
     expect(result).toBeGreaterThanOrEqual(-1)
+  })
+})
+
+describe('tokenizeWords', () => {
+  it('splits on whitespace and keeps punctuation attached', () => {
+    expect(tokenizeWords('hello, world!')).toEqual(['hello,', 'world!'])
+  })
+
+  it('trims leading/trailing whitespace', () => {
+    expect(tokenizeWords('  spaces  ')).toEqual(['spaces'])
+  })
+
+  it('returns empty array for empty string', () => {
+    expect(tokenizeWords('')).toEqual([])
+  })
+
+  it('handles single word', () => {
+    expect(tokenizeWords('single')).toEqual(['single'])
+  })
+
+  it('preserves contractions', () => {
+    expect(tokenizeWords("it's a test")).toEqual(["it's", 'a', 'test'])
+  })
+})
+
+describe('proportional word index formula', () => {
+  function highlightedIndex(cueStart: number, cueEnd: number, currentTime: number, wordCount: number): number {
+    const cueDuration = cueEnd - cueStart
+    const elapsed = currentTime - cueStart
+    const fraction = cueDuration > 0 ? Math.min(Math.max(elapsed / cueDuration, 0), 1) : 0
+    return wordCount > 0 ? Math.min(Math.floor(fraction * wordCount), wordCount - 1) : -1
+  }
+
+  it('returns 0 (first word) when currentTime === cueStart', () => {
+    expect(highlightedIndex(10, 14, 10, 4)).toBe(0)
+  })
+
+  it('returns middle word index at midpoint', () => {
+    // 4 words, midpoint = 50% -> floor(0.5 * 4) = 2
+    expect(highlightedIndex(10, 14, 12, 4)).toBe(2)
+  })
+
+  it('returns last word index when currentTime >= cueEnd', () => {
+    expect(highlightedIndex(10, 14, 14, 4)).toBe(3)
+    expect(highlightedIndex(10, 14, 20, 4)).toBe(3)
+  })
+
+  it('handles plain-text cue with no timing (cueStart === cueEnd === 0)', () => {
+    expect(highlightedIndex(0, 0, 0, 4)).toBe(0)
+  })
+
+  it('clamps to first word when currentTime < cueStart', () => {
+    expect(highlightedIndex(10, 14, 5, 4)).toBe(0)
   })
 })

--- a/src/lib/parse-transcript.ts
+++ b/src/lib/parse-transcript.ts
@@ -1,3 +1,11 @@
+/**
+ * Split a cue's text into an array of word tokens.
+ * Punctuation stays attached to adjacent words (e.g. "hello," is one token).
+ */
+export function tokenizeWords(text: string): string[] {
+  return text.split(/\s+/).filter(Boolean)
+}
+
 export interface TranscriptCue {
   index: number
   startTime: string


### PR DESCRIPTION
Closes #122

## Summary

Implements word-level progressive highlighting within the active transcript cue using proportional timing interpolation, and click-to-seek for any cue or word.

## Changes

### New files
- `src/components/CueText.tsx` — renders active cue text as individually-styled word spans with karaoke highlighting
- `src/components/__tests__/CueText.test.tsx` — component tests

### Modified files
- `src/lib/parse-transcript.ts` — export `tokenizeWords(text: string): string[]`
- `src/components/TranscriptPanel.tsx` — add optional `currentTime?` and `onSeek?` props; use CueText for active cue; click-to-seek on all cue rows
- `src/components/MiniPlayer.tsx` — convert to forwardRef, export `MiniPlayerHandle` with `seekTo` imperative handle
- `src/components/PlayerClient.tsx` — wire miniPlayerRef, handleSeek, pass currentTime/onSeek to TranscriptPanel
- Tests updated for all modified components + new tokenizeWords/formula tests

## Test Results
- Test Suites: 28 passed, 28 total
- Tests: 289 passed, 289 total
- Build: ✅