### PR TITLE
refactor: extract shared data-dir utilities (#165)

### DIFF
--- a/src/app/api/videos/import/route.ts
+++ b/src/app/api/videos/import/route.ts
@@ -4,10 +4,9 @@ import path from 'path'
 import { videoService, videoStore } from '@/lib/server/composition'
 import { ImportLocalVideoRequestSchema } from '@/lib/api-schemas'
 import { generateThumbnail } from '@/lib/thumbnails'
+import { getThumbnailsDir } from '@/lib/data-dir'
 
 export const runtime = 'nodejs'
-
-const dataDir = process.env.LINGOFLOW_DATA_DIR ?? path.join(process.cwd(), '.lingoflow-data')
 
 export async function POST(request: NextRequest) {
   try {
@@ -55,7 +54,7 @@ export async function POST(request: NextRequest) {
     })
 
     if (record.local_video_path) {
-      const thumbnailPath = path.join(dataDir, 'thumbnails', `${videoId}.jpg`)
+      const thumbnailPath = path.join(getThumbnailsDir(), `${videoId}.jpg`)
       void generateThumbnail(record.local_video_path, thumbnailPath)
         .then((resolvedPath) => {
           if (resolvedPath) {

--- a/src/lib/__tests__/data-dir.test.ts
+++ b/src/lib/__tests__/data-dir.test.ts
@@ -1,0 +1,80 @@
+/**
+ * @jest-environment node
+ */
+import path from 'path'
+
+describe('data-dir module', () => {
+  let originalEnv: string | undefined
+
+  beforeEach(() => {
+    originalEnv = process.env.LINGOFLOW_DATA_DIR
+    jest.resetModules()
+  })
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.LINGOFLOW_DATA_DIR
+    } else {
+      process.env.LINGOFLOW_DATA_DIR = originalEnv
+    }
+  })
+
+  describe('getDataDir()', () => {
+    it('returns LINGOFLOW_DATA_DIR when set', async () => {
+      process.env.LINGOFLOW_DATA_DIR = '/custom/data'
+      const { getDataDir } = await import('../data-dir')
+      expect(getDataDir()).toBe('/custom/data')
+    })
+
+    it('falls back to .lingoflow-data in cwd when env var is not set', async () => {
+      delete process.env.LINGOFLOW_DATA_DIR
+      const { getDataDir } = await import('../data-dir')
+      expect(getDataDir()).toBe(path.join(process.cwd(), '.lingoflow-data'))
+    })
+  })
+
+  describe('getTranscriptsDir()', () => {
+    it('returns transcripts subdir inside data dir', async () => {
+      process.env.LINGOFLOW_DATA_DIR = '/my/data'
+      const { getTranscriptsDir } = await import('../data-dir')
+      expect(getTranscriptsDir()).toBe('/my/data/transcripts')
+    })
+  })
+
+  describe('getVideosDir()', () => {
+    it('returns videos subdir inside data dir', async () => {
+      process.env.LINGOFLOW_DATA_DIR = '/my/data'
+      const { getVideosDir } = await import('../data-dir')
+      expect(getVideosDir()).toBe('/my/data/videos')
+    })
+  })
+
+  describe('getThumbnailsDir()', () => {
+    it('returns thumbnails subdir inside data dir', async () => {
+      process.env.LINGOFLOW_DATA_DIR = '/my/data'
+      const { getThumbnailsDir } = await import('../data-dir')
+      expect(getThumbnailsDir()).toBe('/my/data/thumbnails')
+    })
+  })
+
+  describe('getDbPath()', () => {
+    it('returns lingoflow.db path inside data dir', async () => {
+      process.env.LINGOFLOW_DATA_DIR = '/my/data'
+      const { getDbPath } = await import('../data-dir')
+      expect(getDbPath()).toBe('/my/data/lingoflow.db')
+    })
+  })
+
+  describe('subdirectory getters use getDataDir()', () => {
+    it('all subdirectory getters reflect the same data dir', async () => {
+      process.env.LINGOFLOW_DATA_DIR = '/unified/root'
+      const { getDataDir, getTranscriptsDir, getVideosDir, getThumbnailsDir, getDbPath } =
+        await import('../data-dir')
+      const base = getDataDir()
+      expect(getTranscriptsDir()).toBe(path.join(base, 'transcripts'))
+      expect(getVideosDir()).toBe(path.join(base, 'videos'))
+      expect(getThumbnailsDir()).toBe(path.join(base, 'thumbnails'))
+      expect(getDbPath()).toBe(path.join(base, 'lingoflow.db'))
+    })
+  })
+})

--- a/src/lib/data-dir.ts
+++ b/src/lib/data-dir.ts
@@ -1,0 +1,21 @@
+import path from 'path'
+
+export function getDataDir(): string {
+  return process.env.LINGOFLOW_DATA_DIR ?? path.join(process.cwd(), '.lingoflow-data')
+}
+
+export function getTranscriptsDir(): string {
+  return path.join(getDataDir(), 'transcripts')
+}
+
+export function getVideosDir(): string {
+  return path.join(getDataDir(), 'videos')
+}
+
+export function getThumbnailsDir(): string {
+  return path.join(getDataDir(), 'thumbnails')
+}
+
+export function getDbPath(): string {
+  return path.join(getDataDir(), 'lingoflow.db')
+}

--- a/src/lib/server/composition.ts
+++ b/src/lib/server/composition.ts
@@ -8,17 +8,19 @@
  * Example:
  *   LINGOFLOW_DATA_DIR=/var/data/lingoflow pnpm start
  */
-import path from 'path'
 import { ensureDataDirs, openDb, initializeSchema } from '@/lib/db'
 import { SqliteVideoStore } from '@/lib/video-store'
 import { VideoService } from '@/lib/video-service'
 import { writeTranscript, deleteTranscript } from '@/lib/transcripts'
 import { SqliteVocabStore } from '@/lib/vocab-store'
+import { getDataDir, getDbPath, getVideosDir } from '@/lib/data-dir'
 import fs from 'fs'
+import path from 'path'
 
-function createContainer(dataDir: string) {
+function createContainer() {
+  const dataDir = getDataDir()
   ensureDataDirs(dataDir)
-  const db = openDb(path.join(dataDir, 'lingoflow.db'))
+  const db = openDb(getDbPath())
   initializeSchema(db)
 
   const store = new SqliteVideoStore(db)
@@ -29,7 +31,7 @@ function createContainer(dataDir: string) {
   }
   const videoFileStore = {
     write: (videoId: string, ext: string, buffer: Buffer): string => {
-      const videosDir = path.join(dataDir, 'videos')
+      const videosDir = getVideosDir()
       fs.mkdirSync(videosDir, { recursive: true })
       const filePath = path.join(videosDir, `${videoId}.${ext}`)
       fs.writeFileSync(filePath, buffer)
@@ -48,7 +50,6 @@ function createContainer(dataDir: string) {
   return { videoStore: store, videoService: service, vocabStore }
 }
 
-const dataDir = process.env.LINGOFLOW_DATA_DIR ?? path.join(process.cwd(), '.lingoflow-data')
-const { videoStore, videoService, vocabStore } = createContainer(dataDir)
+const { videoStore, videoService, vocabStore } = createContainer()
 
 export { videoStore, videoService, vocabStore }

--- a/src/lib/transcripts.ts
+++ b/src/lib/transcripts.ts
@@ -1,13 +1,8 @@
 import fs from 'fs'
 import path from 'path'
+import { getTranscriptsDir } from '@/lib/data-dir'
 
-function getDataDir(): string {
-  return process.env.LINGOFLOW_DATA_DIR ?? path.join(process.cwd(), '.lingoflow-data')
-}
-
-export function getTranscriptsDir(): string {
-  return path.join(getDataDir(), 'transcripts')
-}
+export { getTranscriptsDir }
 
 export function buildTranscriptPath(videoId: string, ext: string): string {
   return path.join(getTranscriptsDir(), `${videoId}.${ext}`)

--- a/src/lib/video-files.ts
+++ b/src/lib/video-files.ts
@@ -1,13 +1,8 @@
 import fs from 'fs'
 import path from 'path'
+import { getVideosDir } from '@/lib/data-dir'
 
-function getDataDir(): string {
-  return process.env.LINGOFLOW_DATA_DIR ?? path.join(process.cwd(), '.lingoflow-data')
-}
-
-export function getVideosDir(): string {
-  return path.join(getDataDir(), 'videos')
-}
+export { getVideosDir }
 
 export function buildVideoFilePath(videoId: string, ext: string): string {
   return path.join(getVideosDir(), `${videoId}.${ext}`)


### PR DESCRIPTION
## Summary

Resolves #165.

Extracts the copy-pasted `getDataDir()` helper into a single canonical module `src/lib/data-dir.ts`, eliminating four independent copies that could silently diverge.

## Changes

### New
- `src/lib/data-dir.ts` — single source of truth for all data directory paths
  - `getDataDir()` — reads `LINGOFLOW_DATA_DIR` env var, falls back to `.lingoflow-data`
  - `getTranscriptsDir()` — `getDataDir() + '/transcripts'`
  - `getVideosDir()` — `getDataDir() + '/videos'`
  - `getThumbnailsDir()` — `getDataDir() + '/thumbnails'`
  - `getDbPath()` — `getDataDir() + '/lingoflow.db'`
- `src/lib/__tests__/data-dir.test.ts` — boundary tests for all exported functions, covering env var override and default fallback

### Modified (callers migrated)
- `src/lib/transcripts.ts` — removes private `getDataDir()`; imports `getTranscriptsDir` from `data-dir`; re-exports for backward compat
- `src/lib/video-files.ts` — removes private `getDataDir()`; imports `getVideosDir` from `data-dir`; re-exports for backward compat
- `src/lib/server/composition.ts` — removes inline env var logic; uses `getDataDir()`, `getDbPath()`, `getVideosDir()` from `data-dir`; `createContainer` simplified to zero-argument function
- `src/app/api/videos/import/route.ts` — removes module-level `dataDir` constant; uses `getThumbnailsDir()` from `data-dir`

## No behavioral change
Pure extraction — every caller resolves the same paths as before. Adding a new data subdirectory is now a one-line change in `data-dir.ts`.