### PR TITLE
fix: stabilize mini-player flow and tests

### DIFF
--- a/src/components/LessonHero.tsx
+++ b/src/components/LessonHero.tsx
@@ -28,30 +28,17 @@ export default function LessonHero({ video, onPlay }: LessonHeroProps) {
             {video.title}
           </h1>
           <p className="text-on-surface-variant dark:text-slate-400 mt-1">{video.author_name}</p>
-          <div
-            className="inline-flex mt-auto rounded-full"
-            onClick={onPlay}
-            role="button"
-            aria-label="Play video"
-            data-testid="hero-play-area"
-          >
-            <button
-              onClick={(e) => {
-                e.stopPropagation()
-                onPlay()
-              }}
-              aria-label="Play"
-              data-testid="play-button"
-              className="flex items-center justify-center w-14 h-14 rounded-full bg-primary hover:opacity-90 text-on-primary transition"
-            >
-              <svg className="w-7 h-7 ml-0.5" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-                <path d="M8 5v14l11-7z" />
-              </svg>
-            </button>
-          </div>
         </div>
-        <button className="flex items-center gap-2 px-6 py-3 bg-gradient-to-br from-primary to-primary-container text-white rounded-xl font-bold hover:scale-[1.02] transition-transform whitespace-nowrap">
-          Save Lesson
+        <button
+          onClick={onPlay}
+          aria-label="Play video"
+          data-testid="play-button"
+          className="flex items-center gap-2 px-6 py-3 bg-gradient-to-br from-primary to-primary-container text-white rounded-xl font-bold hover:scale-[1.02] transition-transform whitespace-nowrap"
+        >
+          <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M8 5v14l11-7z" />
+          </svg>
+          Play Lesson
         </button>
       </div>
     </div>

--- a/src/components/MiniPlayer.tsx
+++ b/src/components/MiniPlayer.tsx
@@ -19,14 +19,14 @@ export default function MiniPlayer({
   seekToTime,
   onSeekApplied,
 }: MiniPlayerProps) {
-  const iframeRef = useRef<HTMLIFrameElement>(null)
+  const containerRef = useRef<HTMLDivElement>(null)
   const playerRef = useRef<YT.Player | null>(null)
   const pollIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
-  const onTimeUpdateRef = useRef(onTimeUpdate)
-  onTimeUpdateRef.current = onTimeUpdate
+  const configureIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
 
   useEffect(() => {
     let destroyed = false
+    const prevReady = window.onYouTubeIframeAPIReady
 
     function startPolling(player: YT.Player) {
       if (pollIntervalRef.current) return
@@ -34,7 +34,7 @@ export default function MiniPlayer({
         if (destroyed) return
         const current = player.getCurrentTime()
         const total = player.getDuration()
-        if (total > 0) onTimeUpdateRef.current?.(current, total)
+        if (total > 0) onTimeUpdate?.(current, total)
       }, 250)
     }
 
@@ -45,10 +45,44 @@ export default function MiniPlayer({
       }
     }
 
+    function stopConfigureRetry() {
+      if (configureIntervalRef.current) {
+        clearInterval(configureIntervalRef.current)
+        configureIntervalRef.current = null
+      }
+    }
+
+    function configureIframe(player: YT.Player) {
+      const iframe = player.getIframe()
+      iframe.className = 'w-full h-full'
+      iframe.setAttribute('title', title)
+      iframe.setAttribute('data-testid', 'mini-player-iframe')
+    }
+
+    function tryConfigureIframe(player: YT.Player): boolean {
+      try {
+        configureIframe(player)
+        return true
+      } catch {
+        return false
+      }
+    }
+
     function initPlayer() {
-      if (!iframeRef.current) return
-      const player = new window.YT.Player(iframeRef.current, {
+      if (!containerRef.current) return
+
+      const player = new window.YT.Player(containerRef.current, {
+        videoId: youtubeId,
+        playerVars: {
+          autoplay: 1,
+          rel: 0,
+          modestbranding: 1,
+        },
         events: {
+          onReady(event: YT.PlayerEvent) {
+            configureIframe(event.target)
+            event.target.playVideo()
+          },
           onStateChange(event: YT.OnStateChangeEvent) {
             if (event.data === window.YT.PlayerState.PLAYING) {
               startPolling(player)
@@ -56,19 +90,27 @@ export default function MiniPlayer({
               stopPolling()
               if (event.data === window.YT.PlayerState.ENDED) {
                 const total = player.getDuration()
-                if (total > 0) onTimeUpdateRef.current?.(total, total)
+                if (total > 0) onTimeUpdate?.(total, total)
               }
             }
           },
         },
       })
       playerRef.current = player
+
+      if (!tryConfigureIframe(player)) {
+        configureIntervalRef.current = setInterval(() => {
+          if (destroyed) return
+          if (tryConfigureIframe(player)) {
+            stopConfigureRetry()
+          }
+        }, 200)
+      }
     }
 
     if (window.YT?.Player) {
       initPlayer()
     } else {
-      const prevReady = window.onYouTubeIframeAPIReady
       window.onYouTubeIframeAPIReady = () => {
         prevReady?.()
         if (!destroyed) initPlayer()
@@ -82,37 +124,35 @@ export default function MiniPlayer({
 
     return () => {
       destroyed = true
+      window.onYouTubeIframeAPIReady = prevReady
       stopPolling()
+      stopConfigureRetry()
       playerRef.current?.destroy()
       playerRef.current = null
     }
-  }, [youtubeId])
+  }, [onTimeUpdate, title, youtubeId])
 
   useEffect(() => {
-    if (seekToTime == null || !playerRef.current) return
-    playerRef.current.seekTo(seekToTime, true)
+    const player = playerRef.current
+    if (seekToTime == null || !player || typeof player.seekTo !== 'function') return
+    player.seekTo(seekToTime, true)
     onSeekApplied?.()
   }, [onSeekApplied, seekToTime])
 
   function handleClose() {
-    playerRef.current?.pauseVideo()
+    const player = playerRef.current
+    if (player && typeof player.pauseVideo === 'function') {
+      player.pauseVideo()
+    }
     onClose()
   }
 
   return (
     <div
       data-testid="mini-player"
-      className="fixed bottom-4 right-4 z-50 w-80 aspect-video shadow-2xl rounded-xl overflow-hidden bg-black"
+      className="fixed bottom-4 right-4 z-50 w-80 aspect-video shadow-2xl rounded-xl overflow-hidden bg-black md:bottom-auto md:top-20"
     >
-      <iframe
-        ref={iframeRef}
-        src={`https://www.youtube.com/embed/${youtubeId}?autoplay=1&enablejsapi=1&rel=0&modestbranding=1`}
-        className="w-full h-full"
-        allow="autoplay; encrypted-media; fullscreen"
-        allowFullScreen
-        title={title}
-        data-testid="mini-player-iframe"
-      />
+      <div ref={containerRef} className="w-full h-full" />
       <button
         onClick={handleClose}
         aria-label="Close mini player"

--- a/src/components/PlayerClient.tsx
+++ b/src/components/PlayerClient.tsx
@@ -48,6 +48,8 @@ export default function PlayerClient({ video }: { video: Video }) {
   function handleClose() {
     setIsMiniPlayerOpen(false)
     setPlaybackTime({ current: 0, duration: 0 })
+    setActiveCueIndex(0)
+    setRequestedSeekTime(null)
   }
 
   useEffect(() => {
@@ -132,7 +134,7 @@ export default function PlayerClient({ video }: { video: Video }) {
             </button>
           </div>
 
-          <div className="flex-1 overflow-y-auto p-4 space-y-3">
+          <div className={`flex-1 overflow-y-auto p-4 space-y-3 ${isMiniPlayerOpen ? 'pb-52' : ''}`}>
             {activeTab === 'transcript' && (
               <>
                 {loadingTranscript && (

--- a/src/components/__tests__/LessonHero.test.tsx
+++ b/src/components/__tests__/LessonHero.test.tsx
@@ -44,12 +44,4 @@ describe('LessonHero', () => {
     fireEvent.click(screen.getByTestId('play-button'))
     expect(onPlay).toHaveBeenCalledTimes(1)
   })
-
-  it('calls onPlay when the hero area is clicked', () => {
-    const onPlay = jest.fn()
-    render(<LessonHero video={mockVideo} onPlay={onPlay} />)
-    fireEvent.click(screen.getByTestId('hero-play-area'))
-    expect(onPlay).toHaveBeenCalled()
-  })
-
 })

--- a/src/components/__tests__/MiniPlayer.test.tsx
+++ b/src/components/__tests__/MiniPlayer.test.tsx
@@ -2,34 +2,55 @@ import { render, screen, fireEvent, act } from '@testing-library/react'
 import MiniPlayer from '../MiniPlayer'
 
 let capturedOnStateChange: ((event: { data: number }) => void) | null = null
+let mockIframe: HTMLIFrameElement
 
 const mockGetCurrentTime = jest.fn().mockReturnValue(90)
 const mockGetDuration = jest.fn().mockReturnValue(300)
 const mockSeekTo = jest.fn()
 const mockDestroy = jest.fn()
 const mockPauseVideo = jest.fn()
+const mockPlayVideo = jest.fn()
 
 beforeEach(() => {
   jest.useFakeTimers()
   capturedOnStateChange = null
+  mockIframe = document.createElement('iframe')
   mockGetCurrentTime.mockReturnValue(90)
   mockGetDuration.mockReturnValue(300)
   mockSeekTo.mockReset()
   mockDestroy.mockReset()
   mockPauseVideo.mockReset()
+  mockPlayVideo.mockReset()
 
   Object.defineProperty(window, 'YT', {
     value: {
-      Player: jest.fn().mockImplementation((_el: unknown, opts: { events: { onStateChange: (e: { data: number }) => void } }) => {
-        capturedOnStateChange = opts.events.onStateChange
-        return {
-          getCurrentTime: mockGetCurrentTime,
-          getDuration: mockGetDuration,
-          seekTo: mockSeekTo,
-          destroy: mockDestroy,
-          pauseVideo: mockPauseVideo,
+      Player: jest.fn().mockImplementation(
+        (
+          _el: unknown,
+          opts: {
+            events: { onReady?: (event: YT.PlayerEvent) => void; onStateChange: (e: { data: number }) => void }
+          }
+        ) => {
+          capturedOnStateChange = opts.events.onStateChange
+          opts.events.onReady?.(
+            {
+              target: {
+                getIframe: () => mockIframe,
+                playVideo: mockPlayVideo,
+              },
+            } as unknown as YT.PlayerEvent
+          )
+          return {
+            getCurrentTime: mockGetCurrentTime,
+            getDuration: mockGetDuration,
+            seekTo: mockSeekTo,
+            destroy: mockDestroy,
+            pauseVideo: mockPauseVideo,
+            playVideo: mockPlayVideo,
+            getIframe: () => mockIframe,
+          }
         }
-      }),
+      ),
       PlayerState: { PLAYING: 1, PAUSED: 2, ENDED: 0, BUFFERING: 3, CUED: 5 },
     },
     writable: true,
@@ -43,19 +64,26 @@ afterEach(() => {
 })
 
 describe('MiniPlayer', () => {
-  it('renders the iframe with correct YouTube embed src', () => {
+  it('initializes YT player with video id and player vars', () => {
     render(<MiniPlayer youtubeId="abc123" title="My Video" onClose={jest.fn()} />)
-    const iframe = screen.getByTestId('mini-player-iframe')
-    expect(iframe).toHaveAttribute(
-      'src',
-      'https://www.youtube.com/embed/abc123?autoplay=1&enablejsapi=1&rel=0&modestbranding=1'
+    expect(window.YT.Player).toHaveBeenCalledWith(
+      expect.any(HTMLDivElement),
+      expect.objectContaining({
+        videoId: 'abc123',
+        playerVars: expect.objectContaining({
+          autoplay: 1,
+          rel: 0,
+          modestbranding: 1,
+        }),
+      })
     )
   })
 
-  it('renders the iframe with the correct title', () => {
+  it('sets iframe attributes on player ready', () => {
     render(<MiniPlayer youtubeId="abc123" title="My Video" onClose={jest.fn()} />)
-    const iframe = screen.getByTestId('mini-player-iframe')
-    expect(iframe).toHaveAttribute('title', 'My Video')
+    expect(mockIframe).toHaveAttribute('title', 'My Video')
+    expect(mockIframe).toHaveAttribute('data-testid', 'mini-player-iframe')
+    expect(mockPlayVideo).toHaveBeenCalledTimes(1)
   })
 
   it('calls onClose when the close button is clicked', () => {

--- a/tests/e2e/pages/PlayerPage.ts
+++ b/tests/e2e/pages/PlayerPage.ts
@@ -10,16 +10,28 @@ import { expect, type Page, type Locator } from '@playwright/test'
 export class PlayerPage {
   readonly page: Page
   readonly playerClient: Locator
-  readonly transcriptPanel: Locator
   readonly transcriptTab: Locator
   readonly vocabTab: Locator
+  readonly playButton: Locator
+  readonly miniPlayer: Locator
+  readonly miniPlayerClose: Locator
+  readonly miniPlayerIframe: Locator
+  readonly playbackProgress: Locator
+  readonly progressBarFill: Locator
+  readonly currentTime: Locator
 
   constructor(page: Page) {
     this.page = page
     this.playerClient = page.getByTestId('player-client')
-    this.transcriptPanel = page.getByTestId('tab-transcript')
     this.transcriptTab = page.getByTestId('tab-transcript')
     this.vocabTab = page.getByTestId('tab-vocabulary')
+    this.playButton = page.getByTestId('play-button')
+    this.miniPlayer = page.getByTestId('mini-player')
+    this.miniPlayerClose = page.getByTestId('mini-player-close')
+    this.miniPlayerIframe = page.getByTestId('mini-player-iframe')
+    this.playbackProgress = page.getByTestId('playback-progress')
+    this.progressBarFill = page.getByTestId('progress-bar-fill')
+    this.currentTime = page.getByTestId('current-time')
   }
 
   /** Navigates to the player page for the given video id and waits for the player client to attach. */
@@ -42,5 +54,22 @@ export class PlayerPage {
   /** Clicks the Transcript tab. */
   async switchToTranscriptTab(): Promise<void> {
     await this.transcriptTab.click()
+  }
+
+  async clickPlay(): Promise<void> {
+    await this.playButton.click()
+  }
+
+  async closeMiniPlayer(): Promise<void> {
+    await this.miniPlayerClose.click()
+  }
+
+  async assertMiniPlayerOpen(): Promise<void> {
+    await expect(this.miniPlayer).toBeVisible()
+    await expect(this.miniPlayerIframe).toBeVisible()
+  }
+
+  async assertMiniPlayerClosed(): Promise<void> {
+    await expect(this.miniPlayer).toBeHidden()
   }
 }

--- a/tests/e2e/player.spec.ts
+++ b/tests/e2e/player.spec.ts
@@ -1,0 +1,121 @@
+import { test, expect, type Page } from '@playwright/test'
+import { PlayerPage } from './pages/PlayerPage'
+
+const MOCK_VIDEO = {
+  id: 'player-e2e-video-1',
+  youtube_url: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+  youtube_id: 'dQw4w9WgXcQ',
+  title: 'Rick Astley - Never Gonna Give You Up',
+  author_name: 'Rick Astley',
+  thumbnail_url: 'https://img.youtube.com/vi/dQw4w9WgXcQ/0.jpg',
+  transcript_path: '/tmp/test/transcripts/player-e2e-video-1.srt',
+  transcript_format: 'srt',
+  tags: ['english', 'music'],
+  created_at: '2024-01-01T00:00:00.000Z',
+  updated_at: '2024-01-01T00:00:00.000Z',
+}
+
+const MOCK_CUES = [
+  {
+    index: 1,
+    startTime: '00:00:01.000',
+    endTime: '00:00:04.000',
+    text: 'Never gonna give you up',
+  },
+  {
+    index: 2,
+    startTime: '00:00:05.000',
+    endTime: '00:00:08.000',
+    text: 'Never gonna let you down',
+  },
+]
+
+function parseClock(clock: string): number {
+  const [minutes, seconds] = clock.split(':').map(Number)
+  return minutes * 60 + seconds
+}
+
+async function mockPlayerRoutes(page: Page): Promise<void> {
+  await page.route(`**/api/videos/${MOCK_VIDEO.id}`, async route => {
+    await route.fulfill({ json: MOCK_VIDEO })
+  })
+
+  await page.route(`**/api/videos/${MOCK_VIDEO.id}/transcript`, async route => {
+    await route.fulfill({ json: { cues: MOCK_CUES } })
+  })
+}
+
+test.describe('Player + mini-player workflow', () => {
+  test.use({ viewport: { width: 1280, height: 900 } })
+
+  test('opens player, plays, seeks, syncs transcript/progress, closes and reopens cleanly', async ({ page }) => {
+    test.setTimeout(120_000)
+    const consoleErrors: string[] = []
+    const pageErrors: string[] = []
+    page.on('console', msg => {
+      if (msg.type() === 'error') {
+        consoleErrors.push(msg.text())
+      }
+    })
+    page.on('pageerror', error => {
+      pageErrors.push(error.message)
+    })
+
+    await mockPlayerRoutes(page)
+
+    const player = new PlayerPage(page)
+    await player.navigateTo(MOCK_VIDEO.id)
+    await player.assertLoaded()
+
+    await expect(page.getByRole('button', { name: 'Save Lesson' })).toHaveCount(0)
+    await expect(player.playButton).toContainText('Play Lesson')
+
+    await player.clickPlay()
+    await player.assertMiniPlayerOpen()
+    await expect(player.playbackProgress).toBeVisible()
+
+    await page.waitForFunction(
+      () => {
+        const duration = document.querySelector('[data-testid="duration"]')?.textContent
+        return duration !== undefined && duration !== null && duration !== '0:00'
+      },
+      undefined,
+      { timeout: 45_000 }
+    )
+
+    const currentTimeBeforeSeek = await player.currentTime.innerText()
+    const duration = await page.getByTestId('duration').innerText()
+    const fillWidth = await player.progressBarFill.evaluate(el =>
+      window.getComputedStyle(el).getPropertyValue('width')
+    )
+    const containerWidth = await player.playbackProgress.evaluate(el => {
+      const bar = el.querySelector('[data-testid="progress-bar-fill"]')?.parentElement
+      return bar ? window.getComputedStyle(bar).getPropertyValue('width') : '0'
+    })
+
+    const currentSeconds = parseClock(currentTimeBeforeSeek)
+    const durationSeconds = parseClock(duration)
+    const fillPx = Number.parseFloat(fillWidth)
+    const totalPx = Number.parseFloat(containerWidth)
+    const barPct = totalPx > 0 ? (fillPx / totalPx) * 100 : 0
+    const expectedPct = durationSeconds > 0 ? (currentSeconds / durationSeconds) * 100 : 0
+
+    expect(durationSeconds).toBeGreaterThan(0)
+    expect(Math.abs(barPct - expectedPct)).toBeLessThan(8)
+
+    await page.getByTestId('cue-1').click()
+    await expect(page.getByTestId('cue-1')).toHaveClass(/border-primary/)
+
+    await player.closeMiniPlayer()
+    await player.assertMiniPlayerClosed()
+    await expect(player.playbackProgress).not.toBeVisible()
+
+    await player.clickPlay()
+    await player.assertMiniPlayerOpen()
+    await expect(page.getByTestId('cue-0')).toHaveClass(/border-primary/)
+    await expect(page.getByTestId('cue-1')).not.toHaveClass(/border-primary/)
+
+    expect(consoleErrors).toEqual([])
+    expect(pageErrors).toEqual([])
+  })
+})


### PR DESCRIPTION
## Summary\n- refactor MiniPlayer to container-based YT player init with safer lifecycle guards\n- replace Save Lesson with Play Lesson CTA and reset transcript cue state on close\n- add player e2e workflow spec plus PlayerPage page-object enhancements\n\n## Validation\n- pnpm build\n- pnpm test\n- pnpm test:e2e tests/e2e/player.spec.ts\n- Playwright CLI manual checks for open/play/seek/close/reopen flow