### PR TITLE
feat: local video playback foundation (#138)

### DIFF
--- a/src/app/api/videos/[id]/stream/__tests__/route.test.ts
+++ b/src/app/api/videos/[id]/stream/__tests__/route.test.ts
@@ -1,0 +1,177 @@
+// @jest-environment node
+
+// Polyfill ReadableStream for Jest node environment
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { ReadableStream: WebReadableStream } = require('node:stream/web')
+if (typeof global.ReadableStream === 'undefined') {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ;(global as any).ReadableStream = WebReadableStream
+}
+
+import { videoStore } from '@/lib/server/composition'
+
+jest.mock('@/lib/server/composition', () => ({
+  videoStore: { getById: jest.fn() },
+}))
+
+jest.mock('fs', () => ({
+  existsSync: jest.fn(),
+  statSync: jest.fn(),
+  createReadStream: jest.fn(),
+}))
+
+jest.mock('next/server', () => {
+  class MockNextResponse {
+    status: number
+    body: unknown
+    headers: { get: (key: string) => string | null }
+
+    constructor(
+      body: unknown,
+      init?: { status?: number; headers?: Record<string, string> }
+    ) {
+      this.body = body
+      this.status = init?.status ?? 200
+      const headersMap: Record<string, string> = {}
+      for (const [k, v] of Object.entries(init?.headers ?? {})) {
+        headersMap[k.toLowerCase()] = v
+      }
+      this.headers = {
+        get: (key: string) => headersMap[key.toLowerCase()] ?? null,
+      }
+    }
+
+    static json(data: unknown, init?: { status?: number }) {
+      return new MockNextResponse(data, init)
+    }
+  }
+  return { NextResponse: MockNextResponse }
+})
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const fsMock = require('fs') as {
+  existsSync: jest.Mock
+  statSync: jest.Mock
+  createReadStream: jest.Mock
+}
+
+const mockGetById = videoStore.getById as jest.Mock
+
+const mockLocalVideo = {
+  id: 'video-1',
+  source_type: 'local',
+  local_video_path: 'videos/test.mp4',
+  title: 'Test Video',
+  youtube_url: '',
+  youtube_id: '',
+  author_name: 'Tester',
+  thumbnail_url: '',
+  transcript_path: '',
+  transcript_format: 'srt',
+  tags: [],
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+}
+
+function makeRequest(headers: Record<string, string> = {}): Request {
+  return {
+    headers: {
+      get: (key: string) => headers[key.toLowerCase()] ?? null,
+    },
+  } as unknown as Request
+}
+
+// Import route after mocks are set up
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { GET } = require('../route') as { GET: typeof import('../route').GET }
+
+describe('GET /api/videos/[id]/stream', () => {
+  beforeEach(() => {
+    const mockStream = {
+      on: jest.fn().mockReturnThis(),
+    }
+    fsMock.existsSync.mockReturnValue(true)
+    fsMock.statSync.mockReturnValue({ size: 1000 })
+    fsMock.createReadStream.mockReturnValue(mockStream)
+  })
+
+  afterEach(() => jest.clearAllMocks())
+
+  it('returns 404 if video not found', async () => {
+    mockGetById.mockReturnValue(undefined)
+    const res = await GET(makeRequest(), { params: Promise.resolve({ id: 'video-1' }) })
+    expect(res.status).toBe(404)
+  })
+
+  it('returns 404 if video has no local_video_path', async () => {
+    mockGetById.mockReturnValue({
+      ...mockLocalVideo,
+      source_type: 'youtube',
+      local_video_path: null,
+    })
+    const res = await GET(makeRequest(), { params: Promise.resolve({ id: 'video-1' }) })
+    expect(res.status).toBe(404)
+  })
+
+  it('returns 404 if file does not exist on disk', async () => {
+    mockGetById.mockReturnValue(mockLocalVideo)
+    fsMock.existsSync.mockReturnValue(false)
+    const res = await GET(makeRequest(), { params: Promise.resolve({ id: 'video-1' }) })
+    expect(res.status).toBe(404)
+  })
+
+  it('returns 200 with correct content-type for mp4', async () => {
+    mockGetById.mockReturnValue(mockLocalVideo)
+    const res = await GET(makeRequest(), { params: Promise.resolve({ id: 'video-1' }) })
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toBe('video/mp4')
+  })
+
+  it('returns 200 with accept-ranges header', async () => {
+    mockGetById.mockReturnValue(mockLocalVideo)
+    const res = await GET(makeRequest(), { params: Promise.resolve({ id: 'video-1' }) })
+    expect(res.headers.get('accept-ranges')).toBe('bytes')
+  })
+
+  it('returns 200 with correct content-type for webm', async () => {
+    mockGetById.mockReturnValue({
+      ...mockLocalVideo,
+      local_video_path: 'videos/test.webm',
+    })
+    const res = await GET(makeRequest(), { params: Promise.resolve({ id: 'video-1' }) })
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toBe('video/webm')
+  })
+
+  it('returns 200 with correct content-type for mov', async () => {
+    mockGetById.mockReturnValue({
+      ...mockLocalVideo,
+      local_video_path: 'videos/test.mov',
+    })
+    const res = await GET(makeRequest(), { params: Promise.resolve({ id: 'video-1' }) })
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toBe('video/quicktime')
+  })
+
+  it('returns 206 with correct range headers when Range header provided', async () => {
+    mockGetById.mockReturnValue(mockLocalVideo)
+    const res = await GET(
+      makeRequest({ range: 'bytes=0-499' }),
+      { params: Promise.resolve({ id: 'video-1' }) }
+    )
+    expect(res.status).toBe(206)
+    expect(res.headers.get('content-range')).toBe('bytes 0-499/1000')
+    expect(res.headers.get('content-length')).toBe('500')
+    expect(res.headers.get('accept-ranges')).toBe('bytes')
+  })
+
+  it('returns 206 with end calculated from file size when end omitted in range', async () => {
+    mockGetById.mockReturnValue(mockLocalVideo)
+    const res = await GET(
+      makeRequest({ range: 'bytes=500-' }),
+      { params: Promise.resolve({ id: 'video-1' }) }
+    )
+    expect(res.status).toBe(206)
+    expect(res.headers.get('content-range')).toBe('bytes 500-999/1000')
+  })
+})

--- a/src/app/api/videos/[id]/stream/route.ts
+++ b/src/app/api/videos/[id]/stream/route.ts
@@ -1,0 +1,93 @@
+export const runtime = 'nodejs'
+
+import { NextResponse } from 'next/server'
+import fs from 'fs'
+import path from 'path'
+import { videoStore } from '@/lib/server/composition'
+
+const MIME_TYPES: Record<string, string> = {
+  mp4: 'video/mp4',
+  webm: 'video/webm',
+  mov: 'video/quicktime',
+}
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params
+    const video = videoStore.getById(id)
+
+    if (!video || !video.local_video_path) {
+      return new NextResponse('Not Found', { status: 404 })
+    }
+
+    const dataDir =
+      process.env.LINGOFLOW_DATA_DIR ?? path.join(process.cwd(), '.lingoflow-data')
+    const filePath = path.isAbsolute(video.local_video_path)
+      ? video.local_video_path
+      : path.join(dataDir, video.local_video_path)
+
+    if (!fs.existsSync(filePath)) {
+      return new NextResponse('Not Found', { status: 404 })
+    }
+
+    const ext = path.extname(filePath).slice(1).toLowerCase()
+    const contentType = MIME_TYPES[ext] ?? 'application/octet-stream'
+    const fileSize = fs.statSync(filePath).size
+
+    const rangeHeader = request.headers.get('range')
+
+    if (rangeHeader) {
+      const [startStr, endStr] = rangeHeader.replace('bytes=', '').split('-')
+      const start = parseInt(startStr, 10)
+      const end = endStr ? parseInt(endStr, 10) : fileSize - 1
+      const chunkSize = end - start + 1
+
+      const nodeStream = fs.createReadStream(filePath, { start, end })
+      const webStream = new ReadableStream({
+        start(controller) {
+          nodeStream.on('data', (chunk) =>
+            controller.enqueue(chunk instanceof Buffer ? chunk : Buffer.from(chunk))
+          )
+          nodeStream.on('end', () => controller.close())
+          nodeStream.on('error', (err) => controller.error(err))
+        },
+      })
+
+      return new NextResponse(webStream, {
+        status: 206,
+        headers: {
+          'Content-Range': `bytes ${start}-${end}/${fileSize}`,
+          'Accept-Ranges': 'bytes',
+          'Content-Length': String(chunkSize),
+          'Content-Type': contentType,
+        },
+      })
+    }
+
+    const nodeStream = fs.createReadStream(filePath)
+    const webStream = new ReadableStream({
+      start(controller) {
+        nodeStream.on('data', (chunk) =>
+          controller.enqueue(chunk instanceof Buffer ? chunk : Buffer.from(chunk))
+        )
+        nodeStream.on('end', () => controller.close())
+        nodeStream.on('error', (err) => controller.error(err))
+      },
+    })
+
+    return new NextResponse(webStream, {
+      status: 200,
+      headers: {
+        'Content-Length': String(fileSize),
+        'Content-Type': contentType,
+        'Accept-Ranges': 'bytes',
+      },
+    })
+  } catch (error) {
+    console.error('GET video stream error:', error)
+    return new NextResponse('Internal Server Error', { status: 500 })
+  }
+}

--- a/src/components/LocalVideoPlayer.tsx
+++ b/src/components/LocalVideoPlayer.tsx
@@ -1,0 +1,89 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+
+interface LocalVideoPlayerProps {
+  videoId: string
+  title: string
+  onClose: () => void
+  onTimeUpdate?: (currentTime: number, duration: number) => void
+  seekToTime?: number | null
+  onSeekApplied?: () => void
+}
+
+export default function LocalVideoPlayer({
+  videoId,
+  title,
+  onClose,
+  onTimeUpdate,
+  seekToTime,
+  onSeekApplied,
+}: LocalVideoPlayerProps) {
+  const videoRef = useRef<HTMLVideoElement>(null)
+  const pollIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
+
+  function startPolling() {
+    if (pollIntervalRef.current) return
+    pollIntervalRef.current = setInterval(() => {
+      const el = videoRef.current
+      if (el && el.duration > 0) {
+        onTimeUpdate?.(el.currentTime, el.duration)
+      }
+    }, 250)
+  }
+
+  function stopPolling() {
+    if (pollIntervalRef.current) {
+      clearInterval(pollIntervalRef.current)
+      pollIntervalRef.current = null
+    }
+  }
+
+  useEffect(() => {
+    return () => stopPolling()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  useEffect(() => {
+    const el = videoRef.current
+    if (seekToTime == null || !el) return
+    el.currentTime = seekToTime
+    onSeekApplied?.()
+  }, [seekToTime, onSeekApplied])
+
+  function handleClose() {
+    videoRef.current?.pause()
+    onClose()
+  }
+
+  return (
+    <div
+      data-testid="mini-player"
+      className="fixed bottom-4 right-4 z-50 w-80 aspect-video shadow-2xl rounded-xl overflow-hidden bg-black md:bottom-auto md:top-20"
+    >
+      <video
+        ref={videoRef}
+        src={`/api/videos/${videoId}/stream`}
+        title={title}
+        data-testid="local-video"
+        className="w-full h-full"
+        autoPlay
+        onPlay={startPolling}
+        onPause={stopPolling}
+        onEnded={() => {
+          stopPolling()
+          const el = videoRef.current
+          if (el) onTimeUpdate?.(el.duration, el.duration)
+        }}
+      />
+      <button
+        onClick={handleClose}
+        aria-label="Close mini player"
+        data-testid="mini-player-close"
+        className="absolute top-2 right-2 flex items-center justify-center w-7 h-7 rounded-full bg-black/60 hover:bg-black/80 text-white text-sm transition"
+      >
+        ✕
+      </button>
+    </div>
+  )
+}

--- a/src/components/PlayerClient.tsx
+++ b/src/components/PlayerClient.tsx
@@ -5,6 +5,7 @@ import { Video } from '@/lib/videos'
 import { TranscriptCue } from '@/lib/parse-transcript'
 import LessonHero from '@/components/LessonHero'
 import MiniPlayer from '@/components/MiniPlayer'
+import LocalVideoPlayer from '@/components/LocalVideoPlayer'
 import PlaybackProgress from '@/components/PlaybackProgress'
 
 interface WordCard {
@@ -238,14 +239,27 @@ export default function PlayerClient({ video }: { video: Video }) {
       </section>
 
       {isMiniPlayerOpen && (
-        <MiniPlayer
-          youtubeId={video.youtube_id}
-          title={video.title}
-          onClose={handleClose}
-          onTimeUpdate={handleTimeUpdate}
-          seekToTime={requestedSeekTime}
-          onSeekApplied={() => setRequestedSeekTime(null)}
-        />
+        video.source_type === 'local'
+          ? (
+            <LocalVideoPlayer
+              videoId={video.id}
+              title={video.title}
+              onClose={handleClose}
+              onTimeUpdate={handleTimeUpdate}
+              seekToTime={requestedSeekTime}
+              onSeekApplied={() => setRequestedSeekTime(null)}
+            />
+          )
+          : (
+            <MiniPlayer
+              youtubeId={video.youtube_id}
+              title={video.title}
+              onClose={handleClose}
+              onTimeUpdate={handleTimeUpdate}
+              seekToTime={requestedSeekTime}
+              onSeekApplied={() => setRequestedSeekTime(null)}
+            />
+          )
       )}
     </div>
   )

--- a/src/components/__tests__/PlayerClient.test.tsx
+++ b/src/components/__tests__/PlayerClient.test.tsx
@@ -14,6 +14,7 @@ const mockVideo: Video = {
   tags: ['french'],
   created_at: '2026-01-01T00:00:00Z',
   updated_at: '2026-01-01T00:00:00Z',
+  source_type: 'youtube',
 }
 
 // Mock MiniPlayer to expose onTimeUpdate for testing.
@@ -21,6 +22,18 @@ const mockVideo: Video = {
 var mockCapturedOnTimeUpdate: ((current: number, duration: number) => void) | undefined
 
 jest.mock('@/components/MiniPlayer', () => ({
+  __esModule: true,
+  default: ({ onClose, onTimeUpdate }: { onClose: () => void; onTimeUpdate?: (c: number, d: number) => void }) => {
+    mockCapturedOnTimeUpdate = onTimeUpdate
+    return (
+      <div data-testid="mini-player">
+        <button data-testid="mini-player-close" onClick={onClose}>Close</button>
+      </div>
+    )
+  },
+}))
+
+jest.mock('@/components/LocalVideoPlayer', () => ({
   __esModule: true,
   default: ({ onClose, onTimeUpdate }: { onClose: () => void; onTimeUpdate?: (c: number, d: number) => void }) => {
     mockCapturedOnTimeUpdate = onTimeUpdate
@@ -120,6 +133,18 @@ describe('PlayerClient', () => {
 
     fireEvent.click(screen.getByTestId('mini-player-close'))
     expect(screen.queryByTestId('playback-progress')).not.toBeInTheDocument()
+  })
+
+  it('renders mini-player for local video source_type', async () => {
+    const localVideo: Video = {
+      ...mockVideo,
+      source_type: 'local',
+      local_video_path: 'videos/test.mp4',
+      local_video_filename: 'test.mp4',
+    }
+    render(<PlayerClient video={localVideo} />)
+    fireEvent.click(screen.getByTestId('play-button'))
+    expect(screen.getByTestId('mini-player')).toBeInTheDocument()
   })
 })
 

--- a/src/lib/__tests__/videos.test.ts
+++ b/src/lib/__tests__/videos.test.ts
@@ -17,6 +17,7 @@ const validVideo: Video = {
   transcript_path: '/transcripts/v1.vtt',
   transcript_format: 'vtt',
   tags: ['tag1', 'tag2'],
+  source_type: 'youtube',
   created_at: '2024-01-01T00:00:00.000Z',
   updated_at: '2024-01-01T00:00:00.000Z',
 }

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -5,6 +5,7 @@ import path from 'path'
 export function ensureDataDirs(dataDir: string): void {
   fs.mkdirSync(dataDir, { recursive: true })
   fs.mkdirSync(path.join(dataDir, 'transcripts'), { recursive: true })
+  fs.mkdirSync(path.join(dataDir, 'videos'), { recursive: true })
 }
 
 export function openDb(dbPath: string): Database.Database {
@@ -29,4 +30,16 @@ export function initializeSchema(db: Database.Database): void {
       updated_at TEXT NOT NULL DEFAULT (datetime('now'))
     )
   `)
+
+  const addColumnIfMissing = (column: string, definition: string) => {
+    try {
+      db.exec(`ALTER TABLE videos ADD COLUMN ${column} ${definition}`)
+    } catch {
+      // Column already exists — ignore
+    }
+  }
+
+  addColumnIfMissing('source_type', "TEXT NOT NULL DEFAULT 'youtube'")
+  addColumnIfMissing('local_video_path', 'TEXT')
+  addColumnIfMissing('local_video_filename', 'TEXT')
 }

--- a/src/lib/video-store.ts
+++ b/src/lib/video-store.ts
@@ -13,10 +13,19 @@ interface VideoRow {
   tags: string
   created_at: string
   updated_at: string
+  source_type: string
+  local_video_path: string | null
+  local_video_filename: string | null
 }
 
 function rowToVideo(row: VideoRow): Video {
-  return { ...row, tags: JSON.parse(row.tags) }
+  return {
+    ...row,
+    tags: JSON.parse(row.tags) as string[],
+    source_type: ((row.source_type ?? 'youtube') as 'youtube' | 'local'),
+    local_video_path: row.local_video_path ?? null,
+    local_video_filename: row.local_video_filename ?? null,
+  }
 }
 
 export interface VideoStore {

--- a/src/lib/videos.ts
+++ b/src/lib/videos.ts
@@ -12,6 +12,9 @@ export const VideoSchema = z.object({
   tags: z.array(z.string()),
   created_at: z.string(),
   updated_at: z.string(),
+  source_type: z.enum(['youtube', 'local']).default('youtube'),
+  local_video_path: z.string().nullable().optional(),
+  local_video_filename: z.string().nullable().optional(),
 })
 
 export const InsertVideoParamsSchema = z.object({


### PR DESCRIPTION
## Summary

Implements [Issue #138](https://github.com/fperez08/lingoFlow/issues/138) — Local video playback foundation.

## Changes

### Data model
- Added `source_type` (`'youtube' | 'local'`, default `'youtube'`), `local_video_path`, and `local_video_filename` fields to `VideoSchema` and `Video` type
- Added idempotent `ALTER TABLE ADD COLUMN` migrations in `initializeSchema` (try/catch per column)
- Added `videos/` directory to `ensureDataDirs`
- Updated `VideoRow` interface and `rowToVideo` mapping in `SqliteVideoStore`

### Streaming API
- New `GET /api/videos/[id]/stream` route with HTTP Range request support (206 Partial Content)
- Resolves `local_video_path` relative to `LINGOFLOW_DATA_DIR`
- MIME type detection for `.mp4`, `.webm`, `.mov`
- Streams via `ReadableStream` wrapping Node.js `fs.createReadStream`

### Player
- New `LocalVideoPlayer` component: HTML5 `<video>` element pointing at `/api/videos/[id]/stream`, polling `onTimeUpdate` every 250ms, seek via `currentTime`
- `PlayerClient` now conditionally renders `LocalVideoPlayer` (when `source_type === 'local'`) vs `MiniPlayer` (YouTube)

### Tests
- 9 unit tests for stream route (mocking `fs`, `next/server`, composition)
- `PlayerClient` tests updated: added `source_type: 'youtube'` to mock, added test for local video rendering
- `videos.test.ts` updated: added `source_type: 'youtube'` to `validVideo` fixture

## Verification
- ✅ `pnpm build` passes (TypeScript clean, all routes compiled)
- ✅ `pnpm test` — 248/248 tests pass