### PR TITLE
Add CSP header to block injected third-party scripts

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,33 @@
 import type { NextConfig } from "next";
 
+const contentSecurityPolicy = [
+  "default-src 'self'",
+  "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.youtube.com https://www.youtube-nocookie.com https://s.ytimg.com",
+  "style-src 'self' 'unsafe-inline'",
+  "img-src 'self' data: blob: https://i.ytimg.com https://img.youtube.com",
+  "font-src 'self' data:",
+  "connect-src 'self' ws: wss: https://www.youtube.com https://www.youtube-nocookie.com",
+  "frame-src 'self' https://www.youtube.com https://www.youtube-nocookie.com",
+  "object-src 'none'",
+  "base-uri 'self'",
+  "form-action 'self'",
+  "frame-ancestors 'self'",
+].join("; ");
+
 const nextConfig: NextConfig = {
-  /* config options here */
+  async headers() {
+    return [
+      {
+        source: "/:path*",
+        headers: [
+          {
+            key: "Content-Security-Policy",
+            value: contentSecurityPolicy,
+          },
+        ],
+      },
+    ];
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- add a site-wide Content-Security-Policy header in next.config.ts
- allow only the app origin and required YouTube domains for scripts, frames, and connects
- block unexpected third-party script injection that can trigger noisy CORS errors in local dev

## Validation
- pnpm build
- pnpm test
- pnpm test:e2e