### PR TITLE
fix: remove legacy body flex centering that hid player content

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -38,10 +38,6 @@ body {
     Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   margin: 0;
   padding: 0;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  min-height: 100vh;
 }
 
 .register-page,


### PR DESCRIPTION
## Problem
Clicking a video opened the player page showing only the transcript sidebar — all main content (thumbnail, title, author, play button) was invisible.

## Root Cause
`src/app/globals.css` had legacy CSS on `body`:
```css
body {
  display: flex;
  justify-content: center;
  align-items: center;  /* ← culprit */
  min-height: 100vh;
}
```
These rules were left over from a former login/registration page. The `align-items: center` vertically centered the entire app div (~13,000px tall due to ~180 transcript cues) within the 720px viewport, pushing the LessonHero section ~6,352px **above** the viewport top — unreachable by scrolling.

## Fix
Removed the 4 flex properties from `body`. All layout is handled by Tailwind utility classes on the app components.

## Testing
- ✅ 240 Jest unit tests pass
- ✅ 21 Playwright E2E tests pass  
- ✅ `pnpm build` succeeds
- ✅ Visual: player thumbnail, title, author, Save Lesson button all render correctly