### PR TITLE
feat: apply vocabulary across videos and remove player tab (#157)

### DIFF
--- a/docs/project-docs.md
+++ b/docs/project-docs.md
@@ -1,7 +1,7 @@
 # LingoFlow — Project Documentation Snapshot
 
 > **Purpose**: Reference for coding agents. Describes current implemented state only — not aspirational.
-> **Last updated**: auto-generated snapshot (2026-07, HEAD: feat/155-resize-play-cta).
+> **Last updated**: auto-generated snapshot (2026-07, HEAD: main).
 
 ---
 
@@ -24,27 +24,33 @@ src/
 │   │   │       ├── page.tsx              # Server component — delegates to PlayerLoader
 │   │   │       └── __tests__/page.test.tsx
 │   │   └── vocabulary/
-│   │       ├── page.tsx                  # Vocabulary browser (MOCK data only)
+│   │       ├── page.tsx                  # Vocabulary browser — MOCK_VOCAB only, NOT DB-wired
 │   │       └── __tests__/page.test.tsx
 │   └── api/
-│       └── videos/
-│           ├── route.ts                  # GET /api/videos
+│       ├── videos/
+│       │   ├── route.ts                  # GET /api/videos
+│       │   ├── __tests__/route.test.ts
+│       │   ├── import/
+│       │   │   ├── route.ts              # POST /api/videos/import (local video upload)
+│       │   │   └── __tests__/route.test.ts
+│       │   └── [id]/
+│       │       ├── route.ts             # GET / PATCH / DELETE /api/videos/:id
+│       │       ├── __tests__/route.test.ts
+│       │       ├── transcript/
+│       │       │   ├── route.ts         # GET /api/videos/:id/transcript → {cues[]}
+│       │       │   └── __tests__/route.test.ts
+│       │       ├── stream/
+│       │       │   ├── route.ts         # GET /api/videos/:id/stream (byte-range video)
+│       │       │   └── __tests__/route.test.ts
+│       │       └── thumbnail/
+│       │           ├── route.ts         # GET /api/videos/:id/thumbnail
+│       │           └── __tests__/route.test.ts
+│       └── vocabulary/
+│           ├── route.ts                 # GET /api/vocabulary → VocabEntry[]
 │           ├── __tests__/route.test.ts
-│           ├── import/
-│           │   ├── route.ts              # POST /api/videos/import (local video upload)
-│           │   └── __tests__/route.test.ts
-│           └── [id]/
-│               ├── route.ts             # GET / PATCH / DELETE /api/videos/:id
-│               ├── __tests__/route.test.ts
-│               ├── transcript/
-│               │   ├── route.ts         # GET /api/videos/:id/transcript → {cues[]}
-│               │   └── __tests__/route.test.ts
-│               ├── stream/
-│               │   ├── route.ts         # GET /api/videos/:id/stream (byte-range video)
-│               │   └── __tests__/route.test.ts
-│               └── thumbnail/
-│                   ├── route.ts         # GET /api/videos/:id/thumbnail
-│                   └── __tests__/route.test.ts
+│           └── [word]/
+│               ├── route.ts             # PATCH /api/vocabulary/:word → upsert status
+│               └── __tests__/route.test.ts
 ├── components/
 │   ├── PlayerClient.tsx                  # Main player page logic (client component)
 │   ├── PlayerLoader.tsx                  # Fetches video by id, renders PlayerClient
@@ -77,6 +83,7 @@ src/
 │   ├── useVideos.ts                      # React Query: GET /api/videos
 │   ├── useVideoMutations.ts              # deleteVideo + refreshVideos mutations
 │   ├── useImportVideoForm.ts             # Full form state for import modal
+│   ├── useVocabulary.ts                  # useVocabulary() + useUpdateWordStatus() — DB-backed, global
 │   └── __tests__/
 ├── lib/
 │   ├── api-schemas.ts                    # Zod schemas for API request bodies
@@ -84,15 +91,16 @@ src/
 │   ├── videos.ts                         # Zod schemas + TS types: Video, InsertVideoParams, etc.
 │   ├── video-store.ts                    # SqliteVideoStore — CRUD over the `videos` table
 │   ├── video-service.ts                  # VideoService — business logic (import, update, delete)
+│   ├── vocab-store.ts                    # SqliteVocabStore — CRUD over the `vocabulary` table
 │   ├── transcripts.ts                    # writeTranscript / deleteTranscript (filesystem I/O)
 │   ├── parse-transcript.ts               # parseSrt / parseVtt / parseTxt → TranscriptCue[]
 │   ├── tokenize-transcript.ts            # tokenizeCueText → WordToken[] | PunctToken[]
 │   ├── detect-transcript-format.ts       # Detects SRT/VTT/TXT from pasted content
 │   ├── video-files.ts                    # Video file I/O helpers
 │   ├── thumbnails.ts                     # generateThumbnail via ffmpeg
-│   ├── vocabulary.ts                     # MOCK_VOCAB data + VocabWord type (CEFR A1–C2)
+│   ├── vocabulary.ts                     # MOCK_VOCAB + VocabWord type (CEFR A1–C2) + VocabInfo interface
 │   └── server/
-│       └── composition.ts               # DI root — wires VideoService + SqliteVideoStore
+│       └── composition.ts               # DI root — wires VideoService + SqliteVideoStore + SqliteVocabStore
 tests/
 └── e2e/
     ├── *.spec.ts                         # Playwright E2E specs
@@ -135,7 +143,7 @@ page.tsx (Server Component)
               ├── PlaybackProgress    — shown only when miniplayer is open
               ├── Transcript / Vocabulary tab panel
               │     ├── TranscriptCue rows (clickable → seek + word sidebar)
-              │     └── Vocabulary word cards (add/master actions)
+              │     └── Vocabulary word cards (add/master — local state only)
               ├── LocalVideoPlayer    — mounted when isMiniPlayerOpen = true
               └── WordSidebar         — slide-over, mounted when selectedWord ≠ null
 ```
@@ -150,29 +158,21 @@ page.tsx (Server Component)
 
 ```ts
 interface LocalVideoPlayerProps {
-  videoId: string           // Used to build src: /api/videos/{videoId}/stream
-  title: string             // Native <video> title attribute
-  onClose: () => void       // Called when ✕ button clicked; pauses video first
-  onTimeUpdate?: (currentTime: number, duration: number) => void  // Polled every 250ms while playing
-  seekToTime?: number | null  // When non-null, sets videoRef.current.currentTime
-  onSeekApplied?: () => void  // Called immediately after seek is applied
+  videoId: string           // src: /api/videos/{videoId}/stream
+  title: string
+  onClose: () => void
+  onTimeUpdate?: (currentTime: number, duration: number) => void
+  seekToTime?: number | null
+  onSeekApplied?: () => void
 }
 ```
 
-### Internal state / refs
-
-| Ref | Type | Purpose |
-|---|---|---|
-| `videoRef` | `RefObject<HTMLVideoElement>` | Direct access to the `<video>` DOM element |
-| `pollIntervalRef` | `RefObject<ReturnType<setInterval>\|null>` | 250 ms polling interval handle |
-
 ### Behavior
 
-- **Polling**: Starts on `onPlay`, stops on `onPause`/`onEnded`. Calls `onTimeUpdate(currentTime, duration)` every 250ms.
-- **Seek**: `useEffect` on `seekToTime` — sets `el.currentTime = seekToTime` then fires `onSeekApplied()`.
-- **Close**: Pauses video then calls `onClose()`.
-- **No play/pause controls exposed** — the native `<video>` element handles its own controls bar (browser default). The component exposes **no imperative ref handle** (`useImperativeHandle` not used).
-- **No `forwardRef`** — parent cannot imperatively call play/pause/seek.
+- **Polling**: 250ms interval on play, stops on pause/ended. Fires `onTimeUpdate`.
+- **Seek**: `useEffect` on `seekToTime` → sets `el.currentTime`, fires `onSeekApplied()`.
+- **Close**: pauses video then calls `onClose()`.
+- No `forwardRef` / no imperative handle — parent cannot control playback directly.
 
 ### DOM / test IDs
 
@@ -182,82 +182,79 @@ interface LocalVideoPlayerProps {
 | `local-video` | `<video>` element |
 | `mini-player-close` | Close `<button>` |
 
-### Positioning
-
-Fixed, bottom-right (`fixed bottom-4 right-4 z-50 w-80 aspect-video`). On `md:` screens shifts to top-right (`md:bottom-auto md:top-20`).
+Positioning: `fixed bottom-4 right-4 z-50 w-80 aspect-video`. On `md:`: shifts to top-right.
 
 ---
 
-## 5. `PlayerClient.tsx` — Miniplayer Wiring
+## 5. `PlayerClient.tsx` — State, Vocab Flow, and Tab Structure
 
 ### State managed
 
 ```ts
-isMiniPlayerOpen: boolean           // toggles LocalVideoPlayer mount
-playbackTime: { current, duration } // fed by onTimeUpdate
-requestedSeekTime: number | null    // cleared after LocalVideoPlayer calls onSeekApplied
-activeCueIndex: number              // set by clicking a cue row (manual nav)
-selectedWord: { word, contextSentence } | null  // drives WordSidebar
-cues: TranscriptCue[]               // loaded from /api/videos/:id/transcript
-vocabWords: WordCard[]              // extracted from cues, 8 unique words ≥5 chars
+const { data: vocabMap = new Map() } = useVocabulary()  // DB-backed, global, Map<string, VocabEntry>
+const updateWordStatus = useUpdateWordStatus()           // PATCH /api/vocabulary/:word
+
+cues: TranscriptCue[]               // from /api/videos/:id/transcript
+loadingTranscript: boolean
+activeCueIndex: number              // manual cue nav (click)
 activeTab: 'transcript' | 'vocabulary'
+vocabWords: WordCard[]              // LOCAL state — extracted from cues, NOT persisted
+isMiniPlayerOpen: boolean
+playbackTime: { current, duration }
+requestedSeekTime: number | null
+selectedWord: { word, contextSentence } | null  // drives WordSidebar
 ```
 
-### Miniplayer open/close lifecycle
+### Vocabulary tab (in-player — WHAT NEEDS UNDERSTANDING)
 
-1. **Open**: `LessonHero` calls `onPlay` → `setIsMiniPlayerOpen(true)`.
-2. **Time updates**: `LocalVideoPlayer.onTimeUpdate` → `handleTimeUpdate` → `setPlaybackTime`.
-3. **Seek from transcript**: clicking a cue sets `activeCueIndex` + `requestedSeekTime`. `LocalVideoPlayer` receives `seekToTime` prop. On seek applied, `onSeekApplied` clears `requestedSeekTime` to `null`.
-4. **Close**: `LocalVideoPlayer.onClose` → `handleClose` → resets `isMiniPlayerOpen`, `playbackTime`, `activeCueIndex`, `requestedSeekTime`.
+The player contains a **two-tab panel** inside the transcript area:
 
-### Active cue tracking
+```
+[ Transcript ]  [ Vocabulary ]
+    data-testid="tab-transcript"   data-testid="tab-vocabulary"
+```
 
-- **`playbackCueIndex`**: Computed from `playbackTime.current` against cue start/end times (only when `isMiniPlayerOpen`). `-1` when player is closed.
-- **`highlightedCueIndex`**: `playbackCueIndex >= 0 ? playbackCueIndex : activeCueIndex`. Auto-scrolls via `scrollIntoView`.
+Tab state: `activeTab: 'transcript' | 'vocabulary'`, default `'transcript'`.
 
-### What is NOT wired
+**Vocabulary tab panel** (renders when `activeTab === 'vocabulary'`):
+- Shows `vocabWords` — local-only list of ≤8 unique words (≥5 chars) from transcript cues.
+- `extractVocabWords(cues)` runs on transcript load; returns `{ word, status: 'new' }[]`.
+- "Add to Deck" → `handleWordAction(word, 'add')` → **local state only, no DB call**.
+- "Mark Mastered" → `handleWordAction(word, 'master')` → **local state only, no DB call**.
+- State resets on page navigation. Completely disconnected from `vocabStore`.
 
-- No play/pause button in `PlayerClient` (only Play to open the miniplayer; close to dismiss).
-- No volume, speed, or fullscreen controls.
-- No rewind/fast-forward.
-- `LocalVideoPlayer` does not expose any ref handle — `PlayerClient` cannot imperatively control playback.
+**This tab is separate from the DB-backed vocab system.**
+
+### vocabMap (DB vocab) — Transcript tab only
+
+`vocabMap` from `useVocabulary()` (global, DB-backed) is used in the **Transcript tab**:
+1. Passed to `CueText` in every cue row → colors known words red/yellow/green.
+2. Passed to `WordSidebar` → `vocabEntry={vocabMap.get(word.toLowerCase())}`.
+
+`WordSidebar` status toggle → `updateWordStatus.mutate({ word, status })` → `PATCH /api/vocabulary/:word` → SQLite persisted → React Query cache invalidated.
+
+### Word-click → WordSidebar flow
+
+1. Click word in `CueText` → `onWordClick(token.raw, cue.text)`
+2. `PlayerClient`: `setSelectedWord({ word, contextSentence })`
+3. Renders `<WordSidebar ... vocabEntry={vocabMap.get(word.toLowerCase())} onStatusChange={(w,s) => updateWordStatus.mutate(...)} isUpdating={updateWordStatus.isPending} />`
+4. Escape / backdrop → `setSelectedWord(null)` → unmounts
 
 ---
 
 ## 6. `PlaybackProgress.tsx`
 
 ```ts
-interface PlaybackProgressProps {
-  currentTime: number   // seconds
-  duration: number      // seconds (0 while video metadata not loaded)
-}
+interface PlaybackProgressProps { currentTime: number; duration: number }
 ```
 
-- Renders a visual progress bar (`width: (currentTime/duration)*100%`) and `M:SS` / `M:SS` time labels.
-- **Stateless** — driven entirely by props from `PlayerClient`.
-- Shown only when `isMiniPlayerOpen === true`.
+Stateless. Renders progress bar + `M:SS` labels. Shown only when `isMiniPlayerOpen === true`.
 
 Test IDs: `playback-progress`, `progress-bar-fill`, `current-time`, `duration`.
 
 ---
 
-## 7. Playback Control Hooks / Utilities
-
-There are **no dedicated playback control hooks**. All playback state is managed inline in `PlayerClient.tsx`:
-
-| Concern | Where handled |
-|---|---|
-| Open/close miniplayer | `isMiniPlayerOpen` state in `PlayerClient` |
-| Time tracking | 250ms poll in `LocalVideoPlayer` → `onTimeUpdate` callback |
-| Seek | `requestedSeekTime` prop → `LocalVideoPlayer` effect |
-| Active cue sync | Computed `playbackCueIndex` in `PlayerClient` render |
-| Progress bar | `PlaybackProgress` component (display only) |
-
-No `usePlayback`, `useSeek`, or similar hook exists.
-
----
-
-## 8. API Routes (all require `export const runtime = 'nodejs'`)
+## 7. API Routes (all require `export const runtime = 'nodejs'`)
 
 | Method | Path | Description |
 |---|---|---|
@@ -267,101 +264,153 @@ No `usePlayback`, `useSeek`, or similar hook exists.
 | `PATCH` | `/api/videos/:id` | Update tags and/or transcript |
 | `DELETE` | `/api/videos/:id` | Delete video + files |
 | `GET` | `/api/videos/:id/transcript` | Parse transcript → `{ cues: TranscriptCue[] }` |
-| `GET` | `/api/videos/:id/stream` | Byte-range video streaming (mp4/webm/mov) |
-| `GET` | `/api/videos/:id/thumbnail` | Serve generated thumbnail image |
+| `GET` | `/api/videos/:id/stream` | Byte-range video streaming |
+| `GET` | `/api/videos/:id/thumbnail` | Serve generated thumbnail |
+| `GET` | `/api/vocabulary` | List all vocab entries (`vocabStore.getAll()`) |
+| `PATCH` | `/api/vocabulary/:word` | Upsert word status (`vocabStore.upsert(word, status)`) |
 
 ### Tags contract
 
-- `POST /api/videos/import`: `tags` FormData field is **comma-separated string** → `"french,beginner"`.
-- `PATCH /api/videos/:id`: `tags` FormData field is **JSON-serialized array string** → `'["french","beginner"]'`.
+- `POST /api/videos/import`: `tags` FormData = **comma-separated string** → `"french,beginner"`.
+- `PATCH /api/videos/:id`: `tags` FormData = **JSON-serialized array string** → `'["french","beginner"]'`.
 
 ---
 
-## 9. Data Model
+## 8. Data Model
 
-### `Video` (Zod schema in `src/lib/videos.ts`)
+### `Video` (Zod: `src/lib/videos.ts`)
 
 ```ts
 {
-  id: string
-  title: string
-  author_name: string
-  thumbnail_url: string
-  transcript_path: string           // relative or absolute path to transcript file
-  transcript_format: string         // 'srt' | 'vtt' | 'txt'
+  id: string; title: string; author_name: string; thumbnail_url: string
+  transcript_path: string; transcript_format: string
   tags: string[]                    // stored as JSON in SQLite
-  created_at: string                // ISO datetime string
-  updated_at: string
+  created_at: string; updated_at: string
   source_type: 'local'
-  local_video_path?: string | null  // path to video file in .lingoflow-data/videos/
-  local_video_filename?: string | null
-  thumbnail_path?: string | null    // path to generated thumbnail jpg
-}
-```
-
-### `TranscriptCue`
-
-```ts
-{
-  index: number
-  startTime: string   // "HH:MM:SS,mmm" or "HH:MM:SS.mmm"
-  endTime: string
-  text: string
+  local_video_path?: string | null; local_video_filename?: string | null
+  thumbnail_path?: string | null
 }
 ```
 
 ### SQLite schema (`videos` table)
 
 ```sql
-id TEXT PRIMARY KEY
-title TEXT NOT NULL
-author_name TEXT NOT NULL
-thumbnail_url TEXT NOT NULL
-transcript_path TEXT NOT NULL
-transcript_format TEXT NOT NULL
-tags TEXT NOT NULL DEFAULT '[]'     -- JSON array string
-created_at TEXT NOT NULL DEFAULT (datetime('now'))
+id TEXT PRIMARY KEY, title TEXT NOT NULL, author_name TEXT NOT NULL,
+thumbnail_url TEXT NOT NULL, transcript_path TEXT NOT NULL,
+transcript_format TEXT NOT NULL, tags TEXT NOT NULL DEFAULT '[]',
+created_at TEXT NOT NULL DEFAULT (datetime('now')),
+updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+source_type TEXT, local_video_path TEXT, local_video_filename TEXT, thumbnail_path TEXT
+```
+
+### SQLite schema (`vocabulary` table)
+
+```sql
+word TEXT PRIMARY KEY,              -- lowercased word is the PK (no id column)
+status TEXT NOT NULL CHECK(status IN ('new','learning','mastered')),
+level TEXT,                         -- CEFR level, nullable
+definition TEXT,                    -- nullable
+created_at TEXT NOT NULL DEFAULT (datetime('now')),
 updated_at TEXT NOT NULL DEFAULT (datetime('now'))
-source_type TEXT
-local_video_path TEXT
-local_video_filename TEXT
-thumbnail_path TEXT
+```
+
+> No `contextQuote`, `source`, or `video_id` — those exist only in `MOCK_VOCAB`.
+
+### `TranscriptCue`
+
+```ts
+{ index: number; startTime: string; endTime: string; text: string }
 ```
 
 ---
 
-## 10. Vocabulary System — Current State
+## 9. Vocabulary System — Complete Current State
 
-### `src/lib/vocabulary.ts`
+Two coexisting subsystems that are NOT yet unified:
 
-The vocabulary module contains **mock data only** — no database wiring exists yet.
+---
 
-#### Types
+### 9a. DB-backed Vocab (production path)
 
-```ts
-const VocabWordSchema = z.object({
-  id: z.string(),
-  word: z.string(),
-  level: z.enum(['A1', 'A2', 'B1', 'B2', 'C1', 'C2']),
-  definition: z.string(),
-  contextQuote: z.string(),
-  source: z.string(),
-  status: z.enum(['new', 'learning', 'mastered']),
-})
-export type VocabWord = z.infer<typeof VocabWordSchema>
-```
-
-#### `MOCK_VOCAB`
-
-9 hardcoded `VocabWord` entries (CEFR levels B1–C1). Words: Ethereal, Juxtaposition, Eloquent, Serendipity, Ephemeral, Resilient, Ambiguous, Pragmatic, Nuance. Sources: Cinema, Literature, Science, Nature, Tech. Statuses: 3 `new`, 3 `learning`, 3 `mastered`.
+#### `src/lib/vocab-store.ts`
 
 ```ts
-export const MOCK_VOCAB: VocabWord[] = [ /* 9 entries */ ]
-export const VOCAB_SOURCES = ['Cinema', 'Literature', 'Science', 'Nature', 'Tech'] as const
-export const VOCAB_LEVELS = ['A1', 'A2', 'B1', 'B2', 'C1', 'C2'] as const
+export interface VocabEntry {
+  word: string
+  status: 'new' | 'learning' | 'mastered'
+  level?: string
+  definition?: string
+}
+
+export class SqliteVocabStore implements VocabStore {
+  getAll(): VocabEntry[]
+  getByWord(word: string): VocabEntry | null
+  upsert(word: string, status: VocabEntry['status'], level?: string, definition?: string): VocabEntry
+}
 ```
 
-#### Status → color mapping (used in both `CueText` and `WordSidebar`)
+`word` is PK. `upsert` uses `INSERT … ON CONFLICT(word) DO UPDATE SET`.
+
+#### Composition root: `src/lib/server/composition.ts`
+
+`vocabStore` is instantiated alongside `videoStore` and `videoService`. API routes import from here.
+
+#### API routes
+
+- `GET /api/vocabulary` → `vocabStore.getAll()` → `VocabEntry[]`
+- `PATCH /api/vocabulary/:word` → URL-decoded + lowercased `:word` → `vocabStore.upsert(word, status)`
+  - Body schema: `{ status: 'new' | 'learning' | 'mastered' }`
+
+#### `src/hooks/useVocabulary.ts`
+
+```ts
+// Global, NOT scoped per video. Query key: ['vocabulary'].
+export function useVocabulary(): UseQueryResult<Map<string, VocabEntry>, Error>
+
+// Mutation. Invalidates ['vocabulary'] on success.
+export function useUpdateWordStatus(): UseMutationResult<
+  VocabEntry, Error, { word: string; status: VocabEntry['status'] }
+>
+```
+
+Returns `Map<string, VocabEntry>` keyed by lowercased word. **Cross-video** — same cache for all videos.
+
+---
+
+### 9b. Mock/Local Vocab (NOT DB-backed)
+
+#### `src/lib/vocabulary.ts`
+
+```ts
+/** Minimal interface — satisfied by both VocabWord (mock) and VocabEntry (DB). */
+export interface VocabInfo {
+  status: 'new' | 'learning' | 'mastered'
+  level?: string; definition?: string; source?: string
+}
+
+export type VocabWord = {
+  id: string; word: string; level: 'A1'|'A2'|'B1'|'B2'|'C1'|'C2'
+  definition: string; contextQuote: string; source: string
+  status: 'new' | 'learning' | 'mastered'
+}
+
+export const MOCK_VOCAB: VocabWord[]   // 9 hardcoded entries
+export const VOCAB_SOURCES             // ['Cinema','Literature','Science','Nature','Tech']
+export const VOCAB_LEVELS              // ['A1','A2','B1','B2','C1','C2']
+```
+
+`VocabInfo` is used as the type for `CueText.vocabMap` and `WordSidebar.vocabEntry`. Both `VocabEntry` (DB) and `VocabWord` (mock) satisfy it.
+
+#### `/vocabulary` page (`src/app/(app)/vocabulary/page.tsx`)
+
+- **Still uses `MOCK_VOCAB`** — no `useVocabulary()` call, no API fetch.
+- All state is `useState<VocabWord[]>(MOCK_VOCAB)`. `markMastered`/`removeWord` update local state only.
+- Tabs: `new` / `learning` / `mastered`. Source + level filter chips.
+- Completely disconnected from DB.
+
+---
+
+### 9c. Status → color mapping
 
 | Status | Color |
 |---|---|
@@ -369,226 +418,169 @@ export const VOCAB_LEVELS = ['A1', 'A2', 'B1', 'B2', 'C1', 'C2'] as const
 | `learning` | Yellow (text-yellow-600, bg-yellow-50) |
 | `mastered` | Green (text-green-600, bg-green-50) |
 
+Used in `CueText.tsx` (`STATUS_WORD_STYLES`) and `WordSidebar.tsx` (`STATUS_STYLES`, `STATUS_LABELS`).
+
 ---
 
-## 11. `CueText.tsx` — Word Colorization
+### 9d. Vocab data flow summary
+
+```
+DB (vocabulary table)
+    ↑ upsert via PATCH /api/vocabulary/:word (WordSidebar status toggle)
+    ↓ getAll via GET /api/vocabulary
+useVocabulary() → vocabMap: Map<string, VocabEntry>  [global, all videos]
+    → PlayerClient → CueText word colors (Transcript tab)
+    → PlayerClient → WordSidebar (status display + toggle)
+
+MOCK_VOCAB (hardcoded, src/lib/vocabulary.ts)
+    → /vocabulary page (local state only, no persistence)
+
+extractVocabWords(cues) → vocabWords (local state in PlayerClient)
+    → Player Vocabulary tab cards (in-memory only, no persistence)
+```
+
+---
+
+### 9e. Gap analysis
+
+| Component | Status |
+|---|---|
+| `vocabulary` SQLite table | ✅ |
+| `SqliteVocabStore` | ✅ |
+| `vocabStore` in composition root | ✅ |
+| `GET /api/vocabulary` | ✅ |
+| `PATCH /api/vocabulary/:word` | ✅ |
+| `useVocabulary()` + `useUpdateWordStatus()` | ✅ |
+| Word highlighting in transcript (DB) | ✅ via `vocabMap` in `CueText` |
+| WordSidebar status toggle (DB-persisted) | ✅ via `onStatusChange` + `useUpdateWordStatus` |
+| `/vocabulary` page DB-wiring | ❌ uses `MOCK_VOCAB` only |
+| Player Vocabulary tab DB-wiring | ❌ `vocabWords` local-only, no API calls |
+| `POST /api/vocabulary` (create endpoint) | ❌ none — only PATCH exists |
+| `contextQuote` / `source` in DB schema | ❌ not present |
+
+---
+
+## 10. `CueText.tsx` — Word Colorization
 
 ```ts
 interface CueTextProps {
-  text: string                          // raw transcript cue text
-  vocabMap: Map<string, VocabWord>      // keyed by lowercased word
+  text: string
+  vocabMap: Map<string, VocabInfo>   // keyed by lowercased word
   onWordClick: (word: string, sentence: string) => void
 }
 ```
 
-- Calls `tokenizeCueText(text)` → `TranscriptToken[]` (words + punct).
-- For each token: looks up `vocabMap.get(token.normalized)` (normalized = lowercased).
-- If found → applies `STATUS_WORD_STYLES[entry.status]` (red/yellow/green with bg tint).
-- If not found → applies `DEFAULT_WORD_STYLE` (hover highlight only).
-- Punctuation tokens rendered as plain `<span>` (not clickable).
-- Each word span: `role="button"`, `tabIndex={0}`, `data-testid="word-{normalized}"`, `onClick` stops propagation and calls `onWordClick(token.raw, text)`.
-- Keyboard accessible: Enter/Space trigger same callback.
-
-`tokenizeCueText` (`src/lib/tokenize-transcript.ts`): splits on whitespace and non-alpha chars; emits `{ type: 'word', raw, normalized }` for alpha-only tokens, `{ type: 'punct', raw }` otherwise.
+- `tokenizeCueText(text)` → `TranscriptToken[]`.
+- Each word token: looks up `vocabMap.get(token.normalized)`.
+- If found → `STATUS_WORD_STYLES[entry.status]` (red/yellow/green).
+- If not found → `DEFAULT_WORD_STYLE` (hover highlight only).
+- Word spans: `role="button"`, `tabIndex={0}`, `data-testid="word-{normalized}"`, keyboard accessible.
 
 ---
 
-## 12. `WordSidebar.tsx` — Word Detail Panel
+## 11. `WordSidebar.tsx` — Word Detail Panel
 
 ```ts
 interface WordSidebarProps {
-  word: string                        // raw word as clicked (preserves original casing)
-  contextSentence: string             // full cue text containing the word
-  vocabEntry: VocabWord | undefined   // undefined if word not in vocab map
+  word: string                          // raw, original casing
+  contextSentence: string               // full cue text
+  vocabEntry: VocabInfo | undefined
   onClose: () => void
+  onStatusChange?: (word: string, status: 'new' | 'learning' | 'mastered') => void
+  isUpdating?: boolean
 }
 ```
 
-### Behavior
+- Fixed right slide-over (`fixed top-0 right-0 z-50 h-full w-80`).
+- Escape key + transparent backdrop close it.
+- **Status toggle** (`data-testid="status-toggle"`): shown when `onStatusChange` provided. Toggles `mastered` ↔ `new`. Disabled while `isUpdating`.
 
-- Renders a fixed right slide-over (`fixed top-0 right-0 z-50 h-full w-80`).
-- `role="dialog"`, `aria-modal="true"`, `aria-label="Word details"`.
-- Backdrop: transparent `fixed inset-0 z-40` div — click dismisses.
-- Escape key: `document` keydown listener → `onClose()`.
-- Close button: `data-testid="word-sidebar-close"`.
-
-### Content
-
-| Section | Shown when | Content |
+| Section | Shown when | testid |
 |---|---|---|
-| Word display | always | `data-testid="sidebar-word"` — large bold word; colored if `vocabEntry` exists |
-| Status badge | `vocabEntry` defined | Colored pill: "Mastered" / "Learning" / "New" |
-| Vocab details | `vocabEntry` defined | CEFR level badge, source, definition paragraph |
-| Context | always | `data-testid="sidebar-context"` — full cue sentence in italic block |
+| Word (colored) | always | `sidebar-word` |
+| Status badge | `vocabEntry` defined | — |
+| Level + definition | `vocabEntry` defined | — |
+| Status toggle | `onStatusChange` provided | `status-toggle` |
+| Context sentence | always | `sidebar-context` |
 
-### Test IDs
-
-`word-sidebar`, `word-sidebar-close`, `sidebar-word`, `sidebar-context`.
+Other test IDs: `word-sidebar`, `word-sidebar-close`.
 
 ---
 
-## 13. `PlayerClient.tsx` — selectedWord → WordSidebar Flow
+## 12. `LessonHero.tsx`
 
 ```ts
-// Module-level constant (not reactive state)
-const vocabMap: Map<string, VocabWord> = new Map(
-  MOCK_VOCAB.map((entry) => [entry.word.toLowerCase(), entry])
-)
+interface LessonHeroProps { video: Video; onPlay: () => void }
 ```
 
-`vocabMap` is built once at module load from `MOCK_VOCAB`. It is **not** derived from SQLite — it uses the hardcoded mock.
-
-```ts
-// State slice driving WordSidebar
-const [selectedWord, setSelectedWord] = useState<SelectedWord | null>(null)
-// { word: string; contextSentence: string }
-```
-
-**Click flow**:
-1. User clicks word token in `CueText` → `onWordClick(token.raw, cue.text)` called.
-2. `PlayerClient` handler: `setSelectedWord({ word, contextSentence: sentence })`.
-3. `{selectedWord && <WordSidebar word={selectedWord.word} contextSentence={selectedWord.contextSentence} vocabEntry={vocabMap.get(selectedWord.word.toLowerCase())} onClose={() => setSelectedWord(null)} />}`.
-4. `WordSidebar` renders; Escape or backdrop click → `setSelectedWord(null)` → unmounts.
-
-**Both** active and non-active cue rows render `CueText` (with the same `vocabMap` and `onWordClick` handler). Word colorization therefore applies to all visible cues.
-
-### `vocabWords` (Vocabulary tab, separate from vocabMap)
-
-`vocabWords: WordCard[]` — extracted from cues on load via `extractVocabWords(cues)`:
-- Joins all cue text, splits on whitespace, strips non-alpha, keeps words ≥5 chars.
-- Returns up to 8 unique words as `{ word, status: 'new' }`.
-- **Not linked to `MOCK_VOCAB`** — completely separate extraction.
-- `handleWordAction(word, 'add'|'master')` updates status in local state only (no persistence).
+Play button: `data-testid="play-button"`, `aria-label="Play video"`, label `"Play"`, `px-4 py-2`.
 
 ---
 
-## 14. Vocabulary Persistence — Gaps for Issue #156
+## 13. Dependency Injection / Composition Root
 
-### What exists today
+`src/lib/server/composition.ts` — single DI root. Creates:
 
-| Mechanism | Status |
-|---|---|
-| `vocabulary` SQLite table | ❌ Does not exist — `initializeSchema` creates only the `videos` table |
-| Vocab API routes | ❌ None — no `src/app/api/vocabulary/` routes exist |
-| localStorage persistence | ❌ Not used |
-| `VocabWord` Zod schema + type | ✅ Defined in `src/lib/vocabulary.ts` |
-| `MOCK_VOCAB` (9 hardcoded entries) | ✅ Used by `PlayerClient` and `/vocabulary` page |
-| Status→color display logic | ✅ Implemented in `CueText` and `WordSidebar` |
-| Word-click → sidebar flow | ✅ Implemented end-to-end in `PlayerClient` |
+- `SqliteVideoStore`
+- `VideoService` (takes store + transcriptStore + videoFileStore)
+- `SqliteVocabStore` (same DB instance)
 
-### Gaps to fill for issue #156
-
-1. **SQLite `vocabulary` table**: needs `CREATE TABLE IF NOT EXISTS vocabulary (id, word, level, definition, context_quote, source, status, video_id?, created_at, updated_at)` added to `initializeSchema` in `src/lib/db.ts`.
-2. **`SqliteVocabStore`** (parallel to `SqliteVideoStore`): CRUD over the vocabulary table.
-3. **`VocabService`** or inline route logic: add/update/delete vocab entries.
-4. **Composition root update** (`src/lib/server/composition.ts`): wire up vocab store/service.
-5. **API routes**: at minimum `GET /api/vocabulary`, `POST /api/vocabulary`, `PATCH /api/vocabulary/:id` (to update status). Must export `runtime = 'nodejs'`.
-6. **`PlayerClient` wiring**: replace `MOCK_VOCAB` / module-level `vocabMap` with data fetched from API (React Query). `WordSidebar` add-to-vocab action needs to call the API.
-7. **`/vocabulary` page** (`src/app/(app)/vocabulary/page.tsx`): replace mock data with API fetch.
-8. **`WordSidebar` add/update action**: needs an `onStatusChange` prop (or similar) to call the persistence layer when user marks a word as learning/mastered.
+Route handlers import `{ videoStore, videoService, vocabStore }` from here. **Never instantiate directly.**
 
 ---
 
-## 15. `LessonHero.tsx` — Current State (snapshot 2026-07)
-
-File: `src/components/LessonHero.tsx`
-
-### Props
-
-```ts
-interface LessonHeroProps {
-  video: Video
-  onPlay: () => void
-}
-```
-
-### Button (current — post #155)
-
-| Attribute | Current value |
-|---|---|
-| Label text | `Play` |
-| `aria-label` | `"Play video"` |
-| `data-testid` | `"play-button"` |
-| `onClick` | `onPlay` prop |
-| Size classes | `px-4 py-2` (reduced from px-6 py-3) |
-| Visual style | `bg-gradient-to-br from-primary to-primary-container text-white rounded-xl font-bold hover:scale-[1.02] transition-transform whitespace-nowrap` |
-| Icon | `w-5 h-5` SVG play chevron (path `M8 5v14l11-7z`) |
-
-### Test files that reference the button label / component
-
-| File | Reference | Type |
-|---|---|---|
-| `src/components/__tests__/LessonHero.test.tsx` | `getByTestId('play-button')` — no text assertion on label | Unit |
-| `tests/e2e/player.spec.ts` | `toContainText('Play')` | E2E |
-| `tests/e2e/pages/PlayerPage.ts` | `getByTestId('play-button')` — no text assertion | E2E POM |
-
-Issue #155 is merged — label is now `"Play"`, padding is `px-4 py-2`.
-
----
-
-## 16. Dependency Injection / Composition Root
-
-`src/lib/server/composition.ts` is the single DI root. It creates:
-
-- `SqliteVideoStore` (wraps `better-sqlite3`)
-- `VideoService` (business logic, takes store + transcriptStore + videoFileStore)
-
-All API route handlers import `{ videoStore, videoService }` from here. **Never instantiate these directly in route handlers.**
-
----
-
-## 17. Key Library Files
+## 14. Key Library Files
 
 ### `src/lib/parse-transcript.ts`
-- `parseTranscript(content, format)` → `TranscriptCue[]`
-- Supports `'srt'`, `'vtt'` (strips WEBVTT header, parses as SRT), and plain text.
+- `parseTranscript(content, format)` → `TranscriptCue[]`. Supports `'srt'`, `'vtt'`, plain text.
 
 ### `src/lib/tokenize-transcript.ts`
-- `tokenizeCueText(text)` → `TranscriptToken[]`
-- Each token is `{ type: 'word', raw, normalized }` or `{ type: 'punct', raw }`.
-- `normalized` is lowercased word, used for vocab map lookup.
+- `tokenizeCueText(text)` → `{ type:'word', raw, normalized }[] | { type:'punct', raw }[]`.
 
 ### `src/lib/vocabulary.ts`
-- `MOCK_VOCAB: VocabWord[]` — 9 hardcoded entries, CEFR levels B1–C1.
-- `VocabWord` has `{ id, word, level, definition, contextQuote, source, status }`.
-- **Not yet wired to SQLite** — vocabulary page and `PlayerClient` use mock data only.
+- `MOCK_VOCAB` (9 entries B1–C1), `VocabWord` type, `VocabInfo` interface, `VOCAB_SOURCES`, `VOCAB_LEVELS`.
+- `PlayerClient` does NOT use `MOCK_VOCAB` — uses `useVocabulary()` (DB-backed).
+- `/vocabulary` page DOES use `MOCK_VOCAB` — not DB-wired.
+
+### `src/lib/vocab-store.ts`
+- `SqliteVocabStore`: `getAll()`, `getByWord()`, `upsert()`. PK is `word` (lowercased).
 
 ### `src/lib/thumbnails.ts`
-- `generateThumbnail(videoPath, outputPath)` → `string | null`
-- Uses `fluent-ffmpeg` to extract a frame at 1 second. Async, non-blocking (called with `void` in import route).
+- `generateThumbnail(videoPath, outputPath)` → `string | null`. Uses `fluent-ffmpeg`, frame at 1s.
 
 ---
 
-## 18. Build & Test Commands
+## 15. Build & Test Commands
 
 ```bash
-pnpm install          # install / sync deps (run after package.json changes)
-pnpm build            # production build + TypeScript validation — MUST pass
+pnpm install          # install / sync deps
+pnpm build            # production build + TypeScript — MUST pass
 pnpm test             # Jest unit tests
 pnpm dev              # dev server on http://localhost:3000
-pnpm lint             # ESLint — pre-existing failures in test files; NOT a CI gate
+pnpm lint             # ESLint — pre-existing test file failures; NOT a CI gate
 pnpm test:e2e         # Playwright E2E (auto-starts dev server via webServer config)
 ```
 
 ---
 
-## 19. Critical Patterns
+## 16. Critical Patterns
 
-1. **`export const runtime = 'nodejs'`** required in every `src/app/api/` file.
-2. **`// @jest-environment node`** required at top of API route test files.
-3. **Zod v4**: use `result.error.issues[0].message`, NOT `.errors`.
+1. **`export const runtime = 'nodejs'`** — required in every `src/app/api/` file.
+2. **`// @jest-environment node`** — required at top of every API route test file.
+3. **Zod v4**: `result.error.issues[0].message`, NOT `.errors`.
 4. **Dynamic route params**: `params` is `Promise<{ id: string }>` — must `await params`.
-5. **Tags in SQLite**: stored as JSON string; `SqliteVideoStore.rowToVideo()` deserializes. Always pass `string[]` to store methods.
-6. **Composition root**: always import `{ videoStore, videoService }` from `@/lib/server/composition`.
+5. **Tags in SQLite**: stored as JSON string; `rowToVideo()` deserializes. Always pass `string[]` to store methods.
+6. **Composition root**: import `{ videoStore, videoService, vocabStore }` from `@/lib/server/composition`. Never instantiate directly.
 7. **Import tags**: comma-separated string in FormData. **Update tags**: JSON-serialized array string in FormData.
-8. **`@/` path alias** maps to `src/`. Use in all imports.
-9. **Data dir**: `.lingoflow-data/` (gitignored) — contains `lingoflow.db`, `transcripts/`, `videos/`, `thumbnails/`. Override with `LINGOFLOW_DATA_DIR` env var.
+8. **`@/` path alias** maps to `src/`.
+9. **Data dir**: `.lingoflow-data/` — `lingoflow.db`, `transcripts/`, `videos/`, `thumbnails/`. Override via `LINGOFLOW_DATA_DIR`.
 10. **`pnpm` only** — no npm or yarn.
+11. **Vocab store PK**: `vocabulary.word` is lowercased PK. `upsert` handles insert + update. No separate ID.
 
 ---
 
-## 20. CI Pipeline
+## 17. CI Pipeline
 
-Defined in `.github/workflows/e2e.yml`. Triggers on **push to `main` only** (post-merge).
+`.github/workflows/e2e.yml`. Triggers on **push to `main` only** (post-merge).
 Steps: `pnpm install --frozen-lockfile` → `pnpm test` → `pnpm test:e2e`.
 No lint step. Run `pnpm build` and `pnpm test` locally before merging.

--- a/jest.config.js
+++ b/jest.config.js
@@ -7,15 +7,13 @@ const createJestConfig = nextJest({
 
 // Add any custom config to be passed to Jest
 const customJestConfig = {
-  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
   testEnvironment: 'jest-environment-jsdom',
-  testPathIgnorePatterns: ['<rootDir>/node_modules/', '<rootDir>/tests/e2e/'],
+  roots: ['<rootDir>/src', '<rootDir>/tests'],
+  testPathIgnorePatterns: ['<rootDir>/node_modules/', '<rootDir>/tests/e2e/', '<rootDir>/pr-[^/]+/'],
+  modulePathIgnorePatterns: ['<rootDir>/pr-[^/]+/'],
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
-    '^@babel/runtime/(.*)$': '/workspaces/lingoFlow/node_modules/.pnpm/@babel+runtime@7.29.2/node_modules/@babel/runtime/$1',
-  },
-  transform: {
-    '^.+\\.(js|jsx|ts|tsx|mjs)$': ['/workspaces/lingoFlow/node_modules/.pnpm/node_modules/babel-jest/build/index.js', {}],
   },
 }
 

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,1 @@
+require('@testing-library/jest-dom')

--- a/src/app/(app)/vocabulary/__tests__/page.test.tsx
+++ b/src/app/(app)/vocabulary/__tests__/page.test.tsx
@@ -1,5 +1,42 @@
 import { render, screen, fireEvent } from '@testing-library/react'
 import VocabularyPage from '../page'
+import { VocabEntry } from '@/lib/vocab-store'
+
+const mockMutate = jest.fn()
+
+jest.mock('@/hooks/useVocabulary', () => ({
+  useVocabulary: jest.fn(),
+  useUpdateWordStatus: jest.fn(() => ({ mutate: mockMutate, isPending: false })),
+}))
+
+import { useVocabulary } from '@/hooks/useVocabulary'
+
+const MOCK_ENTRIES: VocabEntry[] = [
+  { word: 'ethereal', status: 'new', level: 'B2', definition: 'Extremely delicate' },
+  { word: 'juxtaposition', status: 'new', level: 'C1', definition: 'Two contrasting things' },
+  { word: 'eloquent', status: 'new', level: 'B1', definition: 'Fluent or persuasive' },
+  { word: 'serendipity', status: 'learning', level: 'B2', definition: 'Happy chance' },
+  { word: 'ephemeral', status: 'learning', level: 'C1', definition: 'Lasting briefly' },
+  { word: 'resilient', status: 'learning', level: 'B1', definition: 'Recovering quickly' },
+  { word: 'ambiguous', status: 'mastered', level: 'B1', definition: 'Open to interpretation' },
+  { word: 'pragmatic', status: 'mastered', level: 'B2', definition: 'Dealing sensibly' },
+  { word: 'nuance', status: 'mastered', level: 'B2', definition: 'A subtle difference' },
+]
+
+function makeMap(entries: VocabEntry[]) {
+  return new Map(entries.map((e) => [e.word.toLowerCase(), e]))
+}
+
+beforeEach(() => {
+  jest.mocked(useVocabulary).mockReturnValue({
+    data: makeMap(MOCK_ENTRIES),
+    isLoading: false,
+  } as ReturnType<typeof useVocabulary>)
+})
+
+afterEach(() => {
+  jest.clearAllMocks()
+})
 
 describe('VocabularyPage', () => {
   it('renders the page heading', () => {
@@ -13,7 +50,6 @@ describe('VocabularyPage', () => {
     const newTab = screen.getByTestId('tab-new')
     expect(newTab).toHaveClass('text-primary')
     const cards = screen.getAllByTestId('vocab-card')
-    // 3 new words in mock data
     expect(cards).toHaveLength(3)
   })
 
@@ -22,9 +58,9 @@ describe('VocabularyPage', () => {
     fireEvent.click(screen.getByTestId('tab-learning'))
     const cards = screen.getAllByTestId('vocab-card')
     expect(cards).toHaveLength(3)
-    expect(screen.getByText('Serendipity')).toBeInTheDocument()
-    expect(screen.getByText('Ephemeral')).toBeInTheDocument()
-    expect(screen.getByText('Resilient')).toBeInTheDocument()
+    expect(screen.getByText('serendipity')).toBeInTheDocument()
+    expect(screen.getByText('ephemeral')).toBeInTheDocument()
+    expect(screen.getByText('resilient')).toBeInTheDocument()
   })
 
   it('switches to Mastered tab and shows only mastered words', () => {
@@ -32,47 +68,25 @@ describe('VocabularyPage', () => {
     fireEvent.click(screen.getByTestId('tab-mastered'))
     const cards = screen.getAllByTestId('vocab-card')
     expect(cards).toHaveLength(3)
-    expect(screen.getByText('Ambiguous')).toBeInTheDocument()
-    expect(screen.getByText('Pragmatic')).toBeInTheDocument()
-    expect(screen.getByText('Nuance')).toBeInTheDocument()
+    expect(screen.getByText('ambiguous')).toBeInTheDocument()
+    expect(screen.getByText('pragmatic')).toBeInTheDocument()
+    expect(screen.getByText('nuance')).toBeInTheDocument()
   })
 
   it('filters cards by search query', () => {
     render(<VocabularyPage />)
     const input = screen.getByTestId('vocab-search-input')
-    fireEvent.change(input, { target: { value: 'Ethereal' } })
+    fireEvent.change(input, { target: { value: 'ethereal' } })
     const cards = screen.getAllByTestId('vocab-card')
     expect(cards).toHaveLength(1)
-    expect(screen.getByText('Ethereal')).toBeInTheDocument()
+    expect(screen.getByText('ethereal')).toBeInTheDocument()
   })
 
-  it('mark as mastered removes word from New list', () => {
+  it('mark as mastered calls updateWordStatus mutation', () => {
     render(<VocabularyPage />)
-    // On the New tab, all 3 words visible
-    expect(screen.getAllByTestId('vocab-card')).toHaveLength(3)
     const masterButtons = screen.getAllByTestId('mark-mastered-button')
     fireEvent.click(masterButtons[0])
-    // One word moved to mastered — now 2 new words shown
-    expect(screen.getAllByTestId('vocab-card')).toHaveLength(2)
-  })
-
-  it('remove button removes the card from the list', () => {
-    render(<VocabularyPage />)
-    expect(screen.getAllByTestId('vocab-card')).toHaveLength(3)
-    const removeButtons = screen.getAllByTestId('remove-button')
-    fireEvent.click(removeButtons[0])
-    expect(screen.getAllByTestId('vocab-card')).toHaveLength(2)
-  })
-
-  it('source filter chip filters to only words from that source', () => {
-    render(<VocabularyPage />)
-    // Cinema has 1 new word (Ethereal)
-    const chips = screen.getAllByTestId('source-filter-chip')
-    const cinemaChip = chips.find((c) => c.textContent === 'Cinema')!
-    fireEvent.click(cinemaChip)
-    const cards = screen.getAllByTestId('vocab-card')
-    expect(cards).toHaveLength(1)
-    expect(screen.getByText('Ethereal')).toBeInTheDocument()
+    expect(mockMutate).toHaveBeenCalledWith({ word: expect.any(String), status: 'mastered' })
   })
 
   it('shows empty state when no words match filters', () => {
@@ -81,5 +95,14 @@ describe('VocabularyPage', () => {
     fireEvent.change(input, { target: { value: 'xyznonexistent' } })
     expect(screen.getByTestId('empty-vocab-state')).toBeInTheDocument()
     expect(screen.queryAllByTestId('vocab-card')).toHaveLength(0)
+  })
+
+  it('shows loading state while fetching', () => {
+    jest.mocked(useVocabulary).mockReturnValue({
+      data: undefined,
+      isLoading: true,
+    } as ReturnType<typeof useVocabulary>)
+    render(<VocabularyPage />)
+    expect(screen.getByText('Loading vocabulary…')).toBeInTheDocument()
   })
 })

--- a/src/app/(app)/vocabulary/page.tsx
+++ b/src/app/(app)/vocabulary/page.tsx
@@ -1,7 +1,8 @@
 'use client'
 
 import { useState } from 'react'
-import { MOCK_VOCAB, VOCAB_SOURCES, VOCAB_LEVELS, type VocabWord } from '@/lib/vocabulary'
+import { VOCAB_LEVELS } from '@/lib/vocabulary'
+import { useVocabulary, useUpdateWordStatus, type VocabEntry } from '@/hooks/useVocabulary'
 
 type Tab = 'new' | 'learning' | 'mastered'
 
@@ -12,33 +13,22 @@ const TAB_LABELS: Record<Tab, string> = {
 }
 
 export default function VocabularyPage() {
-  const [words, setWords] = useState<VocabWord[]>(MOCK_VOCAB)
+  const { data: vocabMap = new Map<string, VocabEntry>(), isLoading } = useVocabulary()
+  const updateWordStatus = useUpdateWordStatus()
   const [activeTab, setActiveTab] = useState<Tab>('new')
   const [searchQuery, setSearchQuery] = useState('')
-  const [activeSources, setActiveSources] = useState<string[]>([])
   const [activeLevels, setActiveLevels] = useState<string[]>([])
+
+  const words = Array.from(vocabMap.values())
 
   const countForTab = (tab: Tab) => words.filter((w) => w.status === tab).length
 
   const filteredWords = words.filter((w) => {
     if (w.status !== activeTab) return false
-    if (searchQuery && !w.word.toLowerCase().includes(searchQuery.toLowerCase()) && !w.definition.toLowerCase().includes(searchQuery.toLowerCase())) return false
-    if (activeSources.length > 0 && !activeSources.includes(w.source)) return false
-    if (activeLevels.length > 0 && !activeLevels.includes(w.level)) return false
+    if (searchQuery && !w.word.toLowerCase().includes(searchQuery.toLowerCase()) && !(w.definition ?? '').toLowerCase().includes(searchQuery.toLowerCase())) return false
+    if (activeLevels.length > 0 && !activeLevels.includes(w.level ?? '')) return false
     return true
   })
-
-  function markMastered(id: string) {
-    setWords((prev) => prev.map((w) => (w.id === id ? { ...w, status: 'mastered' } : w)))
-  }
-
-  function removeWord(id: string) {
-    setWords((prev) => prev.filter((w) => w.id !== id))
-  }
-
-  function toggleSource(source: string) {
-    setActiveSources((prev) => prev.includes(source) ? prev.filter((s) => s !== source) : [...prev, source])
-  }
 
   function toggleLevel(level: string) {
     setActiveLevels((prev) => prev.includes(level) ? prev.filter((l) => l !== level) : [...prev, level])
@@ -58,14 +48,6 @@ export default function VocabularyPage() {
           <p className="text-on-surface-variant dark:text-slate-400 mt-2 max-w-xl font-body leading-relaxed">
             Refine your cognitive sanctuary by reviewing and organizing the linguistic gems you&apos;ve collected.
           </p>
-        </div>
-        <div className="flex items-center gap-3 mt-2">
-          <button className="flex items-center gap-2 px-5 py-2.5 bg-surface-container-highest text-on-surface-variant rounded-xl font-bold hover:bg-surface-container-high transition-colors">
-            Export CSV
-          </button>
-          <button className="flex items-center gap-2 px-6 py-2.5 bg-gradient-to-br from-primary to-primary-container text-white rounded-xl font-bold hover:scale-[1.02] transition-transform">
-            New Entry
-          </button>
         </div>
       </div>
 
@@ -116,7 +98,9 @@ export default function VocabularyPage() {
       <div className="grid xl:grid-cols-12 gap-8">
         {/* Word card list — left column */}
         <div className="xl:col-span-8">
-          {filteredWords.length === 0 ? (
+          {isLoading ? (
+            <p className="text-sm text-on-surface-variant dark:text-slate-400 text-center py-8">Loading vocabulary…</p>
+          ) : filteredWords.length === 0 ? (
             <div data-testid="empty-vocab-state" className="flex flex-col items-center justify-center py-20 text-on-surface-variant">
               <p className="text-lg font-medium mb-2">No words found</p>
               <p className="text-sm">Try adjusting your search or filters.</p>
@@ -125,7 +109,7 @@ export default function VocabularyPage() {
             <div className="space-y-4">
               {filteredWords.map((word) => (
                 <div
-                  key={word.id}
+                  key={word.word}
                   data-testid="vocab-card"
                   className="bg-surface-container-lowest dark:bg-slate-900 p-6 rounded-xl hover:bg-surface-bright dark:hover:bg-slate-800 transition-colors"
                 >
@@ -133,37 +117,27 @@ export default function VocabularyPage() {
                     <div className="flex-1">
                       <div className="flex items-center gap-3 mb-2">
                         <h3 className="text-2xl font-bold text-primary">{word.word}</h3>
-                        <span className="px-2 py-0.5 rounded bg-tertiary-fixed text-on-tertiary-fixed text-[10px] font-bold uppercase">
-                          {word.level}
-                        </span>
+                        {word.level && (
+                          <span className="px-2 py-0.5 rounded bg-tertiary-fixed text-on-tertiary-fixed text-[10px] font-bold uppercase">
+                            {word.level}
+                          </span>
+                        )}
                       </div>
-                      <p className="text-on-surface-variant dark:text-slate-400 text-sm italic mb-3">{word.definition}</p>
-                      <div className="bg-surface-container-low dark:bg-slate-950/50 p-4 rounded-lg border-l-4 border-primary/30">
-                        <p className="text-sm text-on-surface dark:text-slate-100 leading-relaxed">
-                          &ldquo;{word.contextQuote}&rdquo; —{' '}
-                          <span className="text-on-surface-variant text-xs uppercase font-bold">{word.source}</span>
-                        </p>
-                      </div>
+                      {word.definition && (
+                        <p className="text-on-surface-variant dark:text-slate-400 text-sm italic mb-3">{word.definition}</p>
+                      )}
                     </div>
                     <div className="flex flex-col gap-2">
                       {word.status !== 'mastered' && (
                         <button
                           data-testid="mark-mastered-button"
-                          onClick={() => markMastered(word.id)}
+                          onClick={() => updateWordStatus.mutate({ word: word.word, status: 'mastered' })}
                           className="p-2 rounded-lg text-on-surface-variant hover:bg-primary-container hover:text-on-primary-container transition-colors"
                           title="Mark as mastered"
                         >
                           ✓
                         </button>
                       )}
-                      <button
-                        data-testid="remove-button"
-                        onClick={() => removeWord(word.id)}
-                        className="p-2 rounded-lg text-on-surface-variant hover:bg-error-container hover:text-on-error-container transition-colors"
-                        title="Remove"
-                      >
-                        ✕
-                      </button>
                     </div>
                   </div>
                 </div>
@@ -174,41 +148,6 @@ export default function VocabularyPage() {
 
         {/* Sidebar bento — right column */}
         <div className="xl:col-span-4">
-          {/* Learning Momentum card */}
-          <div className="bg-primary p-8 rounded-xl text-on-primary mb-6">
-            <p className="text-sm font-bold opacity-70 mb-1 uppercase tracking-wider">This Week</p>
-            <p className="text-4xl font-extrabold">18</p>
-            <p className="text-sm opacity-80 mt-1">Words Learned</p>
-            <div className="mt-6 h-2 bg-white/20 rounded-full">
-              <div className="h-2 bg-white rounded-full" style={{ width: '70%' }}></div>
-            </div>
-            <p className="text-xs opacity-60 mt-2">70% of weekly goal</p>
-          </div>
-
-          {/* Filter by Source */}
-          <div className="bg-surface-container-low dark:bg-slate-950/50 p-6 rounded-xl mb-6">
-            <h4 className="font-bold text-on-surface dark:text-slate-100 mb-4 text-sm uppercase tracking-wider">Filter by Source</h4>
-            <div className="flex flex-wrap gap-2">
-              {VOCAB_SOURCES.map((source) => {
-                const isActive = activeSources.includes(source)
-                return (
-                  <button
-                    key={source}
-                    data-testid="source-filter-chip"
-                    onClick={() => toggleSource(source)}
-                    className={`px-4 py-1.5 rounded-full text-sm font-medium transition-colors ${
-                      isActive
-                        ? 'bg-primary text-on-primary'
-                        : 'bg-surface-container text-on-surface-variant hover:bg-primary hover:text-on-primary'
-                    }`}
-                  >
-                    {source}
-                  </button>
-                )
-              })}
-            </div>
-          </div>
-
           {/* Filter by Difficulty */}
           <div className="bg-surface-container-low dark:bg-slate-950/50 p-6 rounded-xl">
             <h4 className="font-bold text-on-surface dark:text-slate-100 mb-4 text-sm uppercase tracking-wider">Filter by Difficulty</h4>

--- a/src/components/PlayerClient.tsx
+++ b/src/components/PlayerClient.tsx
@@ -10,11 +10,6 @@ import CueText from '@/components/CueText'
 import WordSidebar from '@/components/WordSidebar'
 import { useVocabulary, useUpdateWordStatus } from '@/hooks/useVocabulary'
 
-interface WordCard {
-  word: string
-  status: 'new' | 'added' | 'mastered'
-}
-
 interface SelectedWord {
   word: string
   contextSentence: string
@@ -29,24 +24,12 @@ function parseTimeToSeconds(timestamp: string): number {
   return Number(hh) * 3600 + Number(mm) * 60 + Number(ss) + Number(ms) / 1000
 }
 
-function extractVocabWords(cues: TranscriptCue[]): WordCard[] {
-  const allText = cues.map((c) => c.text).join(' ')
-  const words = allText
-    .split(/\s+/)
-    .map((w) => w.replace(/[^a-zA-Z]/g, '').toLowerCase())
-    .filter((w) => w.length >= 5)
-  const unique = Array.from(new Set(words)).slice(0, 8)
-  return unique.map((word) => ({ word, status: 'new' }))
-}
-
 export default function PlayerClient({ video }: { video: Video }) {
   const { data: vocabMap = new Map() } = useVocabulary()
   const updateWordStatus = useUpdateWordStatus()
   const [cues, setCues] = useState<TranscriptCue[]>([])
   const [loadingTranscript, setLoadingTranscript] = useState(true)
   const [activeCueIndex, setActiveCueIndex] = useState(0)
-  const [activeTab, setActiveTab] = useState<'transcript' | 'vocabulary'>('transcript')
-  const [vocabWords, setVocabWords] = useState<WordCard[]>([])
   const [isMiniPlayerOpen, setIsMiniPlayerOpen] = useState(false)
   const [playbackTime, setPlaybackTime] = useState({ current: 0, duration: 0 })
   const [requestedSeekTime, setRequestedSeekTime] = useState<number | null>(null)
@@ -69,11 +52,9 @@ export default function PlayerClient({ video }: { video: Video }) {
       .then((data) => {
         const fetchedCues: TranscriptCue[] = data.cues ?? []
         setCues(fetchedCues)
-        setVocabWords(extractVocabWords(fetchedCues))
       })
       .catch(() => {
         setCues([])
-        setVocabWords([])
       })
       .finally(() => setLoadingTranscript(false))
   }, [video.id])
@@ -97,14 +78,6 @@ export default function PlayerClient({ video }: { video: Video }) {
     }
   }, [highlightedCueIndex])
 
-  function handleWordAction(word: string, action: 'add' | 'master') {
-    setVocabWords((prev) =>
-      prev.map((w) =>
-        w.word === word ? { ...w, status: action === 'add' ? 'added' : 'mastered' } : w
-      )
-    )
-  }
-
   return (
     <div data-testid="player-client" className="min-h-screen bg-surface dark:bg-slate-900">
       <section className="mx-auto w-full max-w-3xl px-4 py-8 md:px-8">
@@ -117,140 +90,61 @@ export default function PlayerClient({ video }: { video: Video }) {
             <h2 className="font-bold text-on-surface dark:text-slate-100">Interactive Transcript</h2>
           </div>
 
-          <div className="flex border-b border-outline-variant/20 dark:border-slate-700">
-            <button
-              className={`flex-1 py-3 text-sm font-bold transition-colors ${
-                activeTab === 'transcript'
-                  ? 'text-primary border-b-2 border-primary'
-                  : 'font-medium text-on-surface-variant hover:text-on-surface'
-              }`}
-              onClick={() => setActiveTab('transcript')}
-              data-testid="tab-transcript"
-            >
-              Transcript
-            </button>
-            <button
-              className={`flex-1 py-3 text-sm transition-colors ${
-                activeTab === 'vocabulary'
-                  ? 'text-primary font-bold border-b-2 border-primary'
-                  : 'font-medium text-on-surface-variant hover:text-on-surface'
-              }`}
-              onClick={() => setActiveTab('vocabulary')}
-              data-testid="tab-vocabulary"
-            >
-              Vocabulary
-            </button>
-          </div>
-
           <div className={`flex-1 overflow-y-auto p-4 space-y-3 ${isMiniPlayerOpen ? 'pb-52' : ''}`}>
-            {activeTab === 'transcript' && (
-              <>
-                {loadingTranscript && (
-                  <p className="text-sm text-on-surface-variant dark:text-slate-400 text-center py-8">
-                    Loading transcript…
+            <>
+              {loadingTranscript && (
+                <p className="text-sm text-on-surface-variant dark:text-slate-400 text-center py-8">
+                  Loading transcript…
+                </p>
+              )}
+              {!loadingTranscript && cues.length === 0 && (
+                <div className="flex flex-col items-center justify-center py-12 text-center gap-3">
+                  <span className="text-3xl">📄</span>
+                  <p className="text-on-surface font-semibold">No transcript available</p>
+                  <p className="text-sm text-on-surface-variant">
+                    Upload a transcript file to enable interactive subtitles.
                   </p>
-                )}
-                {!loadingTranscript && cues.length === 0 && (
-                  <div className="flex flex-col items-center justify-center py-12 text-center gap-3">
-                    <span className="text-3xl">📄</span>
-                    <p className="text-on-surface font-semibold">No transcript available</p>
-                    <p className="text-sm text-on-surface-variant">
-                      Upload a transcript file to enable interactive subtitles.
-                    </p>
-                  </div>
-                )}
-                {!loadingTranscript &&
-                  cues.map((cue, i) => {
-                    const isPast = i < highlightedCueIndex
-                    const isActive = i === highlightedCueIndex
-                    return (
-                      <div
-                        key={cue.index}
-                        onClick={() => {
-                          setActiveCueIndex(i)
-                          setRequestedSeekTime(parseTimeToSeconds(cue.startTime))
-                        }}
-                        data-testid={`cue-${i}`}
-                        className={`cursor-pointer transition-all ${
-                          isPast
-                            ? 'opacity-40 text-sm text-on-surface-variant dark:text-slate-400 px-3 py-2'
-                            : isActive
-                            ? 'bg-surface-container dark:bg-slate-800 rounded-xl p-3 ring-1 ring-primary/10 border-l-4 border-primary'
-                            : 'opacity-60 text-sm text-on-surface dark:text-slate-100 px-3 py-2'
-                        }`}
-                      >
-                        {isActive ? (
-                          <p className="text-sm text-on-surface dark:text-slate-100 leading-relaxed">
-                            <CueText
-                              text={cue.text}
-                              vocabMap={vocabMap}
-                              onWordClick={(word, sentence) => setSelectedWord({ word, contextSentence: sentence })}
-                            />
-                          </p>
-                        ) : (
+                </div>
+              )}
+              {!loadingTranscript &&
+                cues.map((cue, i) => {
+                  const isPast = i < highlightedCueIndex
+                  const isActive = i === highlightedCueIndex
+                  return (
+                    <div
+                      key={cue.index}
+                      onClick={() => {
+                        setActiveCueIndex(i)
+                        setRequestedSeekTime(parseTimeToSeconds(cue.startTime))
+                      }}
+                      data-testid={`cue-${i}`}
+                      className={`cursor-pointer transition-all ${
+                        isPast
+                          ? 'opacity-40 text-sm text-on-surface-variant dark:text-slate-400 px-3 py-2'
+                          : isActive
+                          ? 'bg-surface-container dark:bg-slate-800 rounded-xl p-3 ring-1 ring-primary/10 border-l-4 border-primary'
+                          : 'opacity-60 text-sm text-on-surface dark:text-slate-100 px-3 py-2'
+                      }`}
+                    >
+                      {isActive ? (
+                        <p className="text-sm text-on-surface dark:text-slate-100 leading-relaxed">
                           <CueText
                             text={cue.text}
                             vocabMap={vocabMap}
                             onWordClick={(word, sentence) => setSelectedWord({ word, contextSentence: sentence })}
                           />
-                        )}
-                      </div>
-                    )
-                  })}
-              </>
-            )}
-
-            {activeTab === 'vocabulary' && (
-              <>
-                {vocabWords.length === 0 ? (
-                  <div className="flex flex-col items-center justify-center py-12 text-center gap-3">
-                    <span className="text-3xl">📚</span>
-                    <p className="text-on-surface font-semibold">No vocabulary yet</p>
-                    <p className="text-sm text-on-surface-variant">
-                      Words from the transcript will appear here.
-                    </p>
-                  </div>
-                ) : (
-                  vocabWords.map(({ word, status }) => (
-                    <div
-                      key={word}
-                      data-testid={`vocab-${word}`}
-                      className="bg-surface-container dark:bg-slate-800 rounded-xl p-4 flex flex-col gap-2"
-                    >
-                      <div className="flex items-center justify-between">
-                        <span className="font-bold text-on-surface dark:text-slate-100 capitalize">{word}</span>
-                        {status === 'added' && (
-                          <span className="px-2 py-0.5 text-xs font-bold rounded-full bg-secondary-container text-on-secondary-container">
-                            Added
-                          </span>
-                        )}
-                        {status === 'mastered' && (
-                          <span className="px-2 py-0.5 text-xs font-bold rounded-full bg-primary text-on-primary">
-                            Mastered
-                          </span>
-                        )}
-                      </div>
-                      <div className="flex gap-2">
-                        <button
-                          onClick={() => handleWordAction(word, 'add')}
-                          disabled={status !== 'new'}
-                          className="flex-1 py-1.5 text-xs font-bold rounded-lg bg-primary-container text-on-primary-container hover:opacity-80 disabled:opacity-40 transition-opacity"
-                        >
-                          {status === 'added' ? 'Added to Deck' : 'Add to Deck'}
-                        </button>
-                        <button
-                          onClick={() => handleWordAction(word, 'master')}
-                          disabled={status === 'mastered'}
-                          className="flex-1 py-1.5 text-xs font-bold rounded-lg bg-surface-container-highest text-on-surface-variant hover:opacity-80 disabled:opacity-40 transition-opacity"
-                        >
-                          {status === 'mastered' ? 'Mastered ✓' : 'Mark Mastered'}
-                        </button>
-                      </div>
+                        </p>
+                      ) : (
+                        <CueText
+                          text={cue.text}
+                          vocabMap={vocabMap}
+                          onWordClick={(word, sentence) => setSelectedWord({ word, contextSentence: sentence })}
+                        />
+                      )}
                     </div>
-                  ))
-                )}
-              </>
-            )}
+                  )
+                })}
+            </>
           </div>
         </div>
       </section>

--- a/src/components/__tests__/PlayerClient.test.tsx
+++ b/src/components/__tests__/PlayerClient.test.tsx
@@ -78,10 +78,10 @@ describe('PlayerClient', () => {
     expect(screen.getByTestId('mini-player')).toBeInTheDocument()
   })
 
-  it('renders the transcript tab area', async () => {
+  it('renders the transcript panel', async () => {
     render(<PlayerClient video={mockVideo} />)
-    expect(screen.getByTestId('tab-transcript')).toBeInTheDocument()
-    expect(screen.getByTestId('tab-vocabulary')).toBeInTheDocument()
+    expect(screen.getByText('Interactive Transcript')).toBeInTheDocument()
+    expect(screen.queryByTestId('tab-vocabulary')).not.toBeInTheDocument()
   })
 
   it('fetches transcript on mount', async () => {

--- a/tests/e2e/cross-screen.spec.ts
+++ b/tests/e2e/cross-screen.spec.ts
@@ -24,7 +24,16 @@ const MOCK_VIDEO = {
 }
 
 test.describe('Cross-screen: Vocabulary page', () => {
+  const MOCK_VOCAB_ENTRIES = [
+    { word: 'ethereal', status: 'new', level: 'B2', definition: 'Extremely delicate' },
+    { word: 'eloquent', status: 'new', level: 'B1', definition: 'Fluent or persuasive' },
+    { word: 'serendipity', status: 'learning', level: 'B2', definition: 'Happy chance' },
+  ]
+
   test('renders the vocabulary manager heading', async ({ page }) => {
+    await page.route('**/api/vocabulary', async route => {
+      await route.fulfill({ json: MOCK_VOCAB_ENTRIES })
+    })
     const vocab = new VocabularyPage(page)
     await vocab.navigateTo()
     await vocab.assertLoaded()
@@ -32,15 +41,20 @@ test.describe('Cross-screen: Vocabulary page', () => {
   })
 
   test('renders word cards in the New Words tab', async ({ page }) => {
+    await page.route('**/api/vocabulary', async route => {
+      await route.fulfill({ json: MOCK_VOCAB_ENTRIES })
+    })
     const vocab = new VocabularyPage(page)
     await vocab.navigateTo()
     await vocab.assertLoaded()
     const count = await vocab.getCardCount()
-    // MOCK_VOCAB contains words in 'new' status by default
     expect(count).toBeGreaterThan(0)
   })
 
   test('search filters vocab cards', async ({ page }) => {
+    await page.route('**/api/vocabulary', async route => {
+      await route.fulfill({ json: MOCK_VOCAB_ENTRIES })
+    })
     const vocab = new VocabularyPage(page)
     await vocab.navigateTo()
     await vocab.assertLoaded()
@@ -49,6 +63,9 @@ test.describe('Cross-screen: Vocabulary page', () => {
   })
 
   test('tab switching works', async ({ page }) => {
+    await page.route('**/api/vocabulary', async route => {
+      await route.fulfill({ json: MOCK_VOCAB_ENTRIES })
+    })
     const vocab = new VocabularyPage(page)
     await vocab.navigateTo()
     await vocab.assertLoaded()
@@ -88,12 +105,15 @@ test.describe('Cross-screen: Player page', () => {
     await page.route(`**/api/videos/${MOCK_VIDEO.id}/transcript`, async route => {
       await route.fulfill({ json: { cues: [] } })
     })
+    await page.route('**/api/vocabulary', async route => {
+      await route.fulfill({ json: [] })
+    })
 
     await player.navigateTo(MOCK_VIDEO.id)
     await player.assertLoaded()
   })
 
-  test('can switch to vocabulary tab in player', async ({ page }) => {
+  test('transcript is visible without tab navigation', async ({ page }) => {
     const player = new PlayerPage(page)
 
     await page.route(`**/api/videos/${MOCK_VIDEO.id}`, async route => {
@@ -102,10 +122,12 @@ test.describe('Cross-screen: Player page', () => {
     await page.route(`**/api/videos/${MOCK_VIDEO.id}/transcript`, async route => {
       await route.fulfill({ json: { cues: [] } })
     })
+    await page.route('**/api/vocabulary', async route => {
+      await route.fulfill({ json: [] })
+    })
 
     await player.navigateTo(MOCK_VIDEO.id)
     await player.assertLoaded()
-    await player.switchToVocabTab()
-    await expect(player.vocabTab).toBeVisible()
+    await expect(page.getByTestId('tab-vocabulary')).not.toBeAttached()
   })
 })

--- a/tests/e2e/pages/PlayerPage.ts
+++ b/tests/e2e/pages/PlayerPage.ts
@@ -2,7 +2,7 @@
  * PlayerPage: page-object for the lingoFlow player route (/player/[id]).
  *
  * Encapsulates all interactions with the player screen, including
- * navigation, transcript panel, vocabulary tab, and tab switching.
+ * navigation, transcript panel, and playback controls.
  */
 
 import { expect, type Page, type Locator } from '@playwright/test'
@@ -11,7 +11,6 @@ export class PlayerPage {
   readonly page: Page
   readonly playerClient: Locator
   readonly transcriptTab: Locator
-  readonly vocabTab: Locator
   readonly playButton: Locator
   readonly miniPlayer: Locator
   readonly miniPlayerClose: Locator
@@ -24,7 +23,6 @@ export class PlayerPage {
     this.page = page
     this.playerClient = page.getByTestId('player-client')
     this.transcriptTab = page.getByTestId('tab-transcript')
-    this.vocabTab = page.getByTestId('tab-vocabulary')
     this.playButton = page.getByTestId('play-button')
     this.miniPlayer = page.getByTestId('mini-player')
     this.miniPlayerClose = page.getByTestId('mini-player-close')
@@ -44,11 +42,6 @@ export class PlayerPage {
   async assertLoaded(): Promise<void> {
     await expect(this.playerClient).toBeAttached({ timeout: 30_000 })
     await expect(this.playerClient).toBeVisible({ timeout: 30_000 })
-  }
-
-  /** Clicks the Vocabulary tab. */
-  async switchToVocabTab(): Promise<void> {
-    await this.vocabTab.click()
   }
 
   /** Clicks the Transcript tab. */


### PR DESCRIPTION
Closes #157

## Summary

- **Remove player Vocabulary tab**: Removed `activeTab`, `vocabWords`, `extractVocabWords`, and `handleWordAction` from `PlayerClient`. Transcript panel is now always visible without tab navigation.
- **Global vocab reuse confirmed**: `useVocabulary()` hook (fetches `GET /api/vocabulary`) was already global — no per-video scoping needed. Retained as-is for transcript word colorization.
- **Vocabulary page wired to real data**: `vocabulary/page.tsx` now uses `useVocabulary()` hook and `useUpdateWordStatus()` mutation instead of `MOCK_VOCAB`. Removed source filter (not in `VocabEntry`).
- **Tests updated**: Vocabulary page unit tests mocked via `jest.mock('@/hooks/useVocabulary')`. E2E cross-screen tests updated to stub `/api/vocabulary` and replaced the vocabulary-tab-in-player test with a check that confirms `tab-vocabulary` is absent.