### PR TITLE
feat: upload validation and size enforcement (#141)

### DIFF
--- a/src/app/api/videos/import/__tests__/route.test.ts
+++ b/src/app/api/videos/import/__tests__/route.test.ts
@@ -314,6 +314,53 @@ describe('POST /api/videos/import — local upload path', () => {
       expect.objectContaining({ author_name: '' })
     )
   })
+
+  it('returns 400 when video MIME type is not allowed', async () => {
+    const videoContent = Buffer.from('data')
+    const videoFile = Object.assign(
+      new File([videoContent], 'my-video.avi', { type: 'video/avi' }),
+      { arrayBuffer: async () => videoContent.buffer }
+    )
+    const transcriptFile = new File(['content'], 'transcript.srt', { type: 'text/plain' })
+    const fd = makeFormData({ video: videoFile, title: 'Test', transcript: transcriptFile })
+    const req = makeRequest(fd)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const res = await POST(req as any)
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.error).toMatch(/Unsupported format/)
+  })
+
+  it('returns 400 when video file exceeds 500 MB', async () => {
+    class OversizedFile extends File {
+      get size() { return 600_000_000 }
+    }
+    const videoFile = Object.assign(
+      new OversizedFile(['x'], 'big-video.mp4', { type: 'video/mp4' }),
+      { arrayBuffer: async () => Buffer.from('x').buffer }
+    )
+    const transcriptFile = new File(['content'], 'transcript.srt', { type: 'text/plain' })
+    const fd = makeFormData({ video: videoFile, title: 'Test', transcript: transcriptFile })
+    const req = makeRequest(fd)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const res = await POST(req as any)
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.error).toMatch(/500 MB/)
+  })
+
+  it('returns 400 when video is a WebM with unsupported extension alias', async () => {
+    const videoContent = Buffer.from('data')
+    const videoFile = Object.assign(
+      new File([videoContent], 'my-video.webm', { type: 'video/webm' }),
+      { arrayBuffer: async () => videoContent.buffer }
+    )
+    const fakeWebmVideo = { ...fakeLocalVideo, local_video_path: '/data/videos/local.webm' }
+    mockVideoService.importLocalVideo.mockResolvedValue(fakeWebmVideo)
+    const fd = makeLocalFormData({ video: videoFile, title: 'WebM Video' })
+    const req = makeRequest(fd)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const res = await POST(req as any)
+    expect(res.status).toBe(201)
+  })
 })
-
-

--- a/src/components/ImportVideoModal.tsx
+++ b/src/components/ImportVideoModal.tsx
@@ -151,7 +151,7 @@ export default function ImportVideoModal({ isOpen, onClose, onSuccess }: ImportV
                   id="videoFile"
                   data-testid="video-file-input"
                   type="file"
-                  accept="video/*,.mp4,.webm,.mov,.mkv"
+                  accept="video/mp4,video/webm,video/quicktime,.mp4,.webm,.mov"
                   onChange={(e) => setVideoFile(e.target.files?.[0] || null)}
                   disabled={isSubmitting}
                   className="w-full px-4 py-3 bg-surface-container-low dark:bg-slate-950/50 rounded-xl border border-outline-variant/30 dark:border-slate-700 text-on-surface dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-primary/20 transition-all duration-300 file:mr-3 file:py-1 file:px-3 file:rounded-lg file:border-0 file:text-sm file:font-bold file:bg-primary/10 file:text-primary"

--- a/src/hooks/__tests__/useImportVideoForm.test.ts
+++ b/src/hooks/__tests__/useImportVideoForm.test.ts
@@ -596,4 +596,70 @@ describe('useImportVideoForm', () => {
       expect(result.current.submitError).toBe('Transcript must contain at least 10 non-whitespace characters')
     })
   })
+
+  describe('local upload video validation', () => {
+    function makeTranscriptFile() {
+      return new File(['1\n00:00:01,000 --> 00:00:02,000\nBonjour'], 'transcript.srt', { type: 'text/plain' })
+    }
+
+    it('sets submitError when video MIME type is not allowed', async () => {
+      const { result } = renderForm()
+      const invalidFile = new File(['data'], 'video.avi', { type: 'video/avi' })
+      act(() => {
+        result.current.setImportMode('local')
+        result.current.setVideoFile(invalidFile)
+        result.current.setTitle('Test')
+        result.current.setTranscriptFile(makeTranscriptFile())
+      })
+      await act(async () => {
+        await result.current.handleSubmit({ preventDefault: jest.fn() } as unknown as React.FormEvent)
+      })
+      expect(result.current.submitError).toMatch(/Unsupported format/)
+    })
+
+    it('sets submitError when video file exceeds 500 MB', async () => {
+      const { result } = renderForm()
+      const oversizedFile = Object.defineProperty(
+        new File(['x'], 'video.mp4', { type: 'video/mp4' }),
+        'size',
+        { value: 600_000_000 }
+      )
+      act(() => {
+        result.current.setImportMode('local')
+        result.current.setVideoFile(oversizedFile)
+        result.current.setTitle('Test')
+        result.current.setTranscriptFile(makeTranscriptFile())
+      })
+      await act(async () => {
+        await result.current.handleSubmit({ preventDefault: jest.fn() } as unknown as React.FormEvent)
+      })
+      expect(result.current.submitError).toMatch(/500 MB/)
+    })
+
+    it('clears submitError for a valid MP4 file and proceeds', async () => {
+      ;(global.fetch as jest.Mock).mockResolvedValue({ ok: true, json: async () => ({}) })
+      const { result, onSuccess } = renderForm()
+      const videoContent = Buffer.from('fake-mp4')
+      const validFile = Object.assign(
+        new File([videoContent], 'video.mp4', { type: 'video/mp4' }),
+        { arrayBuffer: async () => videoContent.buffer }
+      )
+      const transcriptContent = '1\n00:00:01,000 --> 00:00:02,000\nBonjour'
+      const transcriptFile = Object.assign(
+        new File([transcriptContent], 'transcript.srt', { type: 'text/plain' }),
+        { arrayBuffer: async () => Buffer.from(transcriptContent).buffer }
+      )
+      act(() => {
+        result.current.setImportMode('local')
+        result.current.setVideoFile(validFile)
+        result.current.setTitle('My Video')
+        result.current.setTranscriptFile(transcriptFile)
+      })
+      await act(async () => {
+        await result.current.handleSubmit({ preventDefault: jest.fn() } as unknown as React.FormEvent)
+      })
+      expect(result.current.submitError).toBeNull()
+      expect(onSuccess).toHaveBeenCalled()
+    })
+  })
 })

--- a/src/hooks/useImportVideoForm.ts
+++ b/src/hooks/useImportVideoForm.ts
@@ -6,6 +6,7 @@ import {
   YoutubeMetadataError,
 } from '@/lib/youtube'
 import { detectPastedTranscriptFormat } from '@/lib/detect-transcript-format'
+import { ALLOWED_VIDEO_MIME_TYPES, MAX_VIDEO_SIZE_BYTES } from '@/lib/api-schemas'
 
 interface YoutubePreview {
   title: string
@@ -138,6 +139,14 @@ export function useImportVideoForm({
     if (importMode === 'local') {
       if (!videoFile) {
         setSubmitError('Video file is required')
+        return
+      }
+      if (!ALLOWED_VIDEO_MIME_TYPES.includes(videoFile.type as typeof ALLOWED_VIDEO_MIME_TYPES[number])) {
+        setSubmitError('Unsupported format. Please use MP4, WebM, or MOV.')
+        return
+      }
+      if (videoFile.size > MAX_VIDEO_SIZE_BYTES) {
+        setSubmitError('File is too large. Maximum size is 500 MB.')
         return
       }
       if (!title.trim()) {

--- a/src/lib/api-schemas.ts
+++ b/src/lib/api-schemas.ts
@@ -3,6 +3,13 @@ import { z } from 'zod'
 export const ALLOWED_TRANSCRIPT_FORMATS = ['srt', 'vtt', 'txt'] as const
 export type AllowedTranscriptFormat = typeof ALLOWED_TRANSCRIPT_FORMATS[number]
 
+export const ALLOWED_VIDEO_MIME_TYPES = ['video/mp4', 'video/webm', 'video/quicktime'] as const
+export type AllowedVideoMimeType = typeof ALLOWED_VIDEO_MIME_TYPES[number]
+
+export const ALLOWED_VIDEO_EXTENSIONS = ['.mp4', '.webm', '.mov'] as const
+
+export const MAX_VIDEO_SIZE_BYTES = 524_288_000 // 500 MB
+
 function getFileExtension(filename: string): string {
   return filename.split('.').pop()?.toLowerCase() || ''
 }
@@ -38,8 +45,19 @@ export const ImportVideoRequestSchema = z.object({
     .transform((v) => (typeof v === 'string' ? v : '')),
 })
 
+const videoFileSchema = z
+  .custom<File>(isFileLike, 'Video file is required')
+  .refine(
+    (f) => ALLOWED_VIDEO_MIME_TYPES.includes((f as File).type as AllowedVideoMimeType),
+    'Unsupported format. Allowed: MP4, WebM, MOV'
+  )
+  .refine(
+    (f) => (f as File).size <= MAX_VIDEO_SIZE_BYTES,
+    'File exceeds 500 MB limit'
+  )
+
 export const ImportLocalVideoRequestSchema = z.object({
-  video: z.custom<File>(isFileLike, 'Video file is required'),
+  video: videoFileSchema,
   title: z.preprocess(
     (v) => (typeof v === 'string' ? v.trim() : ''),
     z.string().min(1, 'Title is required')


### PR DESCRIPTION
## Summary

Implements upload validation and size enforcement for the local video import flow (closes #141).

## Changes

### `src/lib/api-schemas.ts`
- Export `ALLOWED_VIDEO_MIME_TYPES` (`video/mp4`, `video/webm`, `video/quicktime`)
- Export `ALLOWED_VIDEO_EXTENSIONS` (`.mp4`, `.webm`, `.mov`)
- Export `MAX_VIDEO_SIZE_BYTES` (500 MB = 524_288_000 bytes)
- Add `videoFileSchema` with Zod `.refine()` chains for MIME type and size
- Use `videoFileSchema` in `ImportLocalVideoRequestSchema` (replaces bare `z.custom`)

### `src/hooks/useImportVideoForm.ts`
- Import shared constants from `@/lib/api-schemas`
- Add pre-submit checks in `handleSubmit` for local mode: unsupported format → `submitError`, file too large → `submitError`

### `src/components/ImportVideoModal.tsx`
- Fix `accept` attribute on video file input: `video/mp4,video/webm,video/quicktime,.mp4,.webm,.mov`
- Removes `video/*` and `.mkv`

### Tests
- `src/app/api/videos/import/__tests__/route.test.ts`: 3 new tests (unsupported MIME → 400, oversized → 400, valid WebM → 201)
- `src/hooks/__tests__/useImportVideoForm.test.ts`: 3 new tests (invalid MIME sets error, oversized sets error, valid file succeeds)

## Validation
- `pnpm build` ✅
- `pnpm test` ✅ — 263 tests, 0 failures

Closes #141