### PR TITLE
Redesign player UI and sync transcript

### DIFF
--- a/src/components/LessonHero.tsx
+++ b/src/components/LessonHero.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import { useState } from 'react'
 import { Video } from '@/lib/videos'
 
 interface LessonHeroProps {
@@ -9,52 +8,31 @@ interface LessonHeroProps {
 }
 
 export default function LessonHero({ video, onPlay }: LessonHeroProps) {
-  const [imgSrc, setImgSrc] = useState(
-    `https://img.youtube.com/vi/${video.youtube_id}/maxresdefault.jpg`
-  )
-
   return (
-    <div data-testid="lesson-hero">
-      <div
-        className="relative aspect-video rounded-xl overflow-hidden shadow-2xl mb-6 bg-black cursor-pointer group"
-        onClick={onPlay}
-        role="button"
-        aria-label="Play video"
-        data-testid="hero-play-area"
-      >
-        <img
-          src={imgSrc}
-          alt={video.title}
-          className="w-full h-full object-cover"
-          onError={() =>
-            setImgSrc(`https://img.youtube.com/vi/${video.youtube_id}/hqdefault.jpg`)
-          }
-          data-testid="hero-thumbnail"
-        />
-        <div className="absolute inset-0 flex items-center justify-center bg-black/30 group-hover:bg-black/40 transition">
-          <button
-            onClick={(e) => {
-              e.stopPropagation()
-              onPlay()
-            }}
-            aria-label="Play"
-            data-testid="play-button"
-            className="flex items-center justify-center w-20 h-20 rounded-full bg-white/20 hover:bg-white/30 backdrop-blur-sm transition"
-          >
-            <svg
-              className="w-10 h-10 text-white drop-shadow-lg ml-1"
-              fill="currentColor"
-              viewBox="0 0 24 24"
-              aria-hidden="true"
-            >
-              <path d="M8 5v14l11-7z" />
-            </svg>
-          </button>
-        </div>
-      </div>
-
-      <div className="flex items-start justify-between gap-4 mb-6">
+    <div data-testid="lesson-hero" className="mb-6">
+      <div className="flex items-start justify-between gap-4">
         <div>
+          <div
+            className="inline-flex mb-4 rounded-full"
+            onClick={onPlay}
+            role="button"
+            aria-label="Play video"
+            data-testid="hero-play-area"
+          >
+            <button
+              onClick={(e) => {
+                e.stopPropagation()
+                onPlay()
+              }}
+              aria-label="Play"
+              data-testid="play-button"
+              className="flex items-center justify-center w-14 h-14 rounded-full bg-primary hover:opacity-90 text-on-primary transition"
+            >
+              <svg className="w-7 h-7 ml-0.5" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M8 5v14l11-7z" />
+              </svg>
+            </button>
+          </div>
           {video.tags.length > 0 && (
             <div className="flex gap-2 mb-2 flex-wrap">
               {video.tags.map((tag) => (

--- a/src/components/MiniPlayer.tsx
+++ b/src/components/MiniPlayer.tsx
@@ -7,9 +7,18 @@ interface MiniPlayerProps {
   title: string
   onClose: () => void
   onTimeUpdate?: (currentTime: number, duration: number) => void
+  seekToTime?: number | null
+  onSeekApplied?: () => void
 }
 
-export default function MiniPlayer({ youtubeId, title, onClose, onTimeUpdate }: MiniPlayerProps) {
+export default function MiniPlayer({
+  youtubeId,
+  title,
+  onClose,
+  onTimeUpdate,
+  seekToTime,
+  onSeekApplied,
+}: MiniPlayerProps) {
   const iframeRef = useRef<HTMLIFrameElement>(null)
   const playerRef = useRef<YT.Player | null>(null)
   const pollIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
@@ -78,6 +87,12 @@ export default function MiniPlayer({ youtubeId, title, onClose, onTimeUpdate }: 
       playerRef.current = null
     }
   }, [youtubeId])
+
+  useEffect(() => {
+    if (seekToTime == null || !playerRef.current) return
+    playerRef.current.seekTo(seekToTime, true)
+    onSeekApplied?.()
+  }, [onSeekApplied, seekToTime])
 
   function handleClose() {
     playerRef.current?.pauseVideo()

--- a/src/components/PlayerClient.tsx
+++ b/src/components/PlayerClient.tsx
@@ -12,6 +12,15 @@ interface WordCard {
   status: 'new' | 'added' | 'mastered'
 }
 
+function parseTimeToSeconds(timestamp: string): number {
+  const normalized = timestamp.trim().replace(',', '.')
+  const match = normalized.match(/^(\d{2}):(\d{2}):(\d{2})\.(\d{3})$/)
+  if (!match) return 0
+
+  const [, hh, mm, ss, ms] = match
+  return Number(hh) * 3600 + Number(mm) * 60 + Number(ss) + Number(ms) / 1000
+}
+
 function extractVocabWords(cues: TranscriptCue[]): WordCard[] {
   const allText = cues.map((c) => c.text).join(' ')
   const words = allText
@@ -30,6 +39,7 @@ export default function PlayerClient({ video }: { video: Video }) {
   const [vocabWords, setVocabWords] = useState<WordCard[]>([])
   const [isMiniPlayerOpen, setIsMiniPlayerOpen] = useState(false)
   const [playbackTime, setPlaybackTime] = useState({ current: 0, duration: 0 })
+  const [requestedSeekTime, setRequestedSeekTime] = useState<number | null>(null)
 
   function handleTimeUpdate(current: number, duration: number) {
     setPlaybackTime({ current, duration })
@@ -55,6 +65,28 @@ export default function PlayerClient({ video }: { video: Video }) {
       .finally(() => setLoadingTranscript(false))
   }, [video.id])
 
+  useEffect(() => {
+    if (!isMiniPlayerOpen || cues.length === 0) return
+
+    const now = playbackTime.current
+    const cueIndex = cues.findIndex((cue) => {
+      const start = parseTimeToSeconds(cue.startTime)
+      const end = parseTimeToSeconds(cue.endTime)
+      return now >= start && now < end
+    })
+
+    if (cueIndex >= 0 && cueIndex !== activeCueIndex) {
+      setActiveCueIndex(cueIndex)
+    }
+  }, [activeCueIndex, cues, isMiniPlayerOpen, playbackTime.current])
+
+  useEffect(() => {
+    const activeElement = document.querySelector(`[data-testid="cue-${activeCueIndex}"]`)
+    if (activeElement) {
+      ;(activeElement as HTMLElement).scrollIntoView?.({ block: 'center', behavior: 'smooth' })
+    }
+  }, [activeCueIndex])
+
   function handleWordAction(word: string, action: 'add' | 'master') {
     setVocabWords((prev) =>
       prev.map((w) =>
@@ -64,16 +96,143 @@ export default function PlayerClient({ video }: { video: Video }) {
   }
 
   return (
-    <div data-testid="player-client" className="min-h-screen flex flex-col lg:flex-row bg-surface dark:bg-slate-900">
-      {/* Main content */}
-      <section className="flex-1 p-8 bg-surface dark:bg-slate-900 overflow-y-auto">
+    <div data-testid="player-client" className="min-h-screen bg-surface dark:bg-slate-900">
+      <section className="mx-auto w-full max-w-3xl px-4 py-8 md:px-8">
         <LessonHero video={video} onPlay={() => setIsMiniPlayerOpen(true)} />
         {isMiniPlayerOpen && (
-          <PlaybackProgress
-            currentTime={playbackTime.current}
-            duration={playbackTime.duration}
-          />
+          <PlaybackProgress currentTime={playbackTime.current} duration={playbackTime.duration} />
         )}
+        <div className="rounded-2xl bg-surface-container-low dark:bg-slate-950/50 border border-outline-variant/30 dark:border-slate-700 overflow-hidden min-h-[540px] flex flex-col">
+          <div className="p-4 border-b border-outline-variant/20 flex items-center justify-between">
+            <h2 className="font-bold text-on-surface dark:text-slate-100">Interactive Transcript</h2>
+          </div>
+
+          <div className="flex border-b border-outline-variant/20 dark:border-slate-700">
+            <button
+              className={`flex-1 py-3 text-sm font-bold transition-colors ${
+                activeTab === 'transcript'
+                  ? 'text-primary border-b-2 border-primary'
+                  : 'font-medium text-on-surface-variant hover:text-on-surface'
+              }`}
+              onClick={() => setActiveTab('transcript')}
+              data-testid="tab-transcript"
+            >
+              Transcript
+            </button>
+            <button
+              className={`flex-1 py-3 text-sm transition-colors ${
+                activeTab === 'vocabulary'
+                  ? 'text-primary font-bold border-b-2 border-primary'
+                  : 'font-medium text-on-surface-variant hover:text-on-surface'
+              }`}
+              onClick={() => setActiveTab('vocabulary')}
+              data-testid="tab-vocabulary"
+            >
+              Vocabulary
+            </button>
+          </div>
+
+          <div className="flex-1 overflow-y-auto p-4 space-y-3">
+            {activeTab === 'transcript' && (
+              <>
+                {loadingTranscript && (
+                  <p className="text-sm text-on-surface-variant dark:text-slate-400 text-center py-8">
+                    Loading transcript…
+                  </p>
+                )}
+                {!loadingTranscript && cues.length === 0 && (
+                  <div className="flex flex-col items-center justify-center py-12 text-center gap-3">
+                    <span className="text-3xl">📄</span>
+                    <p className="text-on-surface font-semibold">No transcript available</p>
+                    <p className="text-sm text-on-surface-variant">
+                      Upload a transcript file to enable interactive subtitles.
+                    </p>
+                  </div>
+                )}
+                {!loadingTranscript &&
+                  cues.map((cue, i) => {
+                    const isPast = i < activeCueIndex
+                    const isActive = i === activeCueIndex
+                    return (
+                      <div
+                        key={cue.index}
+                        onClick={() => {
+                          setActiveCueIndex(i)
+                          setRequestedSeekTime(parseTimeToSeconds(cue.startTime))
+                        }}
+                        data-testid={`cue-${i}`}
+                        className={`cursor-pointer transition-all ${
+                          isPast
+                            ? 'opacity-40 text-sm text-on-surface-variant dark:text-slate-400 px-3 py-2'
+                            : isActive
+                            ? 'bg-surface-container dark:bg-slate-800 rounded-xl p-3 ring-1 ring-primary/10 border-l-4 border-primary'
+                            : 'opacity-60 text-sm text-on-surface dark:text-slate-100 px-3 py-2'
+                        }`}
+                      >
+                        {isActive ? (
+                          <p className="text-sm text-on-surface dark:text-slate-100 leading-relaxed">{cue.text}</p>
+                        ) : (
+                          cue.text
+                        )}
+                      </div>
+                    )
+                  })}
+              </>
+            )}
+
+            {activeTab === 'vocabulary' && (
+              <>
+                {vocabWords.length === 0 ? (
+                  <div className="flex flex-col items-center justify-center py-12 text-center gap-3">
+                    <span className="text-3xl">📚</span>
+                    <p className="text-on-surface font-semibold">No vocabulary yet</p>
+                    <p className="text-sm text-on-surface-variant">
+                      Words from the transcript will appear here.
+                    </p>
+                  </div>
+                ) : (
+                  vocabWords.map(({ word, status }) => (
+                    <div
+                      key={word}
+                      data-testid={`vocab-${word}`}
+                      className="bg-surface-container dark:bg-slate-800 rounded-xl p-4 flex flex-col gap-2"
+                    >
+                      <div className="flex items-center justify-between">
+                        <span className="font-bold text-on-surface dark:text-slate-100 capitalize">{word}</span>
+                        {status === 'added' && (
+                          <span className="px-2 py-0.5 text-xs font-bold rounded-full bg-secondary-container text-on-secondary-container">
+                            Added
+                          </span>
+                        )}
+                        {status === 'mastered' && (
+                          <span className="px-2 py-0.5 text-xs font-bold rounded-full bg-primary text-on-primary">
+                            Mastered
+                          </span>
+                        )}
+                      </div>
+                      <div className="flex gap-2">
+                        <button
+                          onClick={() => handleWordAction(word, 'add')}
+                          disabled={status !== 'new'}
+                          className="flex-1 py-1.5 text-xs font-bold rounded-lg bg-primary-container text-on-primary-container hover:opacity-80 disabled:opacity-40 transition-opacity"
+                        >
+                          {status === 'added' ? 'Added to Deck' : 'Add to Deck'}
+                        </button>
+                        <button
+                          onClick={() => handleWordAction(word, 'master')}
+                          disabled={status === 'mastered'}
+                          className="flex-1 py-1.5 text-xs font-bold rounded-lg bg-surface-container-highest text-on-surface-variant hover:opacity-80 disabled:opacity-40 transition-opacity"
+                        >
+                          {status === 'mastered' ? 'Mastered ✓' : 'Mark Mastered'}
+                        </button>
+                      </div>
+                    </div>
+                  ))
+                )}
+              </>
+            )}
+          </div>
+        </div>
       </section>
 
       {isMiniPlayerOpen && (
@@ -82,140 +241,10 @@ export default function PlayerClient({ video }: { video: Video }) {
           title={video.title}
           onClose={handleClose}
           onTimeUpdate={handleTimeUpdate}
+          seekToTime={requestedSeekTime}
+          onSeekApplied={() => setRequestedSeekTime(null)}
         />
       )}
-
-      {/* Right transcript/vocab sidebar */}
-      <aside className="w-full lg:w-[420px] bg-surface-container-low dark:bg-slate-950/50 flex flex-col border-t lg:border-t-0 lg:border-l border-outline-variant/30 dark:border-slate-700 overflow-hidden min-h-[400px] lg:min-h-screen">
-        <div className="p-4 border-b border-outline-variant/20 flex items-center justify-between">
-          <h2 className="font-bold text-on-surface dark:text-slate-100">Interactive Transcript</h2>
-        </div>
-
-        {/* Tab switcher */}
-        <div className="flex border-b border-outline-variant/20 dark:border-slate-700">
-          <button
-            className={`flex-1 py-3 text-sm font-bold transition-colors ${
-              activeTab === 'transcript'
-                ? 'text-primary border-b-2 border-primary'
-                : 'font-medium text-on-surface-variant hover:text-on-surface'
-            }`}
-            onClick={() => setActiveTab('transcript')}
-            data-testid="tab-transcript"
-          >
-            Transcript
-          </button>
-          <button
-            className={`flex-1 py-3 text-sm transition-colors ${
-              activeTab === 'vocabulary'
-                ? 'text-primary font-bold border-b-2 border-primary'
-                : 'font-medium text-on-surface-variant hover:text-on-surface'
-            }`}
-            onClick={() => setActiveTab('vocabulary')}
-            data-testid="tab-vocabulary"
-          >
-            Vocabulary
-          </button>
-        </div>
-
-        {/* Tab content */}
-        <div className="flex-1 overflow-y-auto p-4 space-y-3">
-          {activeTab === 'transcript' && (
-            <>
-              {loadingTranscript && (
-                <p className="text-sm text-on-surface-variant dark:text-slate-400 text-center py-8">
-                  Loading transcript…
-                </p>
-              )}
-              {!loadingTranscript && cues.length === 0 && (
-                <div className="flex flex-col items-center justify-center py-12 text-center gap-3">
-                  <span className="text-3xl">📄</span>
-                  <p className="text-on-surface font-semibold">No transcript available</p>
-                  <p className="text-sm text-on-surface-variant">
-                    Upload a transcript file to enable interactive subtitles.
-                  </p>
-                </div>
-              )}
-              {!loadingTranscript &&
-                cues.map((cue, i) => {
-                  const isPast = i < activeCueIndex
-                  const isActive = i === activeCueIndex
-                  return (
-                    <div
-                      key={cue.index}
-                      onClick={() => setActiveCueIndex(i)}
-                      data-testid={`cue-${i}`}
-                      className={`cursor-pointer transition-all ${
-                        isPast
-                          ? 'opacity-40 text-sm text-on-surface-variant dark:text-slate-400 px-3 py-2'
-                          : isActive
-                          ? 'bg-surface-container dark:bg-slate-800 rounded-xl p-3 ring-1 ring-primary/10 border-l-4 border-primary'
-                          : 'opacity-60 text-sm text-on-surface dark:text-slate-100 px-3 py-2'
-                      }`}
-                    >
-                      {isActive ? (
-                        <p className="text-sm text-on-surface dark:text-slate-100 leading-relaxed">{cue.text}</p>
-                      ) : (
-                        cue.text
-                      )}
-                    </div>
-                  )
-                })}
-            </>
-          )}
-
-          {activeTab === 'vocabulary' && (
-            <>
-              {vocabWords.length === 0 ? (
-                <div className="flex flex-col items-center justify-center py-12 text-center gap-3">
-                  <span className="text-3xl">📚</span>
-                  <p className="text-on-surface font-semibold">No vocabulary yet</p>
-                  <p className="text-sm text-on-surface-variant">
-                    Words from the transcript will appear here.
-                  </p>
-                </div>
-              ) : (
-                vocabWords.map(({ word, status }) => (
-                  <div
-                    key={word}
-                    data-testid={`vocab-${word}`}
-                    className="bg-surface-container dark:bg-slate-800 rounded-xl p-4 flex flex-col gap-2"
-                  >
-                    <div className="flex items-center justify-between">
-                      <span className="font-bold text-on-surface dark:text-slate-100 capitalize">{word}</span>
-                      {status === 'added' && (
-                        <span className="px-2 py-0.5 text-xs font-bold rounded-full bg-secondary-container text-on-secondary-container">
-                          Added
-                        </span>
-                      )}
-                      {status === 'mastered' && (
-                        <span className="px-2 py-0.5 text-xs font-bold rounded-full bg-primary text-on-primary">
-                          Mastered
-                        </span>
-                      )}
-                    </div>
-                    <div className="flex gap-2">
-                      <button
-                        onClick={() => handleWordAction(word, 'add')}
-                        disabled={status !== 'new'}
-                        className="flex-1 py-1.5 text-xs font-bold rounded-lg bg-primary-container text-on-primary-container hover:opacity-80 disabled:opacity-40 transition-opacity"
-                      >
-                        {status === 'added' ? 'Added to Deck' : 'Add to Deck'}
-                      </button>
-                      <button
-                        onClick={() => handleWordAction(word, 'master')}
-                        disabled={status === 'mastered'}
-                        className="flex-1 py-1.5 text-xs font-bold rounded-lg bg-surface-container-highest text-on-surface-variant hover:opacity-80 disabled:opacity-40 transition-opacity"
-                      >
-                        {status === 'mastered' ? 'Mastered ✓' : 'Mark Mastered'}
-                      </button>
-                    </div>
-                  </div>
-                ))
-              )}
-            </>
-          )}
-        </div>
-      </aside>
     </div>
   )
 }

--- a/src/components/__tests__/LessonHero.test.tsx
+++ b/src/components/__tests__/LessonHero.test.tsx
@@ -17,16 +17,6 @@ const mockVideo: Video = {
 }
 
 describe('LessonHero', () => {
-  it('renders the thumbnail image with maxresdefault URL', () => {
-    render(<LessonHero video={mockVideo} onPlay={jest.fn()} />)
-    const img = screen.getByTestId('hero-thumbnail')
-    expect(img).toHaveAttribute(
-      'src',
-      'https://img.youtube.com/vi/abc123/maxresdefault.jpg'
-    )
-    expect(img).toHaveAttribute('alt', 'Test Video Title')
-  })
-
   it('renders the video title', () => {
     render(<LessonHero video={mockVideo} onPlay={jest.fn()} />)
     expect(screen.getByText('Test Video Title')).toBeInTheDocument()
@@ -62,13 +52,4 @@ describe('LessonHero', () => {
     expect(onPlay).toHaveBeenCalled()
   })
 
-  it('falls back to hqdefault thumbnail on image error', () => {
-    render(<LessonHero video={mockVideo} onPlay={jest.fn()} />)
-    const img = screen.getByTestId('hero-thumbnail')
-    fireEvent.error(img)
-    expect(img).toHaveAttribute(
-      'src',
-      'https://img.youtube.com/vi/abc123/hqdefault.jpg'
-    )
-  })
 })

--- a/src/components/__tests__/MiniPlayer.test.tsx
+++ b/src/components/__tests__/MiniPlayer.test.tsx
@@ -5,6 +5,7 @@ let capturedOnStateChange: ((event: { data: number }) => void) | null = null
 
 const mockGetCurrentTime = jest.fn().mockReturnValue(90)
 const mockGetDuration = jest.fn().mockReturnValue(300)
+const mockSeekTo = jest.fn()
 const mockDestroy = jest.fn()
 const mockPauseVideo = jest.fn()
 
@@ -13,6 +14,7 @@ beforeEach(() => {
   capturedOnStateChange = null
   mockGetCurrentTime.mockReturnValue(90)
   mockGetDuration.mockReturnValue(300)
+  mockSeekTo.mockReset()
   mockDestroy.mockReset()
   mockPauseVideo.mockReset()
 
@@ -23,6 +25,7 @@ beforeEach(() => {
         return {
           getCurrentTime: mockGetCurrentTime,
           getDuration: mockGetDuration,
+          seekTo: mockSeekTo,
           destroy: mockDestroy,
           pauseVideo: mockPauseVideo,
         }
@@ -132,5 +135,20 @@ describe('MiniPlayer', () => {
     // No calls after unmount
     expect(onTimeUpdate).not.toHaveBeenCalled()
   })
-})
 
+  it('seeks when seekToTime is provided', () => {
+    const onSeekApplied = jest.fn()
+    render(
+      <MiniPlayer
+        youtubeId="abc123"
+        title="My Video"
+        onClose={jest.fn()}
+        seekToTime={42}
+        onSeekApplied={onSeekApplied}
+      />
+    )
+
+    expect(mockSeekTo).toHaveBeenCalledWith(42, true)
+    expect(onSeekApplied).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
- Remove large player hero thumbnail and keep compact play entrypoint
- Center transcript panel in single-column player layout
- Sync active transcript cue with mini-player playback time
- Add cue click-to-seek behavior and active-cue auto-scroll
- Update affected unit tests