### PR TITLE
feat: export createContainer/getContainer for per-test DI isolation

### DIFF
--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -1,0 +1,355 @@
+# LingoFlow — E2E Testing Reference
+
+> Playwright 1.59, Chromium only. Tests live in `tests/e2e/`. Run with `pnpm test:e2e`.
+
+---
+
+## Configuration (`playwright.config.ts`)
+
+```ts
+// Key settings
+testDir: './tests/e2e'
+testMatch: ['**/*.spec.ts']
+fullyParallel: true
+retries: 2   // CI only
+baseURL: 'http://localhost:3000'
+trace: 'retain-on-failure'
+
+// webServer auto-starts `pnpm dev` with isolated data dir
+// reuseExistingServer: true locally (skips restart if port 3000 is up)
+env: { LINGOFLOW_DATA_DIR: '<unique-tmp-dir-per-run>' }
+```
+
+Only `chromium` project is configured — no Firefox/WebKit.
+
+---
+
+## Test Structure
+
+```ts
+import { test, expect } from '@playwright/test'
+
+test.describe('Feature name', () => {
+  test.use({ viewport: { width: 1280, height: 900 } })  // optional override
+
+  test('scenario description', async ({ page }) => {
+    test.setTimeout(120_000)   // extend for slow tests
+    // ... arrange, act, assert
+  })
+})
+```
+
+### Error monitoring pattern
+
+```ts
+const consoleErrors: string[] = []
+const pageErrors: string[] = []
+page.on('console', msg => { if (msg.type() === 'error') consoleErrors.push(msg.text()) })
+page.on('pageerror', error => { pageErrors.push(error.message) })
+// ...
+expect(consoleErrors).toEqual([])
+expect(pageErrors).toEqual([])
+```
+
+---
+
+## Page Object Model (POM)
+
+All POM classes live in `tests/e2e/pages/`. Each takes a `Page` and wraps interactions behind descriptive async methods.
+
+### `DashboardPage`
+
+```ts
+import { DashboardPage } from './pages/DashboardPage'
+const dashboard = new DashboardPage(page)
+
+await dashboard.loadDashboard()          // goto('/dashboard', { waitUntil: 'networkidle' })
+await dashboard.assertEmpty()            // expects data-testid="empty-state" visible
+await dashboard.assertLoading()          // expects data-testid="loading-indicator" visible
+await dashboard.assertVideoCardCount(2)  // counts [data-testid^="video-card-"] in grid
+const cards = await dashboard.getVideoCards()  // Locator[]
+dashboard.videoCards()                   // Locator (all video cards in grid)
+```
+
+### `ImportActions`
+
+```ts
+import { ImportActions } from './pages/ImportActions'
+const importActions = new ImportActions(page)
+
+await importActions.clickImportButton()   // opens import-modal
+await importActions.fillTitle('My Video')
+await importActions.fillVideoFile('/abs/path/to/video.mp4')
+// or with buffer:
+await importActions.fillVideoFile({ name: 'video.mp4', mimeType: 'video/mp4', buffer: Buffer.from('...') })
+await importActions.fillTranscriptFile('/abs/path/to/sample.srt')
+await importActions.fillTags('french, beginner')   // comma-separated
+await importActions.clickSubmitImport()
+await importActions.assertValidationError('Title is required')  // message optional
+```
+
+### `EditActions`
+
+```ts
+import { EditActions } from './pages/EditActions'
+const editActions = new EditActions(page)
+
+await editActions.clickEditOnCard(0)     // zero-based index in grid
+await editActions.addTag('newTag')       // fill + Enter
+await editActions.removeTag('oldTag')   // clicks data-testid="remove-tag-{tagName}"
+await editActions.clickSave()           // Save button → waits for modal to close
+await editActions.assertTagsSaved(['newTag'])  // checks tags visible on page
+```
+
+### `DeleteActions`
+
+```ts
+import { DeleteActions } from './pages/DeleteActions'
+const deleteActions = new DeleteActions(page)
+
+await deleteActions.clickDeleteOnCard(0)        // zero-based index
+await deleteActions.confirmDelete()             // confirm-delete-button → waits modal to close
+await deleteActions.assertCardRemoved('video-id-123')  // expects card hidden
+```
+
+### `PlayerPage`
+
+```ts
+import { PlayerPage } from './pages/PlayerPage'
+const player = new PlayerPage(page)
+
+await player.navigateTo('video-id-123')   // goto + waits for player-client to attach (30s)
+await player.assertLoaded()
+await player.clickPlay()
+await player.assertMiniPlayerOpen()       // mini-player + local-video visible
+await player.closeMiniPlayer()
+await player.assertMiniPlayerClosed()
+await player.switchToTranscriptTab()
+
+// Direct locators
+player.playButton          // data-testid="play-button"
+player.miniPlayer          // data-testid="mini-player"
+player.miniPlayerClose     // data-testid="mini-player-close"
+player.miniPlayerIframe    // data-testid="local-video" (<video> element)
+player.playbackProgress    // data-testid="playback-progress"
+player.progressBarFill     // data-testid="progress-bar-fill"
+player.currentTime         // data-testid="current-time"
+player.transcriptTab       // data-testid="tab-transcript"
+```
+
+### `VocabularyPage`
+
+```ts
+import { VocabularyPage } from './pages/VocabularyPage'
+const vocabPage = new VocabularyPage(page)
+
+await vocabPage.navigateTo()        // goto('/vocabulary', { waitUntil: 'networkidle' })
+await vocabPage.assertLoaded()      // vocab-page-heading visible
+await vocabPage.search('bonjour')   // fills vocab-search-input
+await vocabPage.clickTab('mastered')  // 'new' | 'learning' | 'mastered'
+const count = await vocabPage.getCardCount()
+
+vocabPage.heading      // data-testid="vocab-page-heading"
+vocabPage.vocabCards   // data-testid="vocab-card"
+vocabPage.searchInput  // data-testid="vocab-search-input"
+```
+
+---
+
+## API Route Interception
+
+Use `page.route()` to stub API calls in tests that don't need a real server.
+
+```ts
+// Stub GET /api/videos
+await page.route('**/api/videos', async route => {
+  await route.fulfill({ json: videos })
+})
+
+// Stub POST and mutate local state
+let videos: Video[] = []
+await page.route('**/api/videos/import', async route => {
+  videos = [importedVideo]
+  await route.fulfill({ status: 201, json: importedVideo })
+})
+
+// Stub video stream (binary body)
+await page.route(`**/api/videos/${id}/stream`, async route => {
+  const mp4Buffer = fs.readFileSync(TEST_MP4)
+  await route.fulfill({
+    status: 200,
+    headers: { 'Content-Type': 'video/mp4', 'Accept-Ranges': 'bytes' },
+    body: mp4Buffer,
+  })
+})
+
+// Stub DELETE
+await page.route(`**/api/videos/${id}`, async route => {
+  if (route.request().method() === 'DELETE') {
+    await route.fulfill({ status: 204 })
+  } else {
+    await route.continue()
+  }
+})
+```
+
+---
+
+## Fixtures (`tests/e2e/fixtures/index.ts`)
+
+Used when tests need a real DB (not route-stubbed).
+
+```ts
+import {
+  setupIsolatedDb,
+  teardownIsolatedDb,
+  seedVideo,
+  seedTranscript,
+  type FixtureContext,
+  type SeedVideoParams,
+} from '../fixtures'
+
+// In beforeAll/afterAll or beforeEach/afterEach:
+let ctx: FixtureContext
+beforeAll(() => { ctx = setupIsolatedDb(workerIndex) })
+afterAll(() => { teardownIsolatedDb(ctx) })
+
+// Seed a video with defaults (all fields optional):
+const video = seedVideo({ id: 'abc', title: 'French Lesson', tags: ['french'] })
+
+// Seed a transcript file:
+const filePath = seedTranscript('abc', 'srt', '1\n00:00:01,000 --> 00:00:02,000\nBonjour\n')
+```
+
+`setupIsolatedDb` creates a temp dir, sets `LINGOFLOW_DATA_DIR`, and initializes the SQLite schema.  
+`teardownIsolatedDb` closes the DB singleton, restores env, and removes the temp dir.
+
+---
+
+## Sample Fixtures
+
+```
+tests/e2e/fixtures/
+  sample.srt     # real SRT file used in transcript upload tests
+  test.mp4       # minimal MP4 used in player stream tests
+```
+
+Reference:
+```ts
+import path from 'path'
+const SAMPLE_SRT = path.join(__dirname, 'fixtures', 'sample.srt')
+const TEST_MP4   = path.join(__dirname, 'fixtures', 'test.mp4')
+```
+
+---
+
+## `data-testid` Reference
+
+### Dashboard / VideoCard
+
+| `data-testid` | Element |
+|---|---|
+| `video-grid` | Video card grid container |
+| `video-card-{id}` | Individual video card |
+| `empty-state` | "No videos yet" placeholder |
+| `loading-indicator` | Loading spinner |
+| `edit-button` | Edit button on a card |
+| `delete-button` | Delete button on a card |
+
+### Import Modal
+
+| `data-testid` | Element |
+|---|---|
+| `import-modal` | Modal container |
+| `video-file-input` | `<input type="file">` for video |
+| `local-title-input` | Title text input |
+| `transcript-input` | `<input type="file">` for transcript |
+| `tags-input` | Tags text input (comma-separated) |
+| `submit-import-button` | Submit / import button |
+| `import-error` | Validation error message |
+
+### Edit Modal
+
+| `data-testid` | Element |
+|---|---|
+| `edit-modal` | Modal container |
+| `tag-input` | Tag entry input (press Enter to add) |
+| `remove-tag-{tagName}` | Remove button for a specific tag |
+
+### Delete Modal
+
+| `data-testid` | Element |
+|---|---|
+| `delete-modal` | Modal container |
+| `confirm-delete-button` | Confirm deletion button |
+
+### Player
+
+| `data-testid` | Element |
+|---|---|
+| `player-client` | Root player container |
+| `play-button` | Play / launch mini-player button |
+| `mini-player` | Floating video player wrapper |
+| `mini-player-close` | Close mini-player button |
+| `local-video` | `<video>` element |
+| `playback-progress` | Progress bar container |
+| `progress-bar-fill` | Filled progress bar |
+| `current-time` | Current time label |
+| `duration` | Duration label |
+| `tab-transcript` | Transcript tab |
+| `tab-vocabulary` | In-player vocabulary tab |
+| `cue-{index}` | Transcript cue row (0-based) |
+| `word-{normalized}` | Clickable word span in cue |
+| `word-sidebar` | Word detail slide-over |
+| `word-sidebar-close` | Close word sidebar button |
+| `sidebar-word` | Word heading in sidebar |
+| `sidebar-context` | Context sentence in sidebar |
+| `status-toggle` | Status toggle button in sidebar |
+
+### Vocabulary Page
+
+| `data-testid` | Element |
+|---|---|
+| `vocab-page-heading` | Page heading |
+| `vocab-card` | Individual word card |
+| `vocab-search-input` | Search input |
+| `tab-new` | "New" status tab |
+| `tab-learning` | "Learning" status tab |
+| `tab-mastered` | "Mastered" status tab |
+
+---
+
+## Common Assertions
+
+```ts
+// Visibility
+await expect(locator).toBeVisible()
+await expect(locator).toBeHidden()
+await expect(locator).toBeAttached({ timeout: 30_000 })
+
+// Content
+await expect(locator).toContainText('Expected text')
+await expect(locator).toHaveText('Exact text')
+await expect(locator).toHaveCount(3)
+
+// Classes
+await expect(locator).toHaveClass(/border-primary/)
+await expect(locator).not.toHaveClass(/border-primary/)
+
+// Input value
+await expect(input).toHaveValue('text')
+```
+
+---
+
+## Running E2E Tests
+
+```bash
+pnpm test:e2e                          # all specs, reuses local server on :3000
+pnpm test:e2e -- --headed              # show browser
+pnpm test:e2e -- tests/e2e/player.spec.ts  # single spec
+pnpm test:e2e -- --grep "import"       # filter by name
+pnpm test:e2e:ui                       # interactive UI mode
+```
+
+E2E tests stub YouTube. `E2E_STUB_YOUTUBE=true` is auto-set by the `webServer` config.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,67 @@
+# LingoFlow Docs — Navigation Index
+
+> Quick reference for coding agents. All docs are in `/workspaces/lingoFlow/docs/`.
+
+---
+
+## Files
+
+| File | Contents |
+|---|---|
+| [`api-docs.md`](./api-docs.md) | Tech stack versions, API patterns, library references |
+| [`e2e-testing.md`](./e2e-testing.md) | Playwright config, Page Object Model, fixtures, `data-testid` reference |
+| [`project-docs.md`](./project-docs.md) | Architecture, directory layout, build/test commands, design decisions |
+
+---
+
+## api-docs.md — Sections
+
+| Section | Relevant Issue(s) |
+|---|---|
+| Tech Stack Summary | — |
+| Next.js App Router Patterns | all |
+| REST API Endpoints | all |
+| Tags API Contract | — |
+| Zod v4 Patterns | — |
+| better-sqlite3 / SQLite Patterns | #166 |
+| Dependency Injection / Composition Root | #166 |
+| TanStack React Query v5 Patterns | #167 |
+| Custom Hooks | #163, #167 |
+| Transcript Utilities | — |
+| File & Data Layout | #165 |
+| Testing Patterns | #163, #166 |
+| **Data Directory Module** | **#165** |
+| **React useReducer Pattern** | **#163** |
+| **PostImportTask Plugin System** | **#164** |
+| **DI Containers — createContainer / getContainer** | **#166** |
+| **React Query — useQueries (Parallel Fetching)** | **#167** |
+| **ApiClient Context Pattern** | **#167** |
+| TypeScript Types Quick Reference | — |
+
+---
+
+## Open Issues Addressed
+
+| Issue | Title | Key API Patterns |
+|---|---|---|
+| #163 | Replace useState with useReducer in useImportVideoForm | `useReducer`, discriminated union actions, pure reducer testing |
+| #164 | PostImportTask plugin system on VideoService | `PostImportTask` interface, `registerPostImportTask`, `drainPostImportTasks` |
+| #165 | Extract getDataDir() to data-dir.ts | `getDataDir`, `getTranscriptsDir`, `getVideosDir`, `getThumbnailsDir`, `getDbPath` |
+| #166 | Export createContainer/getContainer for per-test DI | `createContainer`, `getContainer`, `Database(':memory:')`, `jest.spyOn` |
+| #167 | FetchApiClient + usePlayerData unified data-fetching | `useQueries`, `ApiClient` interface, `ApiClientProvider`, `usePlayerData` |
+
+---
+
+## Stack Versions (from package.json)
+
+| Library | Version |
+|---|---|
+| Next.js | 16.2.3 |
+| React | 19.2.4 |
+| TypeScript | ^5 |
+| TanStack React Query | ^5.96.2 |
+| better-sqlite3 | ^12.8.0 |
+| Zod | ^4.3.6 |
+| Jest | ^30.3.0 |
+| Playwright | ^1.59.1 |
+| Tailwind CSS | ^3.4.19 |

--- a/docs/project-state.md
+++ b/docs/project-state.md
@@ -1,0 +1,551 @@
+# LingoFlow — Project State Snapshot
+
+> Generated for issue #166: Export `createContainer` + `getContainer` for per-test DI isolation.
+> Provides everything a coding agent needs to implement that issue without re-exploring the repo.
+
+---
+
+## 1. `src/` File Tree (2 levels deep)
+
+```
+src/
+├── app/
+│   ├── (app)/
+│   │   ├── dashboard/
+│   │   │   ├── page.tsx
+│   │   │   └── __tests__/page.test.tsx
+│   │   ├── player/
+│   │   │   ├── layout.tsx
+│   │   │   └── [id]/page.tsx
+│   │   └── vocabulary/
+│   │       ├── page.tsx
+│   │       └── __tests__/page.test.tsx
+│   │   └── layout.tsx
+│   ├── api/
+│   │   ├── videos/
+│   │   │   ├── route.ts                         ← GET /api/videos
+│   │   │   ├── __tests__/route.test.ts
+│   │   │   ├── import/
+│   │   │   │   ├── route.ts                     ← POST /api/videos/import
+│   │   │   │   └── __tests__/route.test.ts
+│   │   │   └── [id]/
+│   │   │       ├── route.ts                     ← GET / PATCH / DELETE /api/videos/:id
+│   │   │       ├── __tests__/route.test.ts
+│   │   │       ├── stream/
+│   │   │       │   ├── route.ts
+│   │   │       │   └── __tests__/route.test.ts
+│   │   │       ├── thumbnail/
+│   │   │       │   ├── route.ts
+│   │   │       │   └── __tests__/route.test.ts
+│   │   │       └── transcript/
+│   │   │           ├── route.ts
+│   │   │           └── __tests__/route.test.ts
+│   │   └── vocabulary/
+│   │       ├── route.ts                         ← GET /api/vocabulary
+│   │       ├── __tests__/route.test.ts
+│   │       └── [word]/
+│   │           ├── route.ts                     ← PATCH /api/vocabulary/:word
+│   │           └── __tests__/route.test.ts
+│   ├── layout.tsx
+│   ├── page.tsx                                 ← redirects to /dashboard
+│   ├── globals.css
+│   └── favicon.ico
+├── components/
+│   ├── CueText.tsx
+│   ├── DarkModeToggle.tsx
+│   ├── DeleteVideoModal.tsx
+│   ├── EditVideoModal.tsx
+│   ├── ImportVideoModal.tsx
+│   ├── LessonHero.tsx
+│   ├── LocalVideoPlayer.tsx
+│   ├── PlaybackProgress.tsx
+│   ├── PlayerClient.tsx
+│   ├── PlayerLoader.tsx
+│   ├── Providers.tsx
+│   ├── Sidebar.tsx
+│   ├── Toast.tsx
+│   ├── TopBar.tsx
+│   ├── VideoCard.tsx
+│   ├── WordSidebar.tsx
+│   └── __tests__/   (*.test.tsx for each component)
+├── hooks/
+│   ├── useImportVideoForm.ts
+│   ├── useVideoMutations.ts
+│   ├── useVideos.ts
+│   ├── useVocabulary.ts
+│   └── __tests__/   (*.test.ts / *.test.tsx)
+└── lib/
+    ├── api-schemas.ts
+    ├── data-dir.ts                              ← Path helpers (added in #165)
+    ├── db.ts                                    ← SQLite bootstrap
+    ├── detect-transcript-format.ts
+    ├── parse-transcript.ts
+    ├── thumbnails.ts
+    ├── tokenize-transcript.ts
+    ├── transcripts.ts
+    ├── video-files.ts
+    ├── video-service.ts                         ← VideoService business logic
+    ├── video-store.ts                           ← SqliteVideoStore CRUD
+    ├── videos.ts                                ← Zod schemas + Video types
+    ├── vocab-store.ts                           ← SqliteVocabStore CRUD
+    ├── vocabulary.ts                            ← MOCK_VOCAB + types
+    ├── server/
+    │   └── composition.ts                       ← KEY FILE: DI root (singleton)
+    └── __tests__/   (unit tests for lib modules)
+```
+
+---
+
+## 2. Key Module Summaries
+
+### `src/lib/server/composition.ts` — complete current contents (verbatim)
+
+```ts
+/**
+ * Production composition root.
+ *
+ * Data directory is resolved from the LINGOFLOW_DATA_DIR environment variable.
+ * If the variable is not set, it defaults to `.lingoflow-data` inside the
+ * current working directory (process.cwd()).
+ *
+ * Example:
+ *   LINGOFLOW_DATA_DIR=/var/data/lingoflow pnpm start
+ */
+import { ensureDataDirs, openDb, initializeSchema } from '@/lib/db'
+import { SqliteVideoStore } from '@/lib/video-store'
+import { VideoService } from '@/lib/video-service'
+import { writeTranscript, deleteTranscript } from '@/lib/transcripts'
+import { SqliteVocabStore } from '@/lib/vocab-store'
+import { getDataDir, getDbPath, getVideosDir } from '@/lib/data-dir'
+import fs from 'fs'
+import path from 'path'
+
+function createContainer() {
+  const dataDir = getDataDir()
+  ensureDataDirs(dataDir)
+  const db = openDb(getDbPath())
+  initializeSchema(db)
+
+  const store = new SqliteVideoStore(db)
+  const vocabStore = new SqliteVocabStore(db)
+  const transcriptStore = {
+    write: (videoId: string, ext: string, buffer: Buffer) => writeTranscript(videoId, ext, buffer),
+    delete: (filePath: string) => deleteTranscript(filePath),
+  }
+  const videoFileStore = {
+    write: (videoId: string, ext: string, buffer: Buffer): string => {
+      const videosDir = getVideosDir()
+      fs.mkdirSync(videosDir, { recursive: true })
+      const filePath = path.join(videosDir, `${videoId}.${ext}`)
+      fs.writeFileSync(filePath, buffer)
+      return filePath
+    },
+    delete: (filePath: string): void => {
+      try {
+        fs.unlinkSync(filePath)
+      } catch (err: unknown) {
+        if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err
+      }
+    },
+  }
+  const service = new VideoService(store, transcriptStore, videoFileStore)
+
+  return { videoStore: store, videoService: service, vocabStore }
+}
+
+const { videoStore, videoService, vocabStore } = createContainer()
+
+export { videoStore, videoService, vocabStore }
+```
+
+**Key observations for #166:**
+- `createContainer()` already exists as a local private function — it needs to be exported.
+- The module-level singleton is created by calling `createContainer()` at module load time and destructuring into three named exports.
+- The return type of `createContainer()` is `{ videoStore: SqliteVideoStore, videoService: VideoService, vocabStore: SqliteVocabStore }`.
+- Issue #166 requires: (a) exporting `createContainer` so tests can call it directly to build an isolated container; (b) exporting a `getContainer()` accessor so route handlers (and tests that replace the singleton) can read the current singleton rather than capturing it at import time.
+- The backward-compatible approach: keep the named exports `videoStore`, `videoService`, `vocabStore` pointing to the singleton (so existing `jest.mock` tests need zero changes), and additionally export `createContainer` and `getContainer`.
+
+---
+
+### `src/lib/db.ts` — exported functions and signatures
+
+```ts
+export function ensureDataDirs(dataDir: string): void
+// Creates dataDir, dataDir/transcripts, dataDir/videos, dataDir/thumbnails (all recursive).
+
+export function openDb(dbPath: string): Database.Database
+// Opens better-sqlite3 with WAL mode. Returns the DB handle.
+
+export function initializeSchema(db: Database.Database): void
+// Creates `videos` and `vocabulary` tables if not present.
+// Uses addColumnIfMissing for: source_type, local_video_path, local_video_filename, thumbnail_path.
+```
+
+---
+
+### `src/lib/video-store.ts` — class name, constructor, exported interface
+
+```ts
+export interface VideoStore {
+  list(): Video[]
+  getById(id: string): Video | undefined
+  insert(params: InsertVideoParams): Video
+  update(id: string, params: UpdateVideoParams): Video | undefined
+  delete(id: string): boolean
+}
+
+export class SqliteVideoStore implements VideoStore {
+  constructor(private db: Database.Database) {}
+  // Implements all VideoStore methods.
+  // Tags are stored as JSON array strings; rowToVideo() deserialises them.
+}
+```
+
+---
+
+### `src/lib/video-service.ts` — class name, constructor, exported interfaces
+
+```ts
+export interface TranscriptStore {
+  write(videoId: string, ext: string, buffer: Buffer): string
+  delete(filePath: string): void
+}
+
+export interface VideoFileStore {
+  write(videoId: string, ext: string, buffer: Buffer): string
+  delete(filePath: string): void
+}
+
+export interface ImportVideoParams { id, title, author_name, thumbnail_url, transcript_ext, transcript_buffer, tags }
+export interface ImportLocalVideoParams { id, title, author_name, video_buffer, video_ext, video_filename, transcript_buffer, transcript_ext, tags, source_type: 'local' }
+export interface UpdateVideoServiceParams { tags?, transcript_ext?, transcript_buffer? }
+
+export class VideoService {
+  constructor(
+    private store: VideoStore,
+    private transcripts: TranscriptStore,
+    private videoFiles: VideoFileStore,
+  ) {}
+
+  async importVideo(params: ImportVideoParams): Promise<Video>
+  async importLocalVideo(params: ImportLocalVideoParams): Promise<Video>
+  async updateVideo(id: string, params: UpdateVideoServiceParams): Promise<Video | undefined>
+  async deleteVideo(id: string): Promise<boolean>
+}
+```
+
+---
+
+### `src/lib/data-dir.ts` — all exported functions (added in #165)
+
+```ts
+export function getDataDir(): string
+// Returns process.env.LINGOFLOW_DATA_DIR ?? path.join(process.cwd(), '.lingoflow-data')
+
+export function getTranscriptsDir(): string
+// Returns path.join(getDataDir(), 'transcripts')
+
+export function getVideosDir(): string
+// Returns path.join(getDataDir(), 'videos')
+
+export function getThumbnailsDir(): string
+// Returns path.join(getDataDir(), 'thumbnails')
+
+export function getDbPath(): string
+// Returns path.join(getDataDir(), 'lingoflow.db')
+```
+
+No side effects — pure path derivation. All functions read `process.env.LINGOFLOW_DATA_DIR` at call time, so setting the env var before calling creates an isolated path (useful for test databases).
+
+---
+
+### `src/lib/vocab-store.ts` — class name, constructor, exported interface
+
+```ts
+export interface VocabEntry {
+  word: string
+  status: 'new' | 'learning' | 'mastered'
+  level?: string
+  definition?: string
+}
+
+export interface VocabStore {
+  getAll(): VocabEntry[]
+  getByWord(word: string): VocabEntry | null
+  upsert(word: string, status: VocabEntry['status'], level?: string, definition?: string): VocabEntry
+}
+
+export class SqliteVocabStore implements VocabStore {
+  constructor(private db: Database.Database) {}
+  getAll(): VocabEntry[]
+  getByWord(word: string): VocabEntry | null
+  upsert(word: string, status: VocabEntry['status'], level?: string, definition?: string): VocabEntry
+}
+```
+
+---
+
+## 3. Route Handler Test Files
+
+All 8 route test files live at `src/app/api/**/__tests__/route.test.ts`.
+All start with `// @jest-environment node` (required because jsdom lacks global `Request`).
+All mock `@/lib/server/composition` entirely with `jest.mock(...)`.
+
+### `src/app/api/videos/__tests__/route.test.ts`
+
+**Mocks:**
+- `@/lib/server/composition` → `{ videoStore: { list: jest.fn() } }`
+
+**Tests `GET /api/videos`:**
+- 200 with video array from `store.list()`
+- 500 if `store.list()` throws
+
+---
+
+### `src/app/api/videos/[id]/__tests__/route.test.ts`
+
+**Mocks:**
+- `next/server` → custom `MockNextResponse` class with static `json()`
+- `@/lib/server/composition` → `{ videoStore: { getById: jest.fn() }, videoService: { deleteVideo: jest.fn(), updateVideo: jest.fn() } }`
+
+**Tests `DELETE /api/videos/[id]`:**
+- 404 if `deleteVideo` returns false; 204 on success; verifies `deleteVideo` called with correct id
+
+**Tests `PATCH /api/videos/[id]`:**
+- 400 for missing/invalid/non-array tags; 404 if not found; 200 on tags-only update; 200 on transcript replacement; 400 for invalid extension
+
+**Tests `GET /api/videos/[id]`:**
+- 404 if video not found; 200 with video data on success
+
+---
+
+### `src/app/api/videos/import/__tests__/route.test.ts`
+
+**Mocks:**
+- `@/lib/server/composition` → `{ videoService: { importLocalVideo, updateVideo, deleteVideo }, videoStore: { update } }` (all `jest.fn()`)
+- `@/lib/thumbnails` → `{ generateThumbnail: jest.fn().mockResolvedValue(null) }`
+- `next/server` → `NextResponse.json` shorthand
+
+**Tests `POST /api/videos/import`:**
+- 400 when no video file; 400 when transcript has invalid extension
+- 201 on valid local upload — verifies `importLocalVideo` called with correct params
+- Thumbnail generation fires-and-forgets; `videoStore.update` called if thumbnail succeeds
+- 400 when title missing; 201 with empty tags; 201 with empty author
+- 400 when video MIME type unsupported; 400 when video exceeds 500 MB
+- 201 for WebM videos
+
+---
+
+### `src/app/api/videos/[id]/transcript/__tests__/route.test.ts`
+
+**Mocks:**
+- `next/server` → `MockNextResponse` class
+- `@/lib/server/composition` → `{ videoStore: { getById: jest.fn() } }`
+- `fs` → full mock
+
+**Tests `GET /api/videos/[id]/transcript`:**
+- 404 if video not found
+- 200 `{ cues: [] }` when `transcript_path` is null
+- 200 with parsed SRT cues (checks text content, cue count, `readFileSync` call path)
+
+---
+
+### `src/app/api/videos/[id]/stream/__tests__/route.test.ts`
+
+**Mocks:**
+- `@/lib/server/composition` → `{ videoStore: { getById: jest.fn() } }`
+- `fs` → `{ existsSync, statSync, createReadStream }` all `jest.fn()`
+- `next/server` → `MockNextResponse` with headers map support
+- Polyfills `global.ReadableStream` from `node:stream/web`
+- Route imported via `const { GET } = require('../route')` after mocks (avoids hoisting issue)
+
+**Tests `GET /api/videos/[id]/stream`:**
+- 404 if video not found; 404 if no `local_video_path`; 404 if file missing on disk
+- 200 with correct `Content-Type` for mp4, webm, mov
+- 200 with `Accept-Ranges: bytes` header
+- 206 with `Content-Range`/`Content-Length` when `Range` header provided
+- 206 with end calculated from file size when range end omitted
+
+---
+
+### `src/app/api/videos/[id]/thumbnail/__tests__/route.test.ts`
+
+**Mocks:**
+- `@/lib/server/composition` → `{ videoStore: { getById: jest.fn() } }`
+- `fs` → `{ readFileSync, existsSync }` both `jest.fn()`
+- Polyfills `global.Response` if absent
+- Route imported via `const { GET } = require('../route')` after mocks
+
+**Tests `GET /api/videos/[id]/thumbnail`:**
+- 404 if video not found; 404 if `thumbnail_path` null; 404 if file read throws
+- 200 with `Content-Type: image/jpeg` when thumbnail exists
+- `Cache-Control: public, max-age=31536000, immutable` header present
+
+---
+
+### `src/app/api/vocabulary/__tests__/route.test.ts`
+
+**Mocks:**
+- `next/server` → `MockNextResponse` with `async json()` method
+- `@/lib/server/composition` → `{ vocabStore: { getAll: jest.fn() } }`
+
+**Tests `GET /api/vocabulary`:**
+- 200 with all vocab entries
+- 500 on store error
+
+---
+
+### `src/app/api/vocabulary/[word]/__tests__/route.test.ts`
+
+**Mocks:**
+- `next/server` → `MockNextResponse` with `async json()` method
+- `@/lib/server/composition` → `{ vocabStore: { upsert: jest.fn() } }`
+
+**Tests `PATCH /api/vocabulary/[word]`:**
+- 200 with upserted entry on valid request
+- Decodes and lowercases `word` param (`Hello%20World` → `hello world`)
+- 400 for invalid status value
+- 500 on store error
+
+---
+
+## 4. Route Handler Files — Composition Import Audit
+
+All 8 route files import named exports from `@/lib/server/composition` at **module scope** (top-level `import` statement). All export `export const runtime = 'nodejs'`.
+
+| Route file | Imports used | runtime line |
+|---|---|---|
+| `src/app/api/videos/route.ts` | `videoStore` | line 4 |
+| `src/app/api/videos/[id]/route.ts` | `videoStore`, `videoService` | line 7 |
+| `src/app/api/videos/import/route.ts` | `videoService`, `videoStore` | line 9 |
+| `src/app/api/videos/[id]/transcript/route.ts` | `videoStore` | line 7 |
+| `src/app/api/videos/[id]/stream/route.ts` | `videoStore` | line 1 |
+| `src/app/api/videos/[id]/thumbnail/route.ts` | `videoStore` | line 4 |
+| `src/app/api/vocabulary/route.ts` | `vocabStore` | line 4 |
+| `src/app/api/vocabulary/[word]/route.ts` | `vocabStore` | line 5 |
+
+**Critical implication for #166:** Because all route handlers import the named exports at module scope, they capture the singleton values at the time the module is first loaded. If `getContainer()` is added and route handlers are updated to call `getContainer().videoStore` inside handler functions (instead of capturing at import time), then swapping the container via `setContainer()` in a test will affect all subsequent handler calls. If the named exports remain (backward compat), existing `jest.mock` tests continue to work unchanged.
+
+---
+
+## 5. Existing Test Infrastructure
+
+### Jest config (`jest.config.js`)
+
+```js
+import nextJest from 'next/jest.js'
+const createJestConfig = nextJest({ dir: './' })
+
+const customJestConfig = {
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+  testEnvironment: 'jest-environment-jsdom',       // default; API route tests override per-file
+  roots: ['<rootDir>/src', '<rootDir>/tests'],
+  testPathIgnorePatterns: [
+    '<rootDir>/node_modules/',
+    '<rootDir>/tests/e2e/',
+    '<rootDir>/pr-[^/]+/',
+  ],
+  modulePathIgnorePatterns: ['<rootDir>/pr-[^/]+/'],
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+  },
+}
+
+export default createJestConfig(customJestConfig)
+```
+
+### `jest.setup.ts`
+
+```ts
+import '@testing-library/jest-dom'
+```
+
+Only adds jest-dom matchers. No shared mock helpers, factories, or DI utilities.
+
+### Per-file test patterns used across route tests
+
+| Pattern | Usage |
+|---|---|
+| `// @jest-environment node` at top of file | Required in all API route tests — jsdom lacks `Request` global |
+| `jest.mock('@/lib/server/composition', () => ({ ... }))` | Every route test file mocks the entire composition module |
+| `jest.clearAllMocks()` in `afterEach` or `beforeEach` | Consistent across all route test files |
+| Inline `MockNextResponse` class | Replicated independently in each test file — no shared helper |
+| `require('../route')` after mocks | Used in stream and thumbnail tests to avoid polyfill hoisting issues |
+
+### No shared test utilities for DI
+
+There are **no** existing shared factories, helpers, or fixtures for DI / composition in test code. Each test file independently calls `jest.mock('@/lib/server/composition', ...)` with its own inline shape. This is the pattern that #166 aims to improve upon.
+
+### Relevant lib unit tests (for context)
+
+- `src/lib/__tests__/video-store.test.ts` — real in-memory SQLite, no composition mock.
+- `src/lib/__tests__/video-service.test.ts` — mock `VideoStore`, `TranscriptStore`, `VideoFileStore`.
+- `src/lib/__tests__/data-dir.test.ts` — tests `getDataDir()` / `getDbPath()` against `process.env.LINGOFLOW_DATA_DIR`.
+
+---
+
+## 6. Design Notes for Issue #166
+
+### Goal
+
+Allow integration-style tests to build a fresh, isolated container (real SQLite in a temp db, real stores) per test — without needing `jest.mock('@/lib/server/composition', ...)`. This enables true DI isolation while keeping existing mock-based tests unchanged.
+
+### Minimal change to `composition.ts`
+
+```ts
+// 1. Export createContainer so callers can build a fresh container
+export { createContainer }
+
+// 2. Expose a mutable singleton reference
+let container = createContainer()
+
+export function getContainer() {
+  return container
+}
+
+// Optional: setContainer for tests that want to replace the singleton
+export function setContainer(c: ReturnType<typeof createContainer>) {
+  container = c
+}
+
+// 3. Keep named exports for backward compat (existing route handlers + jest.mock tests)
+export const videoStore = container.videoStore    // ← still module-scope, but now derived
+export const videoService = container.videoService
+export const vocabStore = container.vocabStore
+```
+
+**Important:** If named exports remain static module-scope references (pointing to the initial singleton's store instances), `setContainer()` won't affect them. For full per-test isolation via `setContainer`, route handlers would need to call `getContainer().videoStore` inside the handler body. That is a larger change; #166 may only require `createContainer` + `getContainer` as the initial step.
+
+### Return type of `createContainer`
+
+```ts
+// Inferred from current implementation:
+{
+  videoStore: SqliteVideoStore   // implements VideoStore
+  videoService: VideoService
+  vocabStore: SqliteVocabStore   // implements VocabStore
+}
+```
+
+Tests can import these concrete types from `@/lib/video-store`, `@/lib/video-service`, `@/lib/vocab-store` as needed.
+
+### Pattern for in-process integration tests (after #166)
+
+```ts
+// @jest-environment node
+import { createContainer } from '@/lib/server/composition'
+import Database from 'better-sqlite3'
+import { openDb, initializeSchema } from '@/lib/db'
+
+let container: ReturnType<typeof createContainer>
+
+beforeEach(() => {
+  // In-memory SQLite — isolated per test
+  process.env.LINGOFLOW_DATA_DIR = '/some/test-dir'
+  container = createContainer()
+})
+
+afterEach(() => {
+  // close db if needed
+})
+```

--- a/src/app/api/videos/[id]/__tests__/route.test.ts
+++ b/src/app/api/videos/[id]/__tests__/route.test.ts
@@ -1,67 +1,42 @@
-// @jest-environment node
+/**
+ * @jest-environment node
+ */
+
+jest.mock('@/lib/server/composition', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const actual = jest.requireActual('@/lib/server/composition')
+  return { ...actual, getContainer: jest.fn() }
+})
+
 import { DELETE, PATCH, GET } from '../route'
-import { videoStore, videoService } from '@/lib/server/composition'
+import * as composition from '@/lib/server/composition'
+import { createContainer } from '@/lib/server/composition'
+import type { Container } from '@/lib/server/composition'
+import type { InsertVideoParams } from '@/lib/videos'
 
-jest.mock('next/server', () => ({
-  NextResponse: class MockNextResponse {
-    status: number
-    body: unknown
-    constructor(body: unknown, init?: { status?: number }) {
-      this.body = body
-      this.status = init?.status ?? 200
-    }
-    static json(data: unknown, init?: { status?: number }) {
-      const res = new this(data, init)
-      res.body = data
-      return res
-    }
-  },
-}))
+let container: Container
 
-jest.mock('@/lib/server/composition', () => ({
-  videoStore: { getById: jest.fn() },
-  videoService: { deleteVideo: jest.fn(), updateVideo: jest.fn() },
-}))
+function makeVideoParams(overrides: Partial<InsertVideoParams> = {}): InsertVideoParams {
+  return {
+    id: 'video-1',
+    title: 'Test Video',
+    author_name: 'Author',
+    thumbnail_url: '',
+    transcript_path: '/transcripts/video-1.srt',
+    transcript_format: 'srt',
+    tags: ['spanish'],
+    source_type: 'local',
+    local_video_path: '/videos/video-1.mp4',
+    local_video_filename: 'video-1.mp4',
+    ...overrides,
+  }
+}
 
-const mockGetById = (videoStore.getById as jest.Mock)
-const mockDeleteVideo = (videoService.deleteVideo as jest.Mock)
-const mockUpdateVideo = (videoService.updateVideo as jest.Mock)
-
-function makeRequest() {
+function makeRequest(): Request {
   return { method: 'DELETE', url: 'http://localhost/api/videos/video-1' } as unknown as Request
 }
 
-describe('DELETE /api/videos/[id]', () => {
-  afterEach(() => jest.clearAllMocks())
-
-  it('returns 404 if video not found', async () => {
-    mockDeleteVideo.mockResolvedValue(false)
-    const response = await DELETE(makeRequest(), { params: Promise.resolve({ id: 'video-1' }) })
-    expect(response.status).toBe(404)
-  })
-
-  it('returns 204 on successful delete', async () => {
-    mockDeleteVideo.mockResolvedValue(true)
-    const response = await DELETE(makeRequest(), { params: Promise.resolve({ id: 'video-1' }) })
-    expect(response.status).toBe(204)
-    expect(mockDeleteVideo).toHaveBeenCalledWith('video-1')
-  })
-
-  it('calls service.deleteVideo with the correct id', async () => {
-    mockDeleteVideo.mockResolvedValue(true)
-    await DELETE(makeRequest(), { params: Promise.resolve({ id: 'video-1' }) })
-    expect(mockDeleteVideo).toHaveBeenCalledWith('video-1')
-  })
-
-  it('returns 404 when service.deleteVideo returns false', async () => {
-    mockDeleteVideo.mockResolvedValue(false)
-    await DELETE(makeRequest(), { params: Promise.resolve({ id: 'video-1' }) })
-    const response = await DELETE(makeRequest(), { params: Promise.resolve({ id: 'video-1' }) })
-    expect(response.status).toBe(404)
-  })
-})
-
-function makePatchRequest(fields: Record<string, unknown>) {
+function makePatchRequest(fields: Record<string, unknown>): Request {
   const mockFormData = {
     get: jest.fn((key: string) => fields[key] ?? null),
   }
@@ -72,9 +47,35 @@ function makePatchRequest(fields: Record<string, unknown>) {
   } as unknown as Request
 }
 
-describe('PATCH /api/videos/[id]', () => {
-  afterEach(() => jest.clearAllMocks())
+beforeEach(() => {
+  container = createContainer(':memory:')
+  ;(composition.getContainer as jest.Mock).mockReturnValue(container)
+})
 
+afterEach(() => {
+  jest.restoreAllMocks()
+})
+
+describe('DELETE /api/videos/[id]', () => {
+  it('returns 404 if video not found', async () => {
+    const response = await DELETE(makeRequest(), { params: Promise.resolve({ id: 'video-1' }) })
+    expect(response.status).toBe(404)
+  })
+
+  it('returns 204 on successful delete', async () => {
+    container.videoStore.insert(makeVideoParams())
+    const response = await DELETE(makeRequest(), { params: Promise.resolve({ id: 'video-1' }) })
+    expect(response.status).toBe(204)
+  })
+
+  it('removes video from DB after delete', async () => {
+    container.videoStore.insert(makeVideoParams())
+    await DELETE(makeRequest(), { params: Promise.resolve({ id: 'video-1' }) })
+    expect(container.videoStore.getById('video-1')).toBeUndefined()
+  })
+})
+
+describe('PATCH /api/videos/[id]', () => {
   it('returns 400 if tags field is missing', async () => {
     const response = await PATCH(makePatchRequest({}), { params: Promise.resolve({ id: 'video-1' }) })
     expect(response.status).toBe(400)
@@ -91,60 +92,61 @@ describe('PATCH /api/videos/[id]', () => {
   })
 
   it('returns 404 if video not found', async () => {
-    mockUpdateVideo.mockResolvedValue(undefined)
     const response = await PATCH(makePatchRequest({ tags: JSON.stringify(['spanish']) }), { params: Promise.resolve({ id: 'video-1' }) })
     expect(response.status).toBe(404)
   })
 
   it('returns 200 with updated video on tags-only update', async () => {
-    const updatedVideo = { id: 'video-1', tags: ['spanish', 'advanced'] }
-    mockUpdateVideo.mockResolvedValue(updatedVideo)
-
-    const response = await PATCH(makePatchRequest({ tags: JSON.stringify(['spanish', 'advanced']) }), { params: Promise.resolve({ id: 'video-1' }) })
+    container.videoStore.insert(makeVideoParams({ tags: ['old'] }))
+    const response = await PATCH(
+      makePatchRequest({ tags: JSON.stringify(['spanish', 'advanced']) }),
+      { params: Promise.resolve({ id: 'video-1' }) }
+    )
     expect(response.status).toBe(200)
-    expect(mockUpdateVideo).toHaveBeenCalledWith('video-1', { tags: ['spanish', 'advanced'] })
+    const body = await response.json()
+    expect(body.tags).toEqual(['spanish', 'advanced'])
   })
 
-  it('returns 200 and calls service.updateVideo with transcript params on transcript replacement', async () => {
-    const updatedVideo = { id: 'video-1', tags: ['spanish'], transcript_path: '/new/path.srt' }
-    mockUpdateVideo.mockResolvedValue(updatedVideo)
-
-    const file = { name: 'subtitles.srt', size: 7, arrayBuffer: jest.fn().mockResolvedValue(Buffer.from('content')) } as unknown as File
-    const response = await PATCH(makePatchRequest({ tags: JSON.stringify(['spanish']), transcript: file }), { params: Promise.resolve({ id: 'video-1' }) })
-    expect(response.status).toBe(200)
-    expect(mockUpdateVideo).toHaveBeenCalledWith('video-1', expect.objectContaining({
-      tags: ['spanish'],
-      transcript_ext: 'srt',
-      transcript_buffer: expect.any(Buffer),
-    }))
+  it('persists tag update to DB', async () => {
+    container.videoStore.insert(makeVideoParams({ tags: ['old'] }))
+    await PATCH(
+      makePatchRequest({ tags: JSON.stringify(['new-tag']) }),
+      { params: Promise.resolve({ id: 'video-1' }) }
+    )
+    expect(container.videoStore.getById('video-1')?.tags).toEqual(['new-tag'])
   })
 
   it('returns 400 for invalid transcript extension', async () => {
+    container.videoStore.insert(makeVideoParams())
     const file = { name: 'subtitles.pdf', size: 7, arrayBuffer: jest.fn().mockResolvedValue(Buffer.from('content')) } as unknown as File
     const response = await PATCH(makePatchRequest({ tags: JSON.stringify(['spanish']), transcript: file }), { params: Promise.resolve({ id: 'video-1' }) })
     expect(response.status).toBe(400)
   })
+
+  it('returns 200 on transcript replacement with valid extension', async () => {
+    container.videoStore.insert(makeVideoParams())
+    const file = { name: 'subtitles.srt', size: 7, arrayBuffer: jest.fn().mockResolvedValue(Buffer.from('content')) } as unknown as File
+    const response = await PATCH(
+      makePatchRequest({ tags: JSON.stringify(['spanish']), transcript: file }),
+      { params: Promise.resolve({ id: 'video-1' }) }
+    )
+    expect(response.status).toBe(200)
+  })
 })
 
-function makeGetRequest() {
-  return { method: 'GET', url: 'http://localhost/api/videos/video-1' } as unknown as Request
-}
-
 describe('GET /api/videos/[id]', () => {
-  afterEach(() => jest.clearAllMocks())
-
   it('returns 404 if video not found', async () => {
-    mockGetById.mockReturnValue(undefined)
-    const response = await GET(makeGetRequest(), { params: Promise.resolve({ id: 'video-1' }) })
+    const response = await GET(makeRequest(), { params: Promise.resolve({ id: 'video-1' }) })
     expect(response.status).toBe(404)
   })
 
   it('returns 200 with video data when found', async () => {
-    const video = { id: 'video-1', title: 'Test', tags: ['t1'], transcript_path: 'p.srt', transcript_format: 'srt', created_at: '2026-01-01T00:00:00Z', updated_at: '2026-01-01T00:00:00Z', author_name: 'A', thumbnail_url: 'http://t.com', youtube_url: 'http://y.com', youtube_id: 'abc' }
-    mockGetById.mockReturnValue(video)
-    const response = await GET(makeGetRequest(), { params: Promise.resolve({ id: 'video-1' }) })
+    container.videoStore.insert(makeVideoParams())
+    const response = await GET(makeRequest(), { params: Promise.resolve({ id: 'video-1' }) })
     expect(response.status).toBe(200)
-    expect(mockGetById).toHaveBeenCalledWith('video-1')
+    const body = await response.json()
+    expect(body.id).toBe('video-1')
+    expect(body.title).toBe('Test Video')
   })
 })
 

--- a/src/app/api/videos/[id]/route.ts
+++ b/src/app/api/videos/[id]/route.ts
@@ -1,6 +1,6 @@
 // @jest-environment node
 import { NextResponse } from 'next/server'
-import { videoStore, videoService } from '@/lib/server/composition'
+import { getContainer } from '@/lib/server/composition'
 import { UpdateVideoServiceParams } from '@/lib/video-service'
 import { UpdateVideoRequestSchema } from '@/lib/api-schemas'
 
@@ -12,6 +12,7 @@ export async function GET(
 ) {
   try {
     const { id } = await params
+    const { videoStore } = getContainer()
     const video = videoStore.getById(id)
     if (!video) {
       return new NextResponse('Not Found', { status: 404 })
@@ -29,6 +30,7 @@ export async function DELETE(
 ) {
   try {
     const { id } = await params
+    const { videoService } = getContainer()
     const deleted = await videoService.deleteVideo(id)
     if (!deleted) {
       return new NextResponse('Not Found', { status: 404 })
@@ -66,6 +68,7 @@ export async function PATCH(
       serviceParams.transcript_buffer = Buffer.from(await transcriptFile.arrayBuffer())
     }
 
+    const { videoService } = getContainer()
     const updated = await videoService.updateVideo(id, serviceParams)
     if (!updated) {
       return NextResponse.json({ error: 'Video not found' }, { status: 404 })

--- a/src/app/api/videos/[id]/stream/__tests__/route.test.ts
+++ b/src/app/api/videos/[id]/stream/__tests__/route.test.ts
@@ -1,52 +1,25 @@
-// @jest-environment node
-
-// Polyfill ReadableStream for Jest node environment
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-const { ReadableStream: WebReadableStream } = require('node:stream/web')
-if (typeof global.ReadableStream === 'undefined') {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  ;(global as any).ReadableStream = WebReadableStream
-}
-
-import { videoStore } from '@/lib/server/composition'
-
-jest.mock('@/lib/server/composition', () => ({
-  videoStore: { getById: jest.fn() },
-}))
+/**
+ * @jest-environment node
+ */
 
 jest.mock('fs', () => ({
+  ...jest.requireActual('fs'),
   existsSync: jest.fn(),
   statSync: jest.fn(),
   createReadStream: jest.fn(),
 }))
 
-jest.mock('next/server', () => {
-  class MockNextResponse {
-    status: number
-    body: unknown
-    headers: { get: (key: string) => string | null }
-
-    constructor(
-      body: unknown,
-      init?: { status?: number; headers?: Record<string, string> }
-    ) {
-      this.body = body
-      this.status = init?.status ?? 200
-      const headersMap: Record<string, string> = {}
-      for (const [k, v] of Object.entries(init?.headers ?? {})) {
-        headersMap[k.toLowerCase()] = v
-      }
-      this.headers = {
-        get: (key: string) => headersMap[key.toLowerCase()] ?? null,
-      }
-    }
-
-    static json(data: unknown, init?: { status?: number }) {
-      return new MockNextResponse(data, init)
-    }
-  }
-  return { NextResponse: MockNextResponse }
+jest.mock('@/lib/server/composition', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const actual = jest.requireActual('@/lib/server/composition')
+  return { ...actual, getContainer: jest.fn() }
 })
+
+import * as composition from '@/lib/server/composition'
+import { createContainer } from '@/lib/server/composition'
+import type { Container } from '@/lib/server/composition'
+import type { InsertVideoParams } from '@/lib/videos'
+import { GET } from '../route'
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const fsMock = require('fs') as {
@@ -55,22 +28,22 @@ const fsMock = require('fs') as {
   createReadStream: jest.Mock
 }
 
-const mockGetById = videoStore.getById as jest.Mock
+let container: Container
 
-const mockLocalVideo = {
-  id: 'video-1',
-  source_type: 'local',
-  local_video_path: 'videos/test.mp4',
-  title: 'Test Video',
-  youtube_url: '',
-  youtube_id: '',
-  author_name: 'Tester',
-  thumbnail_url: '',
-  transcript_path: '',
-  transcript_format: 'srt',
-  tags: [],
-  created_at: '2026-01-01T00:00:00Z',
-  updated_at: '2026-01-01T00:00:00Z',
+function makeVideoParams(overrides: Partial<InsertVideoParams> = {}): InsertVideoParams {
+  return {
+    id: 'video-1',
+    title: 'Test Video',
+    author_name: 'Tester',
+    thumbnail_url: '',
+    transcript_path: '',
+    transcript_format: 'srt',
+    tags: [],
+    source_type: 'local',
+    local_video_path: 'videos/test.mp4',
+    local_video_filename: 'test.mp4',
+    ...overrides,
+  }
 }
 
 function makeRequest(headers: Record<string, string> = {}): Request {
@@ -81,80 +54,69 @@ function makeRequest(headers: Record<string, string> = {}): Request {
   } as unknown as Request
 }
 
-// Import route after mocks are set up
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-const { GET } = require('../route') as { GET: typeof import('../route').GET }
+beforeEach(() => {
+  container = createContainer(':memory:')
+  ;(composition.getContainer as jest.Mock).mockReturnValue(container)
+
+  const mockStream = { on: jest.fn().mockReturnThis() }
+  fsMock.existsSync.mockReturnValue(true)
+  fsMock.statSync.mockReturnValue({ size: 1000 })
+  fsMock.createReadStream.mockReturnValue(mockStream)
+})
+
+afterEach(() => {
+  jest.restoreAllMocks()
+  jest.clearAllMocks()
+})
 
 describe('GET /api/videos/[id]/stream', () => {
-  beforeEach(() => {
-    const mockStream = {
-      on: jest.fn().mockReturnThis(),
-    }
-    fsMock.existsSync.mockReturnValue(true)
-    fsMock.statSync.mockReturnValue({ size: 1000 })
-    fsMock.createReadStream.mockReturnValue(mockStream)
-  })
-
-  afterEach(() => jest.clearAllMocks())
-
   it('returns 404 if video not found', async () => {
-    mockGetById.mockReturnValue(undefined)
     const res = await GET(makeRequest(), { params: Promise.resolve({ id: 'video-1' }) })
     expect(res.status).toBe(404)
   })
 
   it('returns 404 if video has no local_video_path', async () => {
-    mockGetById.mockReturnValue({
-      ...mockLocalVideo,
-      source_type: 'youtube',
-      local_video_path: null,
-    })
+    container.videoStore.insert(makeVideoParams({ local_video_path: null }))
     const res = await GET(makeRequest(), { params: Promise.resolve({ id: 'video-1' }) })
     expect(res.status).toBe(404)
   })
 
   it('returns 404 if file does not exist on disk', async () => {
-    mockGetById.mockReturnValue(mockLocalVideo)
+    container.videoStore.insert(makeVideoParams())
     fsMock.existsSync.mockReturnValue(false)
     const res = await GET(makeRequest(), { params: Promise.resolve({ id: 'video-1' }) })
     expect(res.status).toBe(404)
   })
 
   it('returns 200 with correct content-type for mp4', async () => {
-    mockGetById.mockReturnValue(mockLocalVideo)
+    container.videoStore.insert(makeVideoParams())
     const res = await GET(makeRequest(), { params: Promise.resolve({ id: 'video-1' }) })
     expect(res.status).toBe(200)
     expect(res.headers.get('content-type')).toBe('video/mp4')
   })
 
   it('returns 200 with accept-ranges header', async () => {
-    mockGetById.mockReturnValue(mockLocalVideo)
+    container.videoStore.insert(makeVideoParams())
     const res = await GET(makeRequest(), { params: Promise.resolve({ id: 'video-1' }) })
     expect(res.headers.get('accept-ranges')).toBe('bytes')
   })
 
   it('returns 200 with correct content-type for webm', async () => {
-    mockGetById.mockReturnValue({
-      ...mockLocalVideo,
-      local_video_path: 'videos/test.webm',
-    })
+    container.videoStore.insert(makeVideoParams({ local_video_path: 'videos/test.webm', local_video_filename: 'test.webm' }))
     const res = await GET(makeRequest(), { params: Promise.resolve({ id: 'video-1' }) })
     expect(res.status).toBe(200)
     expect(res.headers.get('content-type')).toBe('video/webm')
   })
 
   it('returns 200 with correct content-type for mov', async () => {
-    mockGetById.mockReturnValue({
-      ...mockLocalVideo,
-      local_video_path: 'videos/test.mov',
-    })
+    container.videoStore.insert(makeVideoParams({ local_video_path: 'videos/test.mov', local_video_filename: 'test.mov' }))
     const res = await GET(makeRequest(), { params: Promise.resolve({ id: 'video-1' }) })
     expect(res.status).toBe(200)
     expect(res.headers.get('content-type')).toBe('video/quicktime')
   })
 
   it('returns 206 with correct range headers when Range header provided', async () => {
-    mockGetById.mockReturnValue(mockLocalVideo)
+    container.videoStore.insert(makeVideoParams())
     const res = await GET(
       makeRequest({ range: 'bytes=0-499' }),
       { params: Promise.resolve({ id: 'video-1' }) }
@@ -166,7 +128,7 @@ describe('GET /api/videos/[id]/stream', () => {
   })
 
   it('returns 206 with end calculated from file size when end omitted in range', async () => {
-    mockGetById.mockReturnValue(mockLocalVideo)
+    container.videoStore.insert(makeVideoParams())
     const res = await GET(
       makeRequest({ range: 'bytes=500-' }),
       { params: Promise.resolve({ id: 'video-1' }) }

--- a/src/app/api/videos/[id]/stream/route.ts
+++ b/src/app/api/videos/[id]/stream/route.ts
@@ -3,7 +3,7 @@ export const runtime = 'nodejs'
 import { NextResponse } from 'next/server'
 import fs from 'fs'
 import path from 'path'
-import { videoStore } from '@/lib/server/composition'
+import { getContainer } from '@/lib/server/composition'
 
 const MIME_TYPES: Record<string, string> = {
   mp4: 'video/mp4',
@@ -17,6 +17,7 @@ export async function GET(
 ) {
   try {
     const { id } = await params
+    const { videoStore } = getContainer()
     const video = videoStore.getById(id)
 
     if (!video || !video.local_video_path) {

--- a/src/app/api/videos/[id]/thumbnail/__tests__/route.test.ts
+++ b/src/app/api/videos/[id]/thumbnail/__tests__/route.test.ts
@@ -1,84 +1,82 @@
-// @jest-environment node
-
-// Polyfill Response/Headers for Jest node environment
-/* eslint-disable @typescript-eslint/no-explicit-any */
-if (typeof global.Response === 'undefined') {
-  ;(global as any).Response = globalThis.Response ?? class Response {
-    status: number
-    headers: Headers
-    private _body: unknown
-    constructor(body: unknown, init?: { status?: number; headers?: Record<string, string> }) {
-      this._body = body
-      this.status = init?.status ?? 200
-      const map: Record<string, string> = {}
-      for (const [k, v] of Object.entries(init?.headers ?? {})) map[k.toLowerCase()] = v
-      this.headers = { get: (key: string) => map[key.toLowerCase()] ?? null } as unknown as Headers
-    }
-  }
-}
-/* eslint-enable @typescript-eslint/no-explicit-any */
-
-jest.mock('@/lib/server/composition', () => ({
-  videoStore: { getById: jest.fn() },
-}))
+/**
+ * @jest-environment node
+ */
 
 jest.mock('fs', () => ({
+  ...jest.requireActual('fs'),
   readFileSync: jest.fn(),
   existsSync: jest.fn(),
 }))
 
-import { videoStore } from '@/lib/server/composition'
+jest.mock('@/lib/server/composition', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const actual = jest.requireActual('@/lib/server/composition')
+  return { ...actual, getContainer: jest.fn() }
+})
+
+import * as composition from '@/lib/server/composition'
+import { createContainer } from '@/lib/server/composition'
+import type { Container } from '@/lib/server/composition'
+import type { InsertVideoParams } from '@/lib/videos'
+
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const fsMock = require('fs') as { readFileSync: jest.Mock; existsSync: jest.Mock }
-const mockGetById = videoStore.getById as jest.Mock
 
-const mockVideo = {
-  id: 'video-1',
-  title: 'Test',
-  source_type: 'local',
-  thumbnail_path: '/data/thumbnails/video-1.jpg',
-  youtube_url: '',
-  youtube_id: '',
-  author_name: '',
-  thumbnail_url: '',
-  transcript_path: '',
-  transcript_format: 'srt',
-  tags: [],
-  created_at: '2026-01-01T00:00:00Z',
-  updated_at: '2026-01-01T00:00:00Z',
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { GET } = require('../route') as { GET: typeof import('../route').GET }
+
+let container: Container
+
+function makeVideoParams(overrides: Partial<InsertVideoParams> = {}): InsertVideoParams {
+  return {
+    id: 'video-1',
+    title: 'Test',
+    author_name: '',
+    thumbnail_url: '',
+    transcript_path: '',
+    transcript_format: 'srt',
+    tags: [],
+    source_type: 'local',
+    thumbnail_path: '/data/thumbnails/video-1.jpg',
+    ...overrides,
+  }
 }
 
 function makeRequest(): Request {
   return {} as unknown as Request
 }
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-const { GET } = require('../route') as { GET: typeof import('../route').GET }
+beforeEach(() => {
+  container = createContainer(':memory:')
+  ;(composition.getContainer as jest.Mock).mockReturnValue(container)
+})
+
+afterEach(() => {
+  jest.restoreAllMocks()
+  jest.clearAllMocks()
+})
 
 describe('GET /api/videos/[id]/thumbnail', () => {
-  beforeEach(() => jest.clearAllMocks())
-
   it('returns 404 when video not found', async () => {
-    mockGetById.mockReturnValue(undefined)
     const res = await GET(makeRequest(), { params: Promise.resolve({ id: 'video-1' }) })
     expect(res.status).toBe(404)
   })
 
   it('returns 404 when thumbnail_path is null', async () => {
-    mockGetById.mockReturnValue({ ...mockVideo, thumbnail_path: null })
+    container.videoStore.insert(makeVideoParams({ thumbnail_path: null }))
     const res = await GET(makeRequest(), { params: Promise.resolve({ id: 'video-1' }) })
     expect(res.status).toBe(404)
   })
 
   it('returns 404 when thumbnail file cannot be read', async () => {
-    mockGetById.mockReturnValue(mockVideo)
+    container.videoStore.insert(makeVideoParams())
     fsMock.readFileSync.mockImplementation(() => { throw new Error('ENOENT') })
     const res = await GET(makeRequest(), { params: Promise.resolve({ id: 'video-1' }) })
     expect(res.status).toBe(404)
   })
 
   it('returns 200 with image/jpeg content-type when thumbnail exists', async () => {
-    mockGetById.mockReturnValue(mockVideo)
+    container.videoStore.insert(makeVideoParams())
     fsMock.readFileSync.mockReturnValue(Buffer.from('fake-jpeg-data'))
     const res = await GET(makeRequest(), { params: Promise.resolve({ id: 'video-1' }) })
     expect(res.status).toBe(200)
@@ -86,7 +84,7 @@ describe('GET /api/videos/[id]/thumbnail', () => {
   })
 
   it('includes cache-control header', async () => {
-    mockGetById.mockReturnValue(mockVideo)
+    container.videoStore.insert(makeVideoParams())
     fsMock.readFileSync.mockReturnValue(Buffer.from('fake-jpeg-data'))
     const res = await GET(makeRequest(), { params: Promise.resolve({ id: 'video-1' }) })
     expect(res.headers.get('cache-control')).toBe('public, max-age=31536000, immutable')

--- a/src/app/api/videos/[id]/thumbnail/route.ts
+++ b/src/app/api/videos/[id]/thumbnail/route.ts
@@ -1,10 +1,11 @@
 import fs from 'fs'
-import { videoStore } from '@/lib/server/composition'
+import { getContainer } from '@/lib/server/composition'
 
 export const runtime = 'nodejs'
 
 export async function GET(_req: Request, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params
+  const { videoStore } = getContainer()
   const video = videoStore.getById(id)
 
   if (!video?.thumbnail_path) {

--- a/src/app/api/videos/[id]/transcript/__tests__/route.test.ts
+++ b/src/app/api/videos/[id]/transcript/__tests__/route.test.ts
@@ -1,45 +1,44 @@
-// @jest-environment node
+/**
+ * @jest-environment node
+ */
 import { GET } from '../route'
-import { videoStore } from '@/lib/server/composition'
+import * as composition from '@/lib/server/composition'
+import { createContainer } from '@/lib/server/composition'
+import type { Container } from '@/lib/server/composition'
+import type { InsertVideoParams } from '@/lib/videos'
 import fs from 'fs'
 
-jest.mock('next/server', () => ({
-  NextResponse: class MockNextResponse {
-    status: number
-    body: unknown
-    constructor(body: unknown, init?: { status?: number }) {
-      this.body = body
-      this.status = init?.status ?? 200
-    }
-    static json(data: unknown, init?: { status?: number }) {
-      const res = new this(data, init)
-      res.body = data
-      return res
-    }
-  },
+jest.mock('fs', () => ({
+  ...jest.requireActual('fs'),
+  readFileSync: jest.fn(),
 }))
 
-jest.mock('@/lib/server/composition', () => ({
-  videoStore: { getById: jest.fn() },
-}))
+jest.mock('@/lib/server/composition', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const actual = jest.requireActual('@/lib/server/composition')
+  return { ...actual, getContainer: jest.fn() }
+})
 
-jest.mock('fs')
-
-const mockGetById = videoStore.getById as jest.Mock
 const mockReadFileSync = fs.readFileSync as jest.Mock
 
-const baseVideo = {
-  id: 'video-1',
-  youtube_url: 'https://youtube.com/watch?v=abc',
-  youtube_id: 'abc',
-  title: 'Test Video',
-  author_name: 'Author',
-  thumbnail_url: 'https://img.example.com/thumb.jpg',
-  transcript_path: '/data/transcripts/video-1.srt',
-  transcript_format: 'srt',
-  tags: ['spanish'],
-  created_at: '2026-01-01T00:00:00Z',
-  updated_at: '2026-01-01T00:00:00Z',
+let container: Container
+
+function makeVideoParams(overrides: Partial<InsertVideoParams> = {}): InsertVideoParams {
+  return {
+    id: 'video-1',
+    title: 'Test Video',
+    author_name: 'Author',
+    thumbnail_url: '',
+    transcript_path: '/transcripts/video-1.srt',
+    transcript_format: 'srt',
+    tags: ['spanish'],
+    source_type: 'local',
+    ...overrides,
+  }
+}
+
+function makeRequest(): Request {
+  return { method: 'GET', url: 'http://localhost/api/videos/video-1/transcript' } as Request
 }
 
 const srtContent = `1
@@ -51,35 +50,39 @@ Hello world
 This is a transcript
 `
 
-function makeRequest() {
-  return { method: 'GET', url: 'http://localhost/api/videos/video-1/transcript' } as Request
-}
+beforeEach(() => {
+  container = createContainer(':memory:')
+  ;(composition.getContainer as jest.Mock).mockReturnValue(container)
+})
+
+afterEach(() => {
+  jest.restoreAllMocks()
+  jest.clearAllMocks()
+})
 
 describe('GET /api/videos/[id]/transcript', () => {
-  afterEach(() => jest.clearAllMocks())
-
   it('returns 404 when video not found', async () => {
-    mockGetById.mockReturnValue(undefined)
     const response = await GET(makeRequest(), { params: Promise.resolve({ id: 'video-1' }) })
     expect(response.status).toBe(404)
   })
 
-  it('returns { cues: [] } when transcript_path is null', async () => {
-    mockGetById.mockReturnValue({ ...baseVideo, transcript_path: null })
+  it('returns { cues: [] } when transcript_path is empty', async () => {
+    container.videoStore.insert(makeVideoParams({ transcript_path: '' }))
     const response = await GET(makeRequest(), { params: Promise.resolve({ id: 'video-1' }) })
     expect(response.status).toBe(200)
-    expect((response as { body: { cues: unknown[] } }).body).toEqual({ cues: [] })
+    const body = await response.json()
+    expect(body).toEqual({ cues: [] })
   })
 
   it('returns parsed cues when transcript exists', async () => {
-    mockGetById.mockReturnValue(baseVideo)
+    container.videoStore.insert(makeVideoParams())
     mockReadFileSync.mockReturnValue(srtContent)
     const response = await GET(makeRequest(), { params: Promise.resolve({ id: 'video-1' }) })
     expect(response.status).toBe(200)
-    const body = (response as { body: { cues: { text: string }[] } }).body
+    const body = await response.json()
     expect(body.cues).toHaveLength(2)
     expect(body.cues[0].text).toBe('Hello world')
     expect(body.cues[1].text).toBe('This is a transcript')
-    expect(mockReadFileSync).toHaveBeenCalledWith('/data/transcripts/video-1.srt', 'utf-8')
+    expect(mockReadFileSync).toHaveBeenCalledWith('/transcripts/video-1.srt', 'utf-8')
   })
 })

--- a/src/app/api/videos/[id]/transcript/route.ts
+++ b/src/app/api/videos/[id]/transcript/route.ts
@@ -1,7 +1,7 @@
 // @jest-environment node
 import { NextResponse } from 'next/server'
 import fs from 'fs'
-import { videoStore } from '@/lib/server/composition'
+import { getContainer } from '@/lib/server/composition'
 import { parseTranscript } from '@/lib/parse-transcript'
 
 export const runtime = 'nodejs'
@@ -12,6 +12,7 @@ export async function GET(
 ) {
   try {
     const { id } = await params
+    const { videoStore } = getContainer()
     const video = videoStore.getById(id)
     if (!video) {
       return new NextResponse('Not Found', { status: 404 })

--- a/src/app/api/videos/__tests__/route.test.ts
+++ b/src/app/api/videos/__tests__/route.test.ts
@@ -1,49 +1,66 @@
 /**
  * @jest-environment node
  */
+
+jest.mock('@/lib/server/composition', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const actual = jest.requireActual('@/lib/server/composition')
+  return { ...actual, getContainer: jest.fn() }
+})
+
 import { GET } from '../route'
-import { videoStore } from '@/lib/server/composition'
+import * as composition from '@/lib/server/composition'
+import { createContainer } from '@/lib/server/composition'
+import type { Container } from '@/lib/server/composition'
+import type { InsertVideoParams } from '@/lib/videos'
 
-jest.mock('@/lib/server/composition', () => ({
-  videoStore: { list: jest.fn() },
-}))
+let container: Container
 
-const mockList = (videoStore.list as jest.Mock)
-
-const mockVideos = [
-  {
+function makeVideoParams(overrides: Partial<InsertVideoParams> = {}): InsertVideoParams {
+  return {
     id: 'v1',
     title: 'Video 1',
-    tags: ['tag1'],
-    transcript_path: 'path/v1.srt',
-    transcript_format: 'srt',
-    created_at: '2026-04-10T00:00:00Z',
-    updated_at: '2026-04-10T00:00:00Z',
     author_name: 'Author 1',
-    thumbnail_url: 'https://example.com/thumb1.jpg',
-    youtube_url: 'https://youtube.com/watch?v=1',
-    youtube_id: '1',
-  },
-]
+    thumbnail_url: '',
+    transcript_path: '/transcripts/v1.srt',
+    transcript_format: 'srt',
+    tags: ['tag1'],
+    source_type: 'local',
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  container = createContainer(':memory:')
+  ;(composition.getContainer as jest.Mock).mockReturnValue(container)
+})
+
+afterEach(() => {
+  jest.restoreAllMocks()
+})
 
 describe('GET /api/videos', () => {
-  afterEach(() => jest.clearAllMocks())
-
-  it('returns 200 with video array from store.list()', async () => {
-    mockList.mockReturnValue(mockVideos)
-
+  it('returns 200 with empty array when no videos', async () => {
     const response = await GET()
     expect(response.status).toBe(200)
     const body = await response.json()
-    expect(body).toEqual(mockVideos)
-    expect(mockList).toHaveBeenCalledTimes(1)
+    expect(body).toEqual([])
+  })
+
+  it('returns 200 with videos from DB', async () => {
+    container.videoStore.insert(makeVideoParams())
+    const response = await GET()
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body).toHaveLength(1)
+    expect(body[0].id).toBe('v1')
+    expect(body[0].tags).toEqual(['tag1'])
   })
 
   it('returns 500 if store.list() throws', async () => {
-    mockList.mockImplementation(() => {
+    jest.spyOn(container.videoStore, 'list').mockImplementation(() => {
       throw new Error('DB error')
     })
-
     const response = await GET()
     expect(response.status).toBe(500)
     const body = await response.json()

--- a/src/app/api/videos/import/__tests__/route.test.ts
+++ b/src/app/api/videos/import/__tests__/route.test.ts
@@ -1,63 +1,26 @@
-// @jest-environment node
-
-jest.mock('@/lib/server/composition', () => ({
-  videoService: {
-    importLocalVideo: jest.fn(),
-    updateVideo: jest.fn(),
-    deleteVideo: jest.fn(),
-  },
-  videoStore: {
-    update: jest.fn(),
-  },
-}))
+/**
+ * @jest-environment node
+ */
 
 jest.mock('@/lib/thumbnails', () => ({
   generateThumbnail: jest.fn().mockResolvedValue(null),
 }))
 
-jest.mock('next/server', () => ({
-  NextResponse: {
-    json: (data: unknown, init?: { status?: number }) => ({
-      status: init?.status ?? 200,
-      json: async () => data,
-    }),
-  },
-}))
+jest.mock('@/lib/server/composition', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const actual = jest.requireActual('@/lib/server/composition')
+  return { ...actual, getContainer: jest.fn() }
+})
 
 import { POST } from '../route'
-import { videoService, videoStore } from '@/lib/server/composition'
+import * as composition from '@/lib/server/composition'
+import { createContainer } from '@/lib/server/composition'
+import type { Container } from '@/lib/server/composition'
 import { ALLOWED_TRANSCRIPT_FORMATS } from '@/lib/api-schemas'
 import { generateThumbnail } from '@/lib/thumbnails'
 import type { NextRequest } from 'next/server'
 
-type MockVideoService = {
-  importLocalVideo: jest.Mock
-  updateVideo: jest.Mock
-  deleteVideo: jest.Mock
-}
-
-type MockVideoStore = {
-  update: jest.Mock
-}
-
-const mockVideoService = videoService as unknown as MockVideoService
-const mockVideoStore = videoStore as unknown as MockVideoStore
-const mockGenerateThumbnail = generateThumbnail as jest.MockedFunction<typeof generateThumbnail>
-
-const fakeLocalVideo = {
-  id: 'local-video-uuid',
-  title: 'My Local Video',
-  author_name: 'Local Author',
-  thumbnail_url: '',
-  transcript_path: '/data/transcripts/local-video-uuid.srt',
-  transcript_format: 'srt',
-  tags: ['french', 'beginner'],
-  created_at: '2024-01-01T00:00:00.000Z',
-  updated_at: '2024-01-01T00:00:00.000Z',
-  source_type: 'local' as const,
-  local_video_path: '/data/videos/local-video-uuid.mp4',
-  local_video_filename: 'my-video.mp4',
-}
+let container: Container
 
 function makeFormData(fields: Record<string, string | File>): FormData {
   const fd = new FormData()
@@ -71,13 +34,37 @@ function makeRequest(formData: FormData): { formData: () => Promise<FormData> } 
   return { formData: async () => formData }
 }
 
-describe('POST /api/videos/import', () => {
-  beforeEach(() => {
-    jest.clearAllMocks()
-    mockVideoService.importLocalVideo.mockResolvedValue(fakeLocalVideo)
-    mockGenerateThumbnail.mockResolvedValue(null)
-  })
+function makeLocalFormData(overrides: Record<string, string | File> = {}): FormData {
+  const videoContent = Buffer.from('fake-video-data')
+  const videoFile = Object.assign(
+    new File([videoContent], 'my-video.mp4', { type: 'video/mp4' }),
+    { arrayBuffer: async () => videoContent.buffer }
+  )
+  const transcriptContent = '1\n00:00:01,000 --> 00:00:02,000\nBonjour'
+  const transcriptFile = Object.assign(
+    new File([transcriptContent], 'transcript.srt', { type: 'text/plain' }),
+    { arrayBuffer: async () => Buffer.from(transcriptContent).buffer }
+  )
+  const defaults: Record<string, string | File> = {
+    video: videoFile,
+    title: 'My Local Video',
+    transcript: transcriptFile,
+  }
+  return makeFormData({ ...defaults, ...overrides })
+}
 
+beforeEach(() => {
+  container = createContainer(':memory:')
+  ;(composition.getContainer as jest.Mock).mockReturnValue(container)
+  ;(generateThumbnail as jest.Mock).mockResolvedValue(null)
+})
+
+afterEach(() => {
+  jest.restoreAllMocks()
+  jest.clearAllMocks()
+})
+
+describe('POST /api/videos/import', () => {
   it('exports ALLOWED_TRANSCRIPT_FORMATS with srt, vtt, txt', () => {
     expect(ALLOWED_TRANSCRIPT_FORMATS).toEqual(['srt', 'vtt', 'txt'])
   })
@@ -85,8 +72,7 @@ describe('POST /api/videos/import', () => {
   it('returns 400 when no video file is provided', async () => {
     const transcriptFile = new File(['content'], 'transcript.srt', { type: 'text/plain' })
     const fd = makeFormData({ transcript: transcriptFile })
-    const req = makeRequest(fd)
-    const res = await POST(req as unknown as NextRequest)
+    const res = await POST(makeRequest(fd) as unknown as NextRequest)
     expect(res.status).toBe(400)
     const body = await res.json()
     expect(body.error).toBe('Only local video upload is supported')
@@ -100,93 +86,24 @@ describe('POST /api/videos/import', () => {
     )
     const transcriptFile = new File(['content'], 'transcript.pdf', { type: 'application/pdf' })
     const fd = makeFormData({ video: videoFile, title: 'Test', transcript: transcriptFile })
-    const req = makeRequest(fd)
-    const res = await POST(req as unknown as NextRequest)
+    const res = await POST(makeRequest(fd) as unknown as NextRequest)
     expect(res.status).toBe(400)
     const body = await res.json()
     expect(body.error).toMatch(/Invalid file extension/)
   })
-})
 
-const fakeLocalVideo2 = {
-  id: 'local-video-uuid',
-  title: 'My Local Video',
-  author_name: 'Local Author',
-  thumbnail_url: '',
-  transcript_path: '/data/transcripts/local-video-uuid.srt',
-  transcript_format: 'srt',
-  tags: ['french', 'beginner'],
-  created_at: '2024-01-01T00:00:00.000Z',
-  updated_at: '2024-01-01T00:00:00.000Z',
-  source_type: 'local' as const,
-  local_video_path: '/data/videos/local-video-uuid.mp4',
-  local_video_filename: 'my-video.mp4',
-}
-
-describe('POST /api/videos/import — local upload path', () => {
-  beforeEach(() => {
-    jest.clearAllMocks()
-    mockVideoService.importLocalVideo.mockResolvedValue(fakeLocalVideo2)
-    mockGenerateThumbnail.mockResolvedValue(null)
-  })
-
-  function makeLocalFormData(overrides: Record<string, string | File> = {}): FormData {
-    const videoContent = Buffer.from('fake-video-data')
-    const videoFile = Object.assign(
-      new File([videoContent], 'my-video.mp4', { type: 'video/mp4' }),
-      { arrayBuffer: async () => videoContent.buffer }
-    )
-    const transcriptContent = '1\n00:00:01,000 --> 00:00:02,000\nBonjour'
-    const transcriptFile = Object.assign(
-      new File([transcriptContent], 'transcript.srt', { type: 'text/plain' }),
-      { arrayBuffer: async () => Buffer.from(transcriptContent).buffer }
-    )
-    const defaults: Record<string, string | File> = {
-      video: videoFile,
-      title: 'My Local Video',
-      transcript: transcriptFile,
-    }
-    return makeFormData({ ...defaults, ...overrides })
-  }
-
-  it('returns 201 and calls importLocalVideo when video file is present', async () => {
+  it('returns 201 and inserts video into DB on valid local upload', async () => {
     const fd = makeLocalFormData({ tags: 'french, beginner', author: 'Local Author' })
-    const req = makeRequest(fd)
-    const res = await POST(req as unknown as NextRequest)
+    const res = await POST(makeRequest(fd) as unknown as NextRequest)
     expect(res.status).toBe(201)
     const body = await res.json()
-    expect(body).toEqual(fakeLocalVideo2)
-    expect(mockVideoService.importLocalVideo).toHaveBeenCalledWith(
-      expect.objectContaining({
-        title: 'My Local Video',
-        author_name: 'Local Author',
-        video_ext: 'mp4',
-        video_filename: 'my-video.mp4',
-        transcript_ext: 'srt',
-        tags: ['french', 'beginner'],
-        source_type: 'local',
-      })
-    )
-    expect(mockVideoService.importLocalVideo).toHaveBeenCalled()
-  })
-
-  it('kicks off thumbnail generation after local import', async () => {
-    mockGenerateThumbnail.mockResolvedValue('/data/thumbnails/local-video-uuid.jpg')
-
-    const fd = makeLocalFormData({ tags: 'french, beginner', author: 'Local Author' })
-    const req = makeRequest(fd)
-    const res = await POST(req as unknown as NextRequest)
-
-    expect(res.status).toBe(201)
-    await Promise.resolve()
-
-    expect(mockGenerateThumbnail).toHaveBeenCalledWith(
-      '/data/videos/local-video-uuid.mp4',
-      expect.stringContaining('/thumbnails/')
-    )
-    expect(mockVideoStore.update).toHaveBeenCalledWith(expect.any(String), {
-      thumbnail_path: '/data/thumbnails/local-video-uuid.jpg',
-    })
+    expect(body.title).toBe('My Local Video')
+    expect(body.author_name).toBe('Local Author')
+    expect(body.tags).toEqual(['french', 'beginner'])
+    expect(body.transcript_format).toBe('srt')
+    const stored = container.videoStore.getById(body.id)
+    expect(stored).toBeDefined()
+    expect(stored?.title).toBe('My Local Video')
   })
 
   it('returns 400 when video file is present but title is missing', async () => {
@@ -197,32 +114,26 @@ describe('POST /api/videos/import — local upload path', () => {
     )
     const transcriptFile = new File(['content'], 'transcript.srt', { type: 'text/plain' })
     const fd = makeFormData({ video: videoFile, transcript: transcriptFile })
-    const req = makeRequest(fd)
-    const res = await POST(req as unknown as NextRequest)
+    const res = await POST(makeRequest(fd) as unknown as NextRequest)
     expect(res.status).toBe(400)
     const body = await res.json()
     expect(body.error).toMatch(/Title is required/)
   })
 
   it('returns 201 with empty tags when no tags provided for local upload', async () => {
-    const fakeNoTags = { ...fakeLocalVideo, tags: [] }
-    mockVideoService.importLocalVideo.mockResolvedValue(fakeNoTags)
     const fd = makeLocalFormData()
-    const req = makeRequest(fd)
-    const res = await POST(req as unknown as NextRequest)
+    const res = await POST(makeRequest(fd) as unknown as NextRequest)
     expect(res.status).toBe(201)
-    expect(mockVideoService.importLocalVideo).toHaveBeenCalledWith(
-      expect.objectContaining({ tags: [] })
-    )
+    const body = await res.json()
+    expect(body.tags).toEqual([])
   })
 
   it('returns 201 with empty author_name when no author provided', async () => {
     const fd = makeLocalFormData()
-    const req = makeRequest(fd)
-    await POST(req as unknown as NextRequest)
-    expect(mockVideoService.importLocalVideo).toHaveBeenCalledWith(
-      expect.objectContaining({ author_name: '' })
-    )
+    const res = await POST(makeRequest(fd) as unknown as NextRequest)
+    expect(res.status).toBe(201)
+    const body = await res.json()
+    expect(body.author_name).toBe('')
   })
 
   it('returns 400 when video MIME type is not allowed', async () => {
@@ -233,8 +144,7 @@ describe('POST /api/videos/import — local upload path', () => {
     )
     const transcriptFile = new File(['content'], 'transcript.srt', { type: 'text/plain' })
     const fd = makeFormData({ video: videoFile, title: 'Test', transcript: transcriptFile })
-    const req = makeRequest(fd)
-    const res = await POST(req as unknown as NextRequest)
+    const res = await POST(makeRequest(fd) as unknown as NextRequest)
     expect(res.status).toBe(400)
     const body = await res.json()
     expect(body.error).toMatch(/Unsupported format/)
@@ -250,24 +160,40 @@ describe('POST /api/videos/import — local upload path', () => {
     )
     const transcriptFile = new File(['content'], 'transcript.srt', { type: 'text/plain' })
     const fd = makeFormData({ video: videoFile, title: 'Test', transcript: transcriptFile })
-    const req = makeRequest(fd)
-    const res = await POST(req as unknown as NextRequest)
+    const res = await POST(makeRequest(fd) as unknown as NextRequest)
     expect(res.status).toBe(400)
     const body = await res.json()
     expect(body.error).toMatch(/500 MB/)
   })
 
-  it('returns 400 when video is a WebM with unsupported extension alias', async () => {
+  it('returns 201 for WebM videos', async () => {
     const videoContent = Buffer.from('data')
-    const videoFile = Object.assign(
+    const webmFile = Object.assign(
       new File([videoContent], 'my-video.webm', { type: 'video/webm' }),
       { arrayBuffer: async () => videoContent.buffer }
     )
-    const fakeWebmVideo = { ...fakeLocalVideo, local_video_path: '/data/videos/local.webm' }
-    mockVideoService.importLocalVideo.mockResolvedValue(fakeWebmVideo)
-    const fd = makeLocalFormData({ video: videoFile, title: 'WebM Video' })
-    const req = makeRequest(fd)
-    const res = await POST(req as unknown as NextRequest)
+    const fd = makeLocalFormData({ video: webmFile, title: 'WebM Video' })
+    const res = await POST(makeRequest(fd) as unknown as NextRequest)
     expect(res.status).toBe(201)
+  })
+
+  it('kicks off thumbnail generation after local import', async () => {
+    const thumbnailPath = '/data/thumbnails/video.jpg'
+    ;(generateThumbnail as jest.Mock).mockResolvedValue(thumbnailPath)
+    const updateSpy = jest.spyOn(container.videoStore, 'update')
+
+    const fd = makeLocalFormData({ tags: 'french, beginner', author: 'Local Author' })
+    const res = await POST(makeRequest(fd) as unknown as NextRequest)
+
+    expect(res.status).toBe(201)
+    await Promise.resolve()
+
+    expect(generateThumbnail as jest.Mock).toHaveBeenCalledWith(
+      expect.stringContaining('.mp4'),
+      expect.stringContaining('thumbnails')
+    )
+    expect(updateSpy).toHaveBeenCalledWith(expect.any(String), {
+      thumbnail_path: thumbnailPath,
+    })
   })
 })

--- a/src/app/api/videos/import/route.ts
+++ b/src/app/api/videos/import/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import path from 'path'
 
-import { videoService, videoStore } from '@/lib/server/composition'
+import { getContainer } from '@/lib/server/composition'
 import { ImportLocalVideoRequestSchema } from '@/lib/api-schemas'
 import { generateThumbnail } from '@/lib/thumbnails'
 import { getThumbnailsDir } from '@/lib/data-dir'
@@ -40,6 +40,7 @@ export async function POST(request: NextRequest) {
     const transcriptExt = transcriptFile.name.split('.').pop()?.toLowerCase() || ''
     const tags = tagsString.split(',').map((t) => t.trim()).filter((t) => t.length > 0)
 
+    const { videoService, videoStore } = getContainer()
     const record = await videoService.importLocalVideo({
       id: videoId,
       title,

--- a/src/app/api/videos/route.ts
+++ b/src/app/api/videos/route.ts
@@ -1,10 +1,11 @@
 import { NextResponse } from 'next/server'
-import { videoStore } from '@/lib/server/composition'
+import { getContainer } from '@/lib/server/composition'
 
 export const runtime = 'nodejs'
 
 export async function GET() {
   try {
+    const { videoStore } = getContainer()
     const videos = videoStore.list()
     return NextResponse.json(videos)
   } catch (error) {

--- a/src/app/api/vocabulary/[word]/__tests__/route.test.ts
+++ b/src/app/api/vocabulary/[word]/__tests__/route.test.ts
@@ -1,31 +1,19 @@
-// @jest-environment node
+/**
+ * @jest-environment node
+ */
+
+jest.mock('@/lib/server/composition', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const actual = jest.requireActual('@/lib/server/composition')
+  return { ...actual, getContainer: jest.fn() }
+})
+
 import { PATCH } from '../route'
-import { vocabStore } from '@/lib/server/composition'
+import * as composition from '@/lib/server/composition'
+import { createContainer } from '@/lib/server/composition'
+import type { Container } from '@/lib/server/composition'
 
-jest.mock('next/server', () => ({
-  NextResponse: class MockNextResponse {
-    status: number
-    body: unknown
-    constructor(body: unknown, init?: { status?: number }) {
-      this.body = body
-      this.status = init?.status ?? 200
-    }
-    static json(data: unknown, init?: { status?: number }) {
-      const res = new this(data, init)
-      res.body = data
-      return res
-    }
-    async json() { return this.body }
-  },
-}))
-
-jest.mock('@/lib/server/composition', () => ({
-  vocabStore: {
-    upsert: jest.fn(),
-  },
-}))
-
-const mockVocabStore = vocabStore as jest.Mocked<typeof vocabStore>
+let container: Container
 
 function makeRequest(body: unknown): Request {
   return {
@@ -35,35 +23,37 @@ function makeRequest(body: unknown): Request {
   } as unknown as Request
 }
 
+beforeEach(() => {
+  container = createContainer(':memory:')
+  ;(composition.getContainer as jest.Mock).mockReturnValue(container)
+})
+
+afterEach(() => {
+  jest.restoreAllMocks()
+})
+
 describe('PATCH /api/vocabulary/[word]', () => {
-  beforeEach(() => {
-    jest.clearAllMocks()
-  })
-
   it('upserts and returns the updated entry', async () => {
-    const entry = { word: 'ephemeral', status: 'mastered' }
-    mockVocabStore.upsert.mockReturnValue(entry)
-
     const res = await PATCH(makeRequest({ status: 'mastered' }), {
       params: Promise.resolve({ word: 'ephemeral' }),
     })
 
     expect(res.status).toBe(200)
     const body = await res.json()
-    expect(body).toEqual(entry)
-    expect(mockVocabStore.upsert).toHaveBeenCalledWith('ephemeral', 'mastered')
+    expect(body.word).toBe('ephemeral')
+    expect(body.status).toBe('mastered')
+    expect(container.vocabStore.getByWord('ephemeral')?.status).toBe('mastered')
   })
 
   it('decodes and lowercases the word param', async () => {
-    const entry = { word: 'hello world', status: 'new' }
-    mockVocabStore.upsert.mockReturnValue(entry)
-
     const res = await PATCH(makeRequest({ status: 'new' }), {
       params: Promise.resolve({ word: 'Hello%20World' }),
     })
 
     expect(res.status).toBe(200)
-    expect(mockVocabStore.upsert).toHaveBeenCalledWith('hello world', 'new')
+    const body = await res.json()
+    expect(body.word).toBe('hello world')
+    expect(container.vocabStore.getByWord('hello world')?.status).toBe('new')
   })
 
   it('returns 400 for invalid status', async () => {
@@ -77,7 +67,7 @@ describe('PATCH /api/vocabulary/[word]', () => {
   })
 
   it('returns 500 on store error', async () => {
-    mockVocabStore.upsert.mockImplementation(() => {
+    jest.spyOn(container.vocabStore, 'upsert').mockImplementation(() => {
       throw new Error('db error')
     })
 

--- a/src/app/api/vocabulary/[word]/route.ts
+++ b/src/app/api/vocabulary/[word]/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server'
-import { vocabStore } from '@/lib/server/composition'
+import { getContainer } from '@/lib/server/composition'
 import { UpdateVocabRequestSchema } from '@/lib/api-schemas'
 
 export const runtime = 'nodejs'
@@ -18,6 +18,7 @@ export async function PATCH(
       return NextResponse.json({ error: result.error.issues[0].message }, { status: 400 })
     }
 
+    const { vocabStore } = getContainer()
     const entry = vocabStore.upsert(decoded, result.data.status)
     return NextResponse.json(entry)
   } catch (error) {

--- a/src/app/api/vocabulary/__tests__/route.test.ts
+++ b/src/app/api/vocabulary/__tests__/route.test.ts
@@ -1,55 +1,53 @@
-// @jest-environment node
+/**
+ * @jest-environment node
+ */
+
+jest.mock('@/lib/server/composition', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const actual = jest.requireActual('@/lib/server/composition')
+  return { ...actual, getContainer: jest.fn() }
+})
+
 import { GET } from '../route'
-import { vocabStore } from '@/lib/server/composition'
+import * as composition from '@/lib/server/composition'
+import { createContainer } from '@/lib/server/composition'
+import type { Container } from '@/lib/server/composition'
 
-jest.mock('next/server', () => ({
-  NextResponse: class MockNextResponse {
-    status: number
-    body: unknown
-    constructor(body: unknown, init?: { status?: number }) {
-      this.body = body
-      this.status = init?.status ?? 200
-    }
-    static json(data: unknown, init?: { status?: number }) {
-      const res = new this(data, init)
-      res.body = data
-      return res
-    }
-    async json() { return this.body }
-  },
-}))
+let container: Container
 
-jest.mock('@/lib/server/composition', () => ({
-  vocabStore: {
-    getAll: jest.fn(),
-  },
-}))
+beforeEach(() => {
+  container = createContainer(':memory:')
+  ;(composition.getContainer as jest.Mock).mockReturnValue(container)
+})
 
-const mockVocabStore = vocabStore as jest.Mocked<typeof vocabStore>
+afterEach(() => {
+  jest.restoreAllMocks()
+})
 
 describe('GET /api/vocabulary', () => {
-  beforeEach(() => {
-    jest.clearAllMocks()
-  })
-
   it('returns all vocabulary entries as JSON', async () => {
-    const entries = [
-      { word: 'ephemeral', status: 'new' },
-      { word: 'resilient', status: 'mastered' },
-    ]
-    mockVocabStore.getAll.mockReturnValue(entries)
+    container.vocabStore.upsert('ephemeral', 'new')
+    container.vocabStore.upsert('resilient', 'mastered')
 
     const res = await GET()
     expect(res.status).toBe(200)
     const body = await res.json()
-    expect(body).toEqual(entries)
+    expect(body).toHaveLength(2)
+    expect(body.find((e: { word: string }) => e.word === 'ephemeral')?.status).toBe('new')
+    expect(body.find((e: { word: string }) => e.word === 'resilient')?.status).toBe('mastered')
+  })
+
+  it('returns empty array when no vocabulary entries', async () => {
+    const res = await GET()
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body).toEqual([])
   })
 
   it('returns 500 on store error', async () => {
-    mockVocabStore.getAll.mockImplementation(() => {
+    jest.spyOn(container.vocabStore, 'getAll').mockImplementation(() => {
       throw new Error('db error')
     })
-
     const res = await GET()
     expect(res.status).toBe(500)
     const body = await res.json()

--- a/src/app/api/vocabulary/route.ts
+++ b/src/app/api/vocabulary/route.ts
@@ -1,10 +1,11 @@
 import { NextResponse } from 'next/server'
-import { vocabStore } from '@/lib/server/composition'
+import { getContainer } from '@/lib/server/composition'
 
 export const runtime = 'nodejs'
 
 export async function GET() {
   try {
+    const { vocabStore } = getContainer()
     const entries = vocabStore.getAll()
     return NextResponse.json(entries)
   } catch (error) {

--- a/src/lib/server/composition.ts
+++ b/src/lib/server/composition.ts
@@ -1,36 +1,64 @@
 /**
- * Production composition root.
+ * Composition root.
  *
- * Data directory is resolved from the LINGOFLOW_DATA_DIR environment variable.
- * If the variable is not set, it defaults to `.lingoflow-data` inside the
- * current working directory (process.cwd()).
+ * createContainer(dataDir) — builds a fresh container wired to the given data directory.
+ *   Pass ':memory:' to get an in-memory SQLite database (useful for tests).
  *
- * Example:
+ * getContainer() — returns the process-lifetime singleton, lazily initialised on first call.
+ *   Route handlers MUST call this inside the handler body, never at module scope.
+ *
+ * Example (production):
  *   LINGOFLOW_DATA_DIR=/var/data/lingoflow pnpm start
+ *
+ * Example (test):
+ *   jest.spyOn(composition, 'getContainer').mockReturnValue(createContainer(':memory:'))
  */
+import Database from 'better-sqlite3'
 import { ensureDataDirs, openDb, initializeSchema } from '@/lib/db'
 import { SqliteVideoStore } from '@/lib/video-store'
 import { VideoService } from '@/lib/video-service'
 import { writeTranscript, deleteTranscript } from '@/lib/transcripts'
 import { SqliteVocabStore } from '@/lib/vocab-store'
-import { getDataDir, getDbPath, getVideosDir } from '@/lib/data-dir'
+import { getDataDir, getVideosDir } from '@/lib/data-dir'
 import fs from 'fs'
 import path from 'path'
 
-function createContainer() {
-  const dataDir = getDataDir()
-  ensureDataDirs(dataDir)
-  const db = openDb(getDbPath())
-  initializeSchema(db)
+export interface Container {
+  videoStore: SqliteVideoStore
+  videoService: VideoService
+  vocabStore: SqliteVocabStore
+}
+
+export function createContainer(dataDir: string): Container {
+  let db: Database.Database
+
+  if (dataDir === ':memory:') {
+    db = new Database(':memory:')
+    db.pragma('journal_mode = WAL')
+    initializeSchema(db)
+  } else {
+    ensureDataDirs(dataDir)
+    db = openDb(path.join(dataDir, 'lingoflow.db'))
+    initializeSchema(db)
+  }
 
   const store = new SqliteVideoStore(db)
   const vocabStore = new SqliteVocabStore(db)
+
   const transcriptStore = {
-    write: (videoId: string, ext: string, buffer: Buffer) => writeTranscript(videoId, ext, buffer),
-    delete: (filePath: string) => deleteTranscript(filePath),
+    write: (videoId: string, ext: string, buffer: Buffer): string => {
+      if (dataDir === ':memory:') return `:memory:/transcripts/${videoId}.${ext}`
+      return writeTranscript(videoId, ext, buffer)
+    },
+    delete: (filePath: string): void => {
+      if (dataDir === ':memory:') return
+      deleteTranscript(filePath)
+    },
   }
+
   const videoFileStore = {
     write: (videoId: string, ext: string, buffer: Buffer): string => {
+      if (dataDir === ':memory:') return `:memory:/videos/${videoId}.${ext}`
       const videosDir = getVideosDir()
       fs.mkdirSync(videosDir, { recursive: true })
       const filePath = path.join(videosDir, `${videoId}.${ext}`)
@@ -38,6 +66,7 @@ function createContainer() {
       return filePath
     },
     delete: (filePath: string): void => {
+      if (dataDir === ':memory:') return
       try {
         fs.unlinkSync(filePath)
       } catch (err: unknown) {
@@ -45,11 +74,16 @@ function createContainer() {
       }
     },
   }
-  const service = new VideoService(store, transcriptStore, videoFileStore)
 
+  const service = new VideoService(store, transcriptStore, videoFileStore)
   return { videoStore: store, videoService: service, vocabStore }
 }
 
-const { videoStore, videoService, vocabStore } = createContainer()
+let _container: Container | null = null
 
-export { videoStore, videoService, vocabStore }
+export function getContainer(): Container {
+  if (!_container) {
+    _container = createContainer(getDataDir())
+  }
+  return _container
+}


### PR DESCRIPTION
Closes #166

## Summary

Implements per-test DI isolation via a proper container pattern.

### composition.ts changes
- Export `Container` interface (`videoStore`, `videoService`, `vocabStore`)
- Export `createContainer(dataDir: string)` factory — uses real SQLite for filesystem paths; opens `:memory:` DB with noop file stores when `dataDir === ':memory:'`
- Export `getContainer()` lazy singleton — no module-scope side effects (DB init only on first call)
- Remove backward-compat named exports to prevent accidental DB init at module load time

### Route handler changes (all 8 routes)
All handlers now call `getContainer()` inside their function bodies instead of relying on module-scope imports.

### Test changes (all 8 test files)
Replace mock-based unit tests with integration tests using real in-memory SQLite:
- `createContainer(':memory:')` creates isolated DB per test
- `jest.mock('@/lib/server/composition', () => ({ ...actual, getContainer: jest.fn() }))` factory pattern
- `/** @jest-environment node */` block comment (line-comment form not recognised by Next.js jest config)
- `jest.mock('fs', () => ({ ...jest.requireActual('fs'), ... }))` preserves real `fs` methods needed by `better-sqlite3`

## Test results
265 tests pass. `pnpm build` clean.