### PR TITLE
feat: unified data-fetching layer with FetchApiClient + usePlayerData (#167)

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,0 +1,697 @@
+# LingoFlow — API Reference
+
+> Authoritative reference for all REST endpoints, service interfaces, data types, and key library patterns.
+> Generated from source code at `/workspaces/lingoFlow/src/`.
+
+---
+
+## Tech Stack
+
+| Layer | Library | Version |
+|---|---|---|
+| Framework | Next.js (App Router) | 16.2.3 |
+| UI | React | 19.2.4 |
+| Language | TypeScript | ^5 (`strict: true`) |
+| Data fetching | TanStack React Query | ^5.96.2 |
+| Database | better-sqlite3 | ^12.8.0 |
+| Validation | Zod | ^4.3.6 |
+| Styling | Tailwind CSS | ^3.4.19 |
+| Unit tests | Jest | ^30.3.0 |
+| E2E tests | Playwright | ^1.59.1 |
+
+---
+
+## REST API Endpoints
+
+All routes require `export const runtime = 'nodejs'` — `better-sqlite3` is a native addon and cannot run in the Edge runtime.
+
+### `GET /api/videos`
+
+List all videos ordered by `created_at DESC`.
+
+**Response** `200 Video[]`
+
+```json
+[
+  {
+    "id": "uuid",
+    "title": "string",
+    "author_name": "string",
+    "thumbnail_url": "string",
+    "transcript_path": "string",
+    "transcript_format": "srt|vtt|txt",
+    "tags": ["string"],
+    "created_at": "ISO8601",
+    "updated_at": "ISO8601",
+    "source_type": "local",
+    "local_video_path": "string | null",
+    "local_video_filename": "string | null",
+    "thumbnail_path": "string | null"
+  }
+]
+```
+
+**Error** `500 { "error": "Internal server error" }`
+
+---
+
+### `POST /api/videos/import`
+
+Import a local video file with transcript. Body is `multipart/form-data`.
+
+**Request fields**
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `video` | `File` | ✅ | MP4, WebM, or MOV; max 500 MB |
+| `title` | `string` | ✅ | Min length 1 (trimmed) |
+| `author` | `string` | ❌ | Optional author name |
+| `transcript` | `File` | ✅ | Must be `.srt`, `.vtt`, or `.txt` |
+| `tags` | `string` | ❌ | **Comma-separated** e.g. `"french,beginner"` |
+
+**Response** `201 Video` on success
+
+**Errors**
+- `400 { "error": "Only local video upload is supported" }` — no video file provided
+- `400 { "error": "<zod message>" }` — validation failure
+- `500 { "error": "Internal server error" }`
+
+**Constants** (from `src/lib/api-schemas.ts`)
+```ts
+ALLOWED_VIDEO_MIME_TYPES  = ['video/mp4', 'video/webm', 'video/quicktime']
+ALLOWED_TRANSCRIPT_FORMATS = ['srt', 'vtt', 'txt']
+MAX_VIDEO_SIZE_BYTES       = 524_288_000  // 500 MB
+```
+
+---
+
+### `GET /api/videos/[id]`
+
+Get a single video by ID.
+
+**Response**
+- `200 Video`
+- `404` plain text `"Not Found"`
+- `500 { "error": "Internal server error" }`
+
+---
+
+### `PATCH /api/videos/[id]`
+
+Update video metadata. Body is `multipart/form-data`.
+
+**Request fields**
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `tags` | `string` | ✅ | **JSON-serialized array** e.g. `'["french","beginner"]'` |
+| `transcript` | `File` | ❌ | Replacement transcript (`.srt`, `.vtt`, `.txt`) |
+
+**Response**
+- `200 Video`
+- `400 { "error": "<zod message>" }` — validation failure
+- `404 { "error": "Video not found" }`
+- `500 { "error": "Internal server error" }`
+
+> ⚠️ **Tags format differs between routes:**
+> - `POST /api/videos/import` → comma-separated string: `"french,beginner"`
+> - `PATCH /api/videos/[id]` → JSON array string: `'["french","beginner"]'`
+
+---
+
+### `DELETE /api/videos/[id]`
+
+Delete a video record plus all associated files (transcript, video file, thumbnail).
+
+**Response**
+- `204` (no body) — deleted
+- `404` plain text `"Not Found"`
+- `500` plain text `"Internal Server Error"`
+
+---
+
+### `GET /api/videos/[id]/transcript`
+
+Return parsed transcript cues for a video.
+
+**Response** `200`
+```json
+{ "cues": [{ "index": 1, "startTime": "00:00:01,000", "endTime": "00:00:03,500", "text": "Hello" }] }
+```
+Returns `{ "cues": [] }` if the video has no transcript.
+
+**Error** `404` plain text `"Not Found"` if video does not exist.
+
+---
+
+### `GET /api/videos/[id]/stream`
+
+Stream the local video file. Supports HTTP range requests for seek/partial playback.
+
+**Request headers**
+
+| Header | Example | Notes |
+|---|---|---|
+| `Range` | `bytes=0-1048575` | Optional; triggers 206 partial response |
+
+**Response**
+- `200` full file with `Content-Type`, `Content-Length`, `Accept-Ranges: bytes`
+- `206` partial with `Content-Range: bytes start-end/total`, `Content-Length`, `Content-Type`
+- `404` plain text — video not found or file missing
+- `500` plain text — server error
+
+Supported MIME types: `video/mp4`, `video/webm`, `video/quicktime`.
+
+---
+
+### `GET /api/videos/[id]/thumbnail`
+
+Return the JPEG thumbnail for a video.
+
+**Response**
+- `200 image/jpeg` with `Cache-Control: public, max-age=31536000, immutable`
+- `404` (no body) — video not found or thumbnail not yet generated
+
+---
+
+### `GET /api/vocabulary`
+
+List all vocabulary entries from the database, ordered by `word ASC`.
+
+**Response** `200 VocabEntry[]`
+```json
+[{ "word": "string", "status": "new|learning|mastered", "level": "B2", "definition": "string" }]
+```
+
+**Error** `500 { "error": "Internal server error" }`
+
+---
+
+### `PATCH /api/vocabulary/[word]`
+
+Upsert a vocabulary word's status. The `word` path parameter is URL-decoded and lowercased server-side.
+
+**Request** `Content-Type: application/json`
+```json
+{ "status": "new|learning|mastered" }
+```
+
+**Response**
+- `200 VocabEntry`
+- `400 { "error": "<zod message>" }` — invalid status value
+- `500 { "error": "Internal server error" }`
+
+---
+
+## TypeScript Types
+
+### `Video` — `src/lib/videos.ts`
+
+```ts
+type Video = {
+  id: string
+  title: string
+  author_name: string
+  thumbnail_url: string          // empty string for local-only videos
+  transcript_path: string
+  transcript_format: string      // 'srt' | 'vtt' | 'txt'
+  tags: string[]
+  created_at: string             // ISO 8601
+  updated_at: string             // ISO 8601
+  source_type: 'local'
+  local_video_path: string | null
+  local_video_filename: string | null
+  thumbnail_path: string | null
+}
+
+type InsertVideoParams = Omit<Video, 'created_at' | 'updated_at'>
+type UpdateVideoParams = {
+  tags?: string[]
+  transcript_path?: string
+  transcript_format?: string
+  thumbnail_path?: string | null
+}
+```
+
+### `TranscriptCue` — `src/lib/parse-transcript.ts`
+
+```ts
+interface TranscriptCue {
+  index: number
+  startTime: string   // e.g. "00:00:01,000"
+  endTime: string
+  text: string
+}
+```
+
+### `VocabEntry` — `src/lib/vocab-store.ts`
+
+```ts
+interface VocabEntry {
+  word: string
+  status: 'new' | 'learning' | 'mastered'
+  level?: string      // CEFR level e.g. 'B2'
+  definition?: string
+}
+```
+
+### `VocabWord` — `src/lib/vocabulary.ts` (mock data type)
+
+```ts
+type VocabWord = {
+  id: string
+  word: string
+  level: 'A1' | 'A2' | 'B1' | 'B2' | 'C1' | 'C2'
+  definition: string
+  contextQuote: string
+  source: string
+  status: 'new' | 'learning' | 'mastered'
+}
+```
+
+---
+
+## Database Schema
+
+Managed by `initializeSchema(db)` in `src/lib/db.ts`. New columns added via `addColumnIfMissing`.
+
+### `videos` table
+
+```sql
+CREATE TABLE IF NOT EXISTS videos (
+  id                   TEXT PRIMARY KEY,
+  title                TEXT NOT NULL,
+  author_name          TEXT NOT NULL,
+  thumbnail_url        TEXT NOT NULL,
+  transcript_path      TEXT NOT NULL,
+  transcript_format    TEXT NOT NULL,
+  tags                 TEXT NOT NULL DEFAULT '[]',   -- JSON array string
+  created_at           TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at           TEXT NOT NULL DEFAULT (datetime('now')),
+  source_type          TEXT,
+  local_video_path     TEXT,
+  local_video_filename TEXT,
+  thumbnail_path       TEXT                          -- added via addColumnIfMissing
+)
+```
+
+### `vocabulary` table
+
+```sql
+CREATE TABLE IF NOT EXISTS vocabulary (
+  word       TEXT PRIMARY KEY,
+  status     TEXT NOT NULL CHECK(status IN ('new','learning','mastered')),
+  level      TEXT,
+  definition TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+)
+```
+
+**Tags serialization:** `tags` is always `JSON.stringify(string[])` in SQLite and `JSON.parse()` back to `string[]` in `rowToVideo()`. Never serialize manually in callers.
+
+---
+
+## Zod v4 Patterns
+
+> ⚠️ **Breaking change from Zod v3:** `.error.errors` was renamed to `.error.issues`.
+
+```ts
+const result = schema.safeParse(input)
+if (!result.success) {
+  // ✅ Correct for Zod v4
+  return NextResponse.json({ error: result.error.issues[0].message }, { status: 400 })
+}
+const data = result.data
+```
+
+### Schemas in use
+
+| Schema | File | Used by |
+|---|---|---|
+| `ImportLocalVideoRequestSchema` | `src/lib/api-schemas.ts` | `POST /api/videos/import` |
+| `UpdateVideoRequestSchema` | `src/lib/api-schemas.ts` | `PATCH /api/videos/[id]` |
+| `UpdateVocabRequestSchema` | `src/lib/api-schemas.ts` | `PATCH /api/vocabulary/[word]` |
+| `VideoSchema` | `src/lib/videos.ts` | DB row → `Video` type |
+| `InsertVideoParamsSchema` | `src/lib/videos.ts` | Store insert validation |
+| `UpdateVideoParamsSchema` | `src/lib/videos.ts` | Store update validation |
+| `VocabWordSchema` | `src/lib/vocabulary.ts` | Mock vocabulary data type |
+
+---
+
+## Dependency Injection — Composition Root
+
+`src/lib/server/composition.ts` is the DI root. **Never** instantiate services directly in route handlers.
+
+```ts
+import { getContainer } from '@/lib/server/composition'
+
+// Inside a route handler body (not at module scope):
+const { videoStore, videoService, vocabStore } = getContainer()
+```
+
+### `Container` interface
+
+```ts
+interface Container {
+  videoStore: SqliteVideoStore
+  videoService: VideoService
+  vocabStore: SqliteVocabStore
+}
+```
+
+### `createContainer(dataDir)` — for tests
+
+Builds a fresh container wired to the given data directory. Pass `':memory:'` for an in-memory SQLite database.
+
+```ts
+import { createContainer } from '@/lib/server/composition'
+
+// In tests:
+jest.spyOn(composition, 'getContainer').mockReturnValue(createContainer(':memory:'))
+```
+
+When `dataDir === ':memory:'`:
+- Uses `new Database(':memory:')` (no filesystem I/O)
+- Transcript/video writes return virtual paths (`:memory:/transcripts/<id>.<ext>`)
+- `ThumbnailTask` is **not** registered (avoids loading ffmpeg)
+
+### `getContainer()` — production singleton
+
+Lazily initialised on first call. Uses `LINGOFLOW_DATA_DIR` env var or falls back to `.lingoflow-data/`.
+
+---
+
+## `VideoStore` Interface — `src/lib/video-store.ts`
+
+```ts
+interface VideoStore {
+  list(): Video[]
+  getById(id: string): Video | undefined
+  insert(params: InsertVideoParams): Video
+  update(id: string, params: UpdateVideoParams): Video | undefined
+  delete(id: string): boolean
+}
+```
+
+Implementation: `SqliteVideoStore`. All calls are **synchronous** (no `await`).
+
+---
+
+## `VideoService` — `src/lib/video-service.ts`
+
+```ts
+class VideoService {
+  constructor(store, transcriptStore, videoFileStore)
+
+  // Register a post-import side-effect task (e.g. ThumbnailTask)
+  registerPostImportTask(task: PostImportTask): this
+
+  // Run all registered post-import tasks sequentially; patches video record with results
+  async drainPostImportTasks(video: Video): Promise<void>
+
+  // Import a local video + transcript; runs post-import tasks after insert
+  async importLocalVideo(params: ImportLocalVideoParams): Promise<Video>
+
+  // Update tags and/or replace transcript file
+  async updateVideo(id: string, params: UpdateVideoServiceParams): Promise<Video | undefined>
+
+  // Delete video record, transcript file, video file, and thumbnail
+  async deleteVideo(id: string): Promise<boolean>
+}
+```
+
+### `PostImportTask` interface
+
+```ts
+interface PostImportTask {
+  run(video: Video): Promise<Partial<UpdateVideoParams>>
+}
+```
+
+`ThumbnailTask` (registered in production) extracts a JPEG thumbnail via ffmpeg and returns `{ thumbnail_path }`.
+
+### `ImportLocalVideoParams`
+
+```ts
+interface ImportLocalVideoParams {
+  id: string
+  title: string
+  author_name: string
+  video_buffer: Buffer
+  video_ext: string           // 'mp4' | 'webm' | 'mov'
+  video_filename: string
+  transcript_buffer: Buffer
+  transcript_ext: string      // 'srt' | 'vtt' | 'txt'
+  tags: string[]
+  source_type: 'local'
+}
+```
+
+### `UpdateVideoServiceParams`
+
+```ts
+interface UpdateVideoServiceParams {
+  tags?: string[]
+  transcript_ext?: string
+  transcript_buffer?: Buffer
+}
+```
+
+---
+
+## `VocabStore` Interface — `src/lib/vocab-store.ts`
+
+```ts
+interface VocabStore {
+  getAll(): VocabEntry[]
+  getByWord(word: string): VocabEntry | null
+  upsert(word: string, status: VocabEntry['status'], level?: string, definition?: string): VocabEntry
+}
+```
+
+Implementation: `SqliteVocabStore`. All calls synchronous.
+
+---
+
+## Data Directory — `src/lib/data-dir.ts`
+
+```ts
+getDataDir(): string        // LINGOFLOW_DATA_DIR ?? cwd()/.lingoflow-data
+getTranscriptsDir(): string // <dataDir>/transcripts
+getVideosDir(): string      // <dataDir>/videos
+getThumbnailsDir(): string  // <dataDir>/thumbnails
+getDbPath(): string         // <dataDir>/lingoflow.db
+```
+
+Override the root via `LINGOFLOW_DATA_DIR` environment variable.
+
+---
+
+## better-sqlite3 Patterns
+
+All `better-sqlite3` API calls are **synchronous**:
+
+```ts
+import Database from 'better-sqlite3'
+
+const db = new Database(dbPath)
+db.pragma('journal_mode = WAL')  // always set WAL mode
+
+// SELECT many
+const rows = db.prepare('SELECT * FROM videos ORDER BY created_at DESC').all()
+
+// SELECT one
+const row = db.prepare('SELECT * FROM videos WHERE id = ?').get(id)
+
+// INSERT / UPDATE / DELETE
+db.prepare('INSERT INTO videos (...) VALUES (...)').run(...values)
+db.prepare('UPDATE videos SET tags = ? WHERE id = ?').run(JSON.stringify(tags), id)
+db.prepare('DELETE FROM videos WHERE id = ?').run(id)
+```
+
+### Additive migration pattern
+
+```ts
+const addColumnIfMissing = (column: string, definition: string) => {
+  try {
+    db.exec(`ALTER TABLE videos ADD COLUMN ${column} ${definition}`)
+  } catch { /* already exists — ignore */ }
+}
+addColumnIfMissing('thumbnail_path', 'TEXT')
+```
+
+---
+
+## TanStack React Query v5 Patterns
+
+### Provider setup
+
+```tsx
+// src/components/Providers.tsx (wrapped in src/app/layout.tsx)
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { useState } from 'react'
+
+export default function Providers({ children }: { children: React.ReactNode }) {
+  const [queryClient] = useState(() => new QueryClient())
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+}
+```
+
+### Query keys in use
+
+| Key | Data type | Source |
+|---|---|---|
+| `['videos']` | `Video[]` | `GET /api/videos` |
+| `['vocabulary']` | `Map<string, VocabEntry>` | `GET /api/vocabulary` |
+
+---
+
+## Custom Hooks
+
+### `useVideos()` — `src/hooks/useVideos.ts`
+
+```ts
+const { data: videos = [], isLoading, error } = useVideos()
+// Returns UseQueryResult<Video[], Error>
+// Fetches GET /api/videos
+```
+
+### `useVideoMutations()` — `src/hooks/useVideoMutations.ts`
+
+```ts
+const { deleteVideo, refreshVideos } = useVideoMutations()
+
+deleteVideo.mutate(id)                           // DELETE /api/videos/:id + invalidate ['videos']
+deleteVideo.mutate(id, { onSuccess: () => ... }) // with callback
+refreshVideos()                                  // queryClient.invalidateQueries({ queryKey: ['videos'] })
+```
+
+### `useImportVideoForm()` — `src/hooks/useImportVideoForm.ts`
+
+Form state for the import modal. Handles `POST /api/videos/import`.
+
+```ts
+const {
+  videoFile, setVideoFile,
+  title, setTitle,
+  author, setAuthor,
+  transcriptFile, setTranscriptFile,
+  transcriptMode, setTranscriptMode,   // 'upload' | 'paste'
+  pastedTranscript, setPastedTranscript,
+  tags, setTags,
+  isSubmitting,
+  submitError,
+  handleSubmit,
+  canSubmit,
+} = useImportVideoForm({ onSuccess, onClose })
+```
+
+### `useVocabulary()` — `src/hooks/useVocabulary.ts`
+
+```ts
+const { data: vocabMap } = useVocabulary()
+// Returns UseQueryResult<Map<string, VocabEntry>, Error>
+// Fetches GET /api/vocabulary; keyed by word.toLowerCase()
+```
+
+### `useUpdateWordStatus()` — `src/hooks/useVocabulary.ts`
+
+```ts
+const mutation = useUpdateWordStatus()
+mutation.mutate({ word: 'resilient', status: 'mastered' })
+// PATCH /api/vocabulary/:word + invalidate ['vocabulary']
+// Returns UseMutationResult<VocabEntry, Error, { word, status }>
+```
+
+---
+
+## Transcript Utilities
+
+### `parseTranscript(content, format)` — `src/lib/parse-transcript.ts`
+
+```ts
+import { parseTranscript, TranscriptCue } from '@/lib/parse-transcript'
+
+const cues: TranscriptCue[] = parseTranscript(fileContent, 'srt')
+```
+
+Supported formats: `'srt'`, `'vtt'`, `'txt'` (plain lines, no timestamps).
+
+### `detectPastedTranscriptFormat(text)` — `src/lib/detect-transcript-format.ts`
+
+```ts
+import { detectPastedTranscriptFormat } from '@/lib/detect-transcript-format'
+const ext = detectPastedTranscriptFormat(text)  // 'vtt' | 'srt' | 'txt'
+```
+
+### Transcript file I/O — `src/lib/transcripts.ts`
+
+```ts
+writeTranscript(videoId, ext, buffer): string   // writes to getTranscriptsDir(); returns path
+deleteTranscript(filePath): void                 // ENOENT silently ignored
+```
+
+---
+
+## Next.js App Router Patterns
+
+### Dynamic route `params` must be awaited
+
+`params` is typed as `Promise<{ id: string }>` in Next.js 16:
+
+```ts
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params
+  // ...
+}
+```
+
+### Response patterns
+
+```ts
+import { NextResponse } from 'next/server'
+
+NextResponse.json(data)                              // 200
+NextResponse.json(data, { status: 201 })             // 201
+NextResponse.json({ error: 'msg' }, { status: 400 }) // 400
+new NextResponse(null, { status: 204 })              // 204 No Content
+new NextResponse('Not Found', { status: 404 })       // 404 plain text
+new Response(buffer, { headers: { 'Content-Type': 'image/jpeg' } }) // binary
+```
+
+---
+
+## Testing Patterns
+
+### API route tests require node environment
+
+```ts
+// @jest-environment node
+```
+
+Default `jsdom` environment lacks `Request`/`Response` globals.
+
+### Mocking the composition root
+
+```ts
+jest.mock('@/lib/server/composition', () => ({
+  getContainer: jest.fn().mockReturnValue({
+    videoStore: { list: jest.fn(), getById: jest.fn(), insert: jest.fn(), update: jest.fn(), delete: jest.fn() },
+    videoService: { importLocalVideo: jest.fn(), updateVideo: jest.fn(), deleteVideo: jest.fn() },
+    vocabStore: { getAll: jest.fn(), getByWord: jest.fn(), upsert: jest.fn() },
+  }),
+}))
+```
+
+### In-memory container for integration tests
+
+```ts
+import { createContainer } from '@/lib/server/composition'
+import * as composition from '@/lib/server/composition'
+
+jest.spyOn(composition, 'getContainer').mockReturnValue(createContainer(':memory:'))
+```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,342 @@
+# LingoFlow — Architecture Reference
+
+> **Purpose**: Accurate developer reference for architecture, data flow, patterns, and conventions.
+> **Last updated**: 2026-07, HEAD: main.
+
+---
+
+## 1. High-Level Architecture
+
+LingoFlow is a **local-first, single-user Next.js application** (App Router, React 19, TypeScript 5 strict).
+
+```
+Browser (React 19 client components)
+        ↕  fetch / FormData
+Next.js App Router (Node.js runtime)
+        ↕  better-sqlite3 (native addon)
+SQLite DB  +  local filesystem (transcripts/, videos/, thumbnails/)
+```
+
+There is no external backend, no auth, and no cloud storage. All data lives in `.lingoflow-data/` (overridable via `LINGOFLOW_DATA_DIR`).
+
+---
+
+## 2. App Router Layout
+
+```
+src/app/
+├── layout.tsx              ← Root layout: Providers (React Query), fonts (Manrope, Inter)
+├── page.tsx                ← Redirects to /dashboard
+├── globals.css
+├── (app)/                  ← Route group — adds Sidebar + TopBar shell
+│   ├── layout.tsx          ← Renders <Sidebar />, <TopBar />, <main>
+│   ├── dashboard/page.tsx  ← "My Library" grid, import/edit/delete modals (client component)
+│   ├── player/
+│   │   ├── layout.tsx      ← Pass-through (no extra chrome)
+│   │   └── [id]/page.tsx   ← Server component — awaits params, delegates to <PlayerLoader>
+│   └── vocabulary/page.tsx ← Vocabulary browser (DB-wired via /api/vocabulary)
+└── api/
+    ├── videos/route.ts                    ← GET  /api/videos
+    ├── videos/import/route.ts             ← POST /api/videos/import
+    ├── videos/[id]/route.ts               ← GET / PATCH / DELETE /api/videos/:id
+    ├── videos/[id]/transcript/route.ts    ← GET  /api/videos/:id/transcript → {cues[]}
+    ├── videos/[id]/stream/route.ts        ← GET  /api/videos/:id/stream (byte-range)
+    ├── videos/[id]/thumbnail/route.ts     ← GET  /api/videos/:id/thumbnail
+    ├── vocabulary/route.ts                ← GET  /api/vocabulary
+    └── vocabulary/[word]/route.ts         ← PATCH /api/vocabulary/:word
+```
+
+**Critical rule**: every `src/app/api/` file must export `export const runtime = 'nodejs'`.
+`better-sqlite3` is a native addon and cannot run in the Edge runtime.
+
+---
+
+## 3. Dependency Injection / Composition Root
+
+All route handlers obtain services through a single composition root.
+
+```ts
+// src/lib/server/composition.ts
+
+export interface Container {
+  videoStore: SqliteVideoStore
+  videoService: VideoService
+  vocabStore: SqliteVocabStore
+}
+
+// Production: singleton, lazily initialised on first call.
+export function getContainer(): Container
+
+// Test/isolation: fresh container wired to any dataDir or ':memory:'.
+export function createContainer(dataDir: string): Container
+```
+
+**Rules**:
+- Route handlers call `getContainer()` **inside** the handler body, never at module scope.
+- Never construct `SqliteVideoStore` or `VideoService` directly in route handlers.
+- Tests mock via `jest.spyOn(composition, 'getContainer').mockReturnValue(createContainer(':memory:'))`.
+
+**`createContainer` wires up**:
+1. `better-sqlite3` DB (WAL mode, schema auto-migrated via `initializeSchema`)
+2. `SqliteVideoStore` — CRUD over `videos` table
+3. `SqliteVocabStore` — CRUD over `vocabulary` table
+4. `TranscriptStore` adapter (filesystem writes/deletes)
+5. `VideoFileStore` adapter (filesystem writes/deletes)
+6. `VideoService` receiving all three stores
+7. `ThumbnailTask` registered as a post-import task (production only; skipped for `:memory:`)
+
+---
+
+## 4. Data Layer
+
+### SQLite Schema (`src/lib/db.ts`)
+
+**`videos` table**
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | TEXT PK | UUID |
+| `title` | TEXT | |
+| `author_name` | TEXT | |
+| `thumbnail_url` | TEXT | Empty string for local videos |
+| `transcript_path` | TEXT | Absolute path on filesystem |
+| `transcript_format` | TEXT | `srt` / `vtt` / `txt` |
+| `tags` | TEXT | JSON-serialised array `'["a","b"]'` |
+| `created_at` | TEXT | ISO 8601 |
+| `updated_at` | TEXT | ISO 8601 |
+| `source_type` | TEXT | Always `'local'` |
+| `local_video_path` | TEXT NULL | Absolute path (local upload only) |
+| `local_video_filename` | TEXT NULL | Original filename |
+| `thumbnail_path` | TEXT NULL | Path to ffmpeg-generated thumbnail |
+
+**`vocabulary` table**
+
+| Column | Type | Notes |
+|---|---|---|
+| `word` | TEXT PK | Lowercase |
+| `status` | TEXT | `new` / `learning` / `mastered` |
+| `level` | TEXT NULL | CEFR level hint |
+| `definition` | TEXT NULL | |
+| `created_at` / `updated_at` | TEXT | ISO 8601 |
+
+**Important**: `tags` is always stored as a JSON array string. `SqliteVideoStore.rowToVideo()` deserialises on read. Callers always pass `string[]`; never serialise manually outside the store.
+
+### Data Directory Layout (`src/lib/data-dir.ts`)
+
+```
+$LINGOFLOW_DATA_DIR/           (default: .lingoflow-data/)
+├── lingoflow.db
+├── transcripts/<videoId>.<ext>
+├── videos/<videoId>.<ext>
+└── thumbnails/<videoId>.jpg
+```
+
+Helpers: `getDataDir()`, `getTranscriptsDir()`, `getVideosDir()`, `getThumbnailsDir()`, `getDbPath()`.
+
+---
+
+## 5. Service Layer (`src/lib/video-service.ts`)
+
+`VideoService` owns all business logic. It accepts three store interfaces via constructor injection:
+
+```ts
+new VideoService(store: VideoStore, transcripts: TranscriptStore, videoFiles: VideoFileStore)
+```
+
+**Key methods**:
+
+| Method | Description |
+|---|---|
+| `importVideo(params)` | Writes transcript to disk, inserts DB record. Rolls back on failure. |
+| `importLocalVideo(params)` | Writes video + transcript, inserts DB record, runs post-import tasks. |
+| `updateVideo(id, params)` | Replaces transcript if provided; updates tags. Cleans up old transcript file. |
+| `deleteVideo(id)` | Deletes DB record + transcript file + local video file + thumbnail. |
+
+**Post-import task system**:
+```ts
+service.registerPostImportTask(task: PostImportTask)
+// PostImportTask.run(video) → Promise<Partial<UpdateVideoParams>>
+```
+Currently only `ThumbnailTask` is registered (generates JPEG thumbnail via ffmpeg/ffprobe). Tasks run sequentially after DB insert; failures are logged and do not abort the import.
+
+---
+
+## 6. Data-Fetching Patterns
+
+### React Query (TanStack Query v5) — server state
+
+All server state in the client is managed through React Query. The `QueryClientProvider` is mounted at root in `src/components/Providers.tsx`.
+
+```ts
+// Providers.tsx
+const [queryClient] = useState(() => new QueryClient())
+return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+```
+
+**Query hooks** use `useQuery`; **mutation hooks** use `useMutation` + `queryClient.invalidateQueries`.
+
+### Raw `fetch` in `useEffect` — component-local state
+
+`PlayerLoader` and `PlayerClient` fetch data via raw `fetch` inside `useEffect`. This data is not cached in React Query — it is component-local state only.
+
+- `PlayerLoader`: fetches `GET /api/videos/:id` on mount to resolve a `Video` object.
+- `PlayerClient`: fetches `GET /api/videos/:id/transcript` on mount to load `TranscriptCue[]`.
+
+---
+
+## 7. Component Hierarchy
+
+### Root shell
+
+```
+RootLayout (src/app/layout.tsx)
+  └─ Providers (React Query QueryClientProvider)
+       └─ AppLayout (src/app/(app)/layout.tsx)
+            ├─ Sidebar
+            ├─ TopBar (contains DarkModeToggle)
+            └─ <main> → route page
+```
+
+### Dashboard (`/dashboard`)
+
+```
+DashboardPage  [client component, 'use client']
+  ├─ useVideos()            ← React Query: GET /api/videos
+  ├─ useVideoMutations()    ← React Query: DELETE + cache invalidation
+  ├─ VideoCard[]            ← per-video card; callbacks onDelete / onEdit
+  ├─ ImportVideoModal       ← controlled by isModalOpen state
+  │    └─ useImportVideoForm()   ← useReducer form state + submit handler
+  ├─ EditVideoModal         ← controlled by editTarget state
+  └─ DeleteVideoModal       ← controlled by deleteTarget state
+```
+
+### Player (`/player/[id]`)
+
+```
+PlayerPage  [server component]           ← awaits params.id
+  └─ PlayerLoader  [client component]    ← fetches Video via raw fetch/useEffect
+       └─ PlayerClient  [client component]
+            ├─ useVocabulary()            ← React Query: GET /api/vocabulary
+            ├─ useUpdateWordStatus()      ← React Query mutation: PATCH /api/vocabulary/:word
+            ├─ LessonHero                 ← title, author, tags, Play button
+            ├─ PlaybackProgress           ← progress bar (shown only when mini-player open)
+            ├─ CueText[]                  ← tokenized transcript cues; word-click support
+            ├─ LocalVideoPlayer           ← floating <video> mini-player (conditional)
+            └─ WordSidebar                ← slide-over word detail panel (conditional)
+```
+
+### Vocabulary (`/vocabulary`)
+
+```
+VocabularyPage  [client component, 'use client']
+  ├─ useVocabulary()          ← React Query: GET /api/vocabulary
+  └─ (renders vocabulary list with CEFR level grouping)
+```
+
+---
+
+## 8. Hook Inventory
+
+| Hook | File | Pattern | Purpose |
+|---|---|---|---|
+| `useVideos` | `hooks/useVideos.ts` | `useQuery` | Fetches `Video[]` from `GET /api/videos`; query key `['videos']` |
+| `useVideoMutations` | `hooks/useVideoMutations.ts` | `useMutation` + `invalidateQueries` | `deleteVideo(id)` mutation; `refreshVideos()` cache invalidation |
+| `useImportVideoForm` | `hooks/useImportVideoForm.ts` | `useReducer` + `useCallback` | Full import form state machine; submits to `POST /api/videos/import` |
+| `useVocabulary` | `hooks/useVocabulary.ts` | `useQuery` | Fetches `VocabEntry[]`; returns `Map<string, VocabEntry>`; query key `['vocabulary']` |
+| `useUpdateWordStatus` | `hooks/useVocabulary.ts` | `useMutation` + `invalidateQueries` | `PATCH /api/vocabulary/:word`; invalidates `['vocabulary']` on success |
+
+### `useImportVideoForm` — reducer shape
+
+State is managed with `useReducer` using a discriminated-union action type. Exported for direct unit testing:
+
+```ts
+export { initialImportFormState, importFormReducer, State, Action }
+```
+
+Action types: `SET_IMPORT_MODE`, `SET_VIDEO_FILE`, `SET_TITLE`, `SET_AUTHOR`, `SET_TRANSCRIPT_MODE`, `SET_TRANSCRIPT_FILE`, `SET_PASTED_TRANSCRIPT`, `SET_TAGS`, `SUBMIT_START`, `SUBMIT_SUCCESS`, `SUBMIT_ERROR`, `RESET`.
+
+---
+
+## 9. API Contract Notes
+
+### Tags encoding differs between endpoints
+
+| Endpoint | `tags` field format |
+|---|---|
+| `POST /api/videos/import` | Comma-separated string: `"french,beginner"` |
+| `PATCH /api/videos/:id` | JSON-serialised array string: `'["french","beginner"]'` |
+
+Both are parsed by Zod schemas in `src/lib/api-schemas.ts`.
+
+### Dynamic route `params` must be awaited (Next.js App Router)
+
+```ts
+export async function GET(_req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
+}
+```
+
+### Zod v4 error access
+
+```ts
+result.error.issues[0].message   // ✅ Zod v4
+result.error.errors               // ❌ renamed in Zod v4
+```
+
+---
+
+## 10. Testing Conventions
+
+### Unit / Integration — Jest 30 + React Testing Library
+
+- **Config**: `jest.config.js`, setup in `jest.setup.ts` (imports `@testing-library/jest-dom`).
+- **Default environment**: `jsdom` (set in `jest.config.js`).
+- **API route tests** must opt into the Node environment (global `Request` not available in jsdom):
+  ```ts
+  // @jest-environment node   ← must be first line of file
+  ```
+- **Mocking the composition root** in route tests:
+  ```ts
+  jest.mock('@/lib/server/composition', () => ({ getContainer: jest.fn() }))
+  ```
+- **Reducer testing**: `importFormReducer` is exported as a pure function and tested directly without mounting a component.
+- **Component tests** are colocated in `src/components/__tests__/` and `src/app/(app)/**/\__tests__/`.
+- **Lib tests** are colocated in `src/lib/__tests__/`.
+
+### E2E — Playwright 1.59
+
+- **Config**: `playwright.config.ts` (Chromium only in CI).
+- **Dev server**: auto-started by Playwright's `webServer` config. Reuses existing server on port 3000 if already running.
+- **YouTube stub**: `E2E_STUB_YOUTUBE=true` is set by `webServer` config; `src/lib/youtube.ts` returns stub data when this env var is set.
+- **Page Object Model (POM)**: all page interactions are encapsulated in `tests/e2e/pages/`:
+
+| POM class | File | Covers |
+|---|---|---|
+| `DashboardPage` | `pages/DashboardPage.ts` | Navigation, empty/loading state, video card grid |
+| `ImportActions` | `pages/ImportActions.ts` | Import modal interactions |
+| `EditActions` | `pages/EditActions.ts` | Edit modal interactions |
+| `DeleteActions` | `pages/DeleteActions.ts` | Delete modal interactions |
+| `PlayerPage` | `pages/PlayerPage.ts` | Player route assertions |
+| `VocabularyPage` | `pages/VocabularyPage.ts` | Vocabulary route assertions |
+
+- **Fixtures** (`tests/e2e/fixtures/`): `setupIsolatedDb` / `teardownIsolatedDb` provision a per-test SQLite data directory; `seedVideo` / `seedTranscript` populate it. Sample transcript files: `sample.srt`, `fire-drill.srt`.
+- **Specs** (`tests/e2e/*.spec.ts`): each spec covers an independent user flow (import, delete, edit, player, cross-screen).
+
+### Running tests
+
+```bash
+pnpm test           # Jest unit tests
+pnpm test:e2e       # Playwright E2E (starts dev server automatically)
+pnpm build          # TypeScript validation (must pass before merging)
+```
+
+---
+
+## 11. Key Invariants
+
+1. `better-sqlite3` is synchronous; all DB calls are blocking. No async DB wrappers.
+2. `tags` column always contains a JSON array string. Deserialisation happens only in `rowToVideo()`.
+3. `source_type` is always `'local'` — YouTube import was removed.
+4. `getContainer()` must be called inside handler bodies, not at module scope (singleton is lazily initialised).
+5. All `src/app/api/` files must export `export const runtime = 'nodejs'`.
+6. Path alias `@/` maps to `src/`. Use in all imports within `src/`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,9 @@
 
 | File | Contents |
 |---|---|
-| [`api-docs.md`](./api-docs.md) | Tech stack versions, API patterns, library references |
+| [`architecture.md`](./architecture.md) | **Architecture reference** — App Router layout, DI/composition root, data flow, component hierarchy, hook inventory, testing conventions |
+| [`api-reference.md`](./api-reference.md) | **Canonical API reference** — all REST endpoints, types, service interfaces, DB schema, library patterns |
+| [`api-docs.md`](./api-docs.md) | Extended API patterns, hooks, and issue-specific notes |
 | [`e2e-testing.md`](./e2e-testing.md) | Playwright config, Page Object Model, fixtures, `data-testid` reference |
 | [`project-docs.md`](./project-docs.md) | Architecture, directory layout, build/test commands, design decisions |
 

--- a/src/components/PlayerClient.tsx
+++ b/src/components/PlayerClient.tsx
@@ -24,11 +24,11 @@ function parseTimeToSeconds(timestamp: string): number {
   return Number(hh) * 3600 + Number(mm) * 60 + Number(ss) + Number(ms) / 1000
 }
 
-export default function PlayerClient({ video }: { video: Video }) {
+export default function PlayerClient({ video, cues: propCues }: { video: Video; cues?: TranscriptCue[] }) {
   const { data: vocabMap = new Map() } = useVocabulary()
   const updateWordStatus = useUpdateWordStatus()
-  const [cues, setCues] = useState<TranscriptCue[]>([])
-  const [loadingTranscript, setLoadingTranscript] = useState(true)
+  const [cues, setCues] = useState<TranscriptCue[]>(propCues ?? [])
+  const [loadingTranscript, setLoadingTranscript] = useState(propCues === undefined)
   const [activeCueIndex, setActiveCueIndex] = useState(0)
   const [isMiniPlayerOpen, setIsMiniPlayerOpen] = useState(false)
   const [playbackTime, setPlaybackTime] = useState({ current: 0, duration: 0 })
@@ -47,6 +47,7 @@ export default function PlayerClient({ video }: { video: Video }) {
   }
 
   useEffect(() => {
+    if (propCues !== undefined) return
     fetch(`/api/videos/${video.id}/transcript`)
       .then((r) => r.json())
       .then((data) => {

--- a/src/components/PlayerLoader.tsx
+++ b/src/components/PlayerLoader.tsx
@@ -1,7 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
-import { Video } from '@/lib/videos'
+import { usePlayerData } from '@/hooks/usePlayerData'
 import PlayerClient from '@/components/PlayerClient'
 
 interface PlayerLoaderProps {
@@ -9,28 +8,9 @@ interface PlayerLoaderProps {
 }
 
 export default function PlayerLoader({ id }: PlayerLoaderProps) {
-  const [video, setVideo] = useState<Video | null>(null)
-  const [status, setStatus] = useState<'loading' | 'not-found' | 'error' | 'ready'>('loading')
+  const { video, cues, isLoading, error } = usePlayerData(id)
 
-  useEffect(() => {
-    fetch(`/api/videos/${id}`)
-      .then(async (res) => {
-        if (res.status === 404) {
-          setStatus('not-found')
-          return
-        }
-        if (!res.ok) {
-          setStatus('error')
-          return
-        }
-        const data: Video = await res.json()
-        setVideo(data)
-        setStatus('ready')
-      })
-      .catch(() => setStatus('error'))
-  }, [id])
-
-  if (status === 'loading') {
+  if (isLoading) {
     return (
       <div className="min-h-screen flex items-center justify-center">
         <p className="text-on-surface-variant">Loading…</p>
@@ -38,15 +18,7 @@ export default function PlayerLoader({ id }: PlayerLoaderProps) {
     )
   }
 
-  if (status === 'not-found') {
-    return (
-      <div className="min-h-screen flex items-center justify-center">
-        <p className="text-on-surface-variant">Video not found.</p>
-      </div>
-    )
-  }
-
-  if (status === 'error') {
+  if (error || !video) {
     return (
       <div className="min-h-screen flex items-center justify-center">
         <p className="text-on-surface-variant">Failed to load video.</p>
@@ -54,5 +26,6 @@ export default function PlayerLoader({ id }: PlayerLoaderProps) {
     )
   }
 
-  return <PlayerClient video={video!} />
+  return <PlayerClient video={video} cues={cues ?? []} />
 }
+

--- a/src/components/Providers.tsx
+++ b/src/components/Providers.tsx
@@ -2,13 +2,16 @@
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { useState } from 'react'
+import { ApiClientProvider } from '@/lib/api-client'
 
 export default function Providers({ children }: { children: React.ReactNode }) {
   const [queryClient] = useState(() => new QueryClient())
 
   return (
     <QueryClientProvider client={queryClient}>
-      {children}
+      <ApiClientProvider>
+        {children}
+      </ApiClientProvider>
     </QueryClientProvider>
   )
 }

--- a/src/components/__tests__/PlayerClient.test.tsx
+++ b/src/components/__tests__/PlayerClient.test.tsx
@@ -40,10 +40,7 @@ jest.mock('@/components/LocalVideoPlayer', () => ({
 
 beforeEach(() => {
   mockCapturedOnTimeUpdate = undefined
-  global.fetch = jest.fn().mockResolvedValue({
-    ok: true,
-    json: async () => ({ cues: [] }),
-  }) as jest.Mock
+  global.fetch = jest.fn()
 })
 
 afterEach(() => {
@@ -52,19 +49,19 @@ afterEach(() => {
 
 describe('PlayerClient', () => {
   it('initially shows the lesson hero and not the mini-player', async () => {
-    render(<PlayerClient video={mockVideo} />)
+    render(<PlayerClient video={mockVideo} cues={[]} />)
     expect(screen.getByTestId('lesson-hero')).toBeInTheDocument()
     expect(screen.queryByTestId('mini-player')).not.toBeInTheDocument()
   })
 
   it('shows mini-player after clicking play', async () => {
-    render(<PlayerClient video={mockVideo} />)
+    render(<PlayerClient video={mockVideo} cues={[]} />)
     fireEvent.click(screen.getByTestId('play-button'))
     expect(screen.getByTestId('mini-player')).toBeInTheDocument()
   })
 
   it('hides mini-player after clicking close', async () => {
-    render(<PlayerClient video={mockVideo} />)
+    render(<PlayerClient video={mockVideo} cues={[]} />)
     fireEvent.click(screen.getByTestId('play-button'))
     expect(screen.getByTestId('mini-player')).toBeInTheDocument()
     fireEvent.click(screen.getByTestId('mini-player-close'))
@@ -72,19 +69,32 @@ describe('PlayerClient', () => {
   })
 
   it('still shows the lesson hero while mini-player is open', () => {
-    render(<PlayerClient video={mockVideo} />)
+    render(<PlayerClient video={mockVideo} cues={[]} />)
     fireEvent.click(screen.getByTestId('play-button'))
     expect(screen.getByTestId('lesson-hero')).toBeInTheDocument()
     expect(screen.getByTestId('mini-player')).toBeInTheDocument()
   })
 
   it('renders the transcript panel', async () => {
-    render(<PlayerClient video={mockVideo} />)
+    render(<PlayerClient video={mockVideo} cues={[]} />)
     expect(screen.getByText('Interactive Transcript')).toBeInTheDocument()
     expect(screen.queryByTestId('tab-vocabulary')).not.toBeInTheDocument()
   })
 
-  it('fetches transcript on mount', async () => {
+  it('uses provided cues and does not fetch transcript', () => {
+    const cues = [
+      { index: 1, startTime: '00:00:00,000', endTime: '00:00:02,000', text: 'Hello' },
+    ]
+    render(<PlayerClient video={mockVideo} cues={cues} />)
+    expect(screen.getByText('Hello')).toBeInTheDocument()
+    expect(global.fetch).not.toHaveBeenCalled()
+  })
+
+  it('fetches transcript when cues prop is not provided', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ cues: [] }),
+    }) as jest.Mock
     render(<PlayerClient video={mockVideo} />)
     await waitFor(() => {
       expect(global.fetch).toHaveBeenCalledWith('/api/videos/video-1/transcript')
@@ -92,19 +102,19 @@ describe('PlayerClient', () => {
   })
 
   it('does not render PlaybackProgress before play is clicked', () => {
-    render(<PlayerClient video={mockVideo} />)
+    render(<PlayerClient video={mockVideo} cues={[]} />)
     expect(screen.queryByTestId('playback-progress')).not.toBeInTheDocument()
   })
 
   it('renders PlaybackProgress with 0 times after clicking play', () => {
-    render(<PlayerClient video={mockVideo} />)
+    render(<PlayerClient video={mockVideo} cues={[]} />)
     fireEvent.click(screen.getByTestId('play-button'))
     expect(screen.getByTestId('playback-progress')).toBeInTheDocument()
     expect(screen.getByTestId('current-time')).toHaveTextContent('0:00')
   })
 
   it('updates PlaybackProgress when onTimeUpdate is called', () => {
-    render(<PlayerClient video={mockVideo} />)
+    render(<PlayerClient video={mockVideo} cues={[]} />)
     fireEvent.click(screen.getByTestId('play-button'))
 
     act(() => {
@@ -116,7 +126,7 @@ describe('PlayerClient', () => {
   })
 
   it('hides PlaybackProgress after closing the mini-player', () => {
-    render(<PlayerClient video={mockVideo} />)
+    render(<PlayerClient video={mockVideo} cues={[]} />)
     fireEvent.click(screen.getByTestId('play-button'))
 
     act(() => {
@@ -135,7 +145,7 @@ describe('PlayerClient', () => {
       local_video_path: 'videos/test.mp4',
       local_video_filename: 'test.mp4',
     }
-    render(<PlayerClient video={localVideo} />)
+    render(<PlayerClient video={localVideo} cues={[]} />)
     fireEvent.click(screen.getByTestId('play-button'))
     expect(screen.getByTestId('mini-player')).toBeInTheDocument()
   })

--- a/src/hooks/__tests__/usePlayerData.test.ts
+++ b/src/hooks/__tests__/usePlayerData.test.ts
@@ -1,0 +1,151 @@
+import { renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import React from 'react'
+import { usePlayerData } from '../usePlayerData'
+import { ApiClient, ApiClientProvider } from '@/lib/api-client'
+import { Video } from '@/lib/videos'
+import { TranscriptCue } from '@/lib/parse-transcript'
+
+const mockVideo: Video = {
+  id: 'video-1',
+  title: 'Test Video',
+  author_name: 'Author',
+  thumbnail_url: '',
+  transcript_path: 'transcripts/video-1.srt',
+  transcript_format: 'srt',
+  tags: ['french'],
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+  source_type: 'local',
+}
+
+const mockCues: TranscriptCue[] = [
+  { index: 1, startTime: '00:00:00,000', endTime: '00:00:02,000', text: 'Hello' },
+  { index: 2, startTime: '00:00:02,500', endTime: '00:00:05,000', text: 'World' },
+]
+
+function makeClient(overrides: Partial<ApiClient> = {}): ApiClient {
+  return {
+    listVideos: jest.fn(),
+    getVideo: jest.fn(),
+    getTranscript: jest.fn(),
+    importVideo: jest.fn(),
+    updateVideo: jest.fn(),
+    deleteVideo: jest.fn(),
+    ...overrides,
+  }
+}
+
+function createWrapper(client: ApiClient) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  function Wrapper({ children }: { children: React.ReactNode }) {
+    return React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      React.createElement(ApiClientProvider, { client }, children)
+    )
+  }
+  Wrapper.displayName = 'UsePlayerDataWrapper'
+  return { Wrapper, queryClient }
+}
+
+describe('usePlayerData', () => {
+  it('returns isLoading=true while fetching', () => {
+    const client = makeClient({
+      getVideo: jest.fn(() => new Promise(() => {})),
+      getTranscript: jest.fn(() => new Promise(() => {})),
+    })
+    const { Wrapper } = createWrapper(client)
+    const { result } = renderHook(() => usePlayerData('video-1'), { wrapper: Wrapper })
+
+    expect(result.current.isLoading).toBe(true)
+    expect(result.current.video).toBeUndefined()
+    expect(result.current.cues).toBeUndefined()
+    expect(result.current.error).toBeNull()
+  })
+
+  it('returns video and cues on parallel-fetch success', async () => {
+    const client = makeClient({
+      getVideo: jest.fn().mockResolvedValue(mockVideo),
+      getTranscript: jest.fn().mockResolvedValue(mockCues),
+    })
+    const { Wrapper } = createWrapper(client)
+    const { result } = renderHook(() => usePlayerData('video-1'), { wrapper: Wrapper })
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    expect(result.current.video).toEqual(mockVideo)
+    expect(result.current.cues).toEqual(mockCues)
+    expect(result.current.error).toBeNull()
+    expect(client.getVideo).toHaveBeenCalledWith('video-1')
+    expect(client.getTranscript).toHaveBeenCalledWith('video-1')
+  })
+
+  it('fires video and transcript queries in parallel (both called before either resolves)', () => {
+    let videoResolve!: (v: Video) => void
+    let transcriptResolve!: (c: TranscriptCue[]) => void
+    const client = makeClient({
+      getVideo: jest.fn(() => new Promise<Video>((r) => { videoResolve = r })),
+      getTranscript: jest.fn(() => new Promise<TranscriptCue[]>((r) => { transcriptResolve = r })),
+    })
+    const { Wrapper } = createWrapper(client)
+    renderHook(() => usePlayerData('video-1'), { wrapper: Wrapper })
+
+    expect(client.getVideo).toHaveBeenCalledWith('video-1')
+    expect(client.getTranscript).toHaveBeenCalledWith('video-1')
+
+    // cleanup
+    videoResolve(mockVideo)
+    transcriptResolve(mockCues)
+  })
+
+  it('returns error when getVideo fails', async () => {
+    const client = makeClient({
+      getVideo: jest.fn().mockRejectedValue(new Error('Video not found: video-1')),
+      getTranscript: jest.fn().mockResolvedValue(mockCues),
+    })
+    const { Wrapper } = createWrapper(client)
+    const { result } = renderHook(() => usePlayerData('video-1'), { wrapper: Wrapper })
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    expect(result.current.error).toBeInstanceOf(Error)
+    expect(result.current.error?.message).toBe('Video not found: video-1')
+    expect(result.current.video).toBeUndefined()
+  })
+
+  it('returns error when getTranscript fails', async () => {
+    const client = makeClient({
+      getVideo: jest.fn().mockResolvedValue(mockVideo),
+      getTranscript: jest.fn().mockRejectedValue(new Error('Failed to fetch transcript for: video-1')),
+    })
+    const { Wrapper } = createWrapper(client)
+    const { result } = renderHook(() => usePlayerData('video-1'), { wrapper: Wrapper })
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    expect(result.current.error).toBeInstanceOf(Error)
+    expect(result.current.error?.message).toBe('Failed to fetch transcript for: video-1')
+  })
+
+  it('serves cached video data on cache-hit without re-fetching', async () => {
+    const client = makeClient({
+      getVideo: jest.fn().mockResolvedValue(mockVideo),
+      getTranscript: jest.fn().mockResolvedValue(mockCues),
+    })
+    const { Wrapper, queryClient } = createWrapper(client)
+
+    // Pre-populate the cache
+    queryClient.setQueryData(['videos', 'video-1'], mockVideo)
+    queryClient.setQueryData(['transcript', 'video-1'], mockCues)
+
+    const { result } = renderHook(() => usePlayerData('video-1'), { wrapper: Wrapper })
+
+    // Data available synchronously from cache
+    expect(result.current.video).toEqual(mockVideo)
+    expect(result.current.cues).toEqual(mockCues)
+    expect(result.current.isLoading).toBe(false)
+  })
+})

--- a/src/hooks/usePlayerData.ts
+++ b/src/hooks/usePlayerData.ts
@@ -1,0 +1,38 @@
+import { useQueries } from '@tanstack/react-query'
+import { useApiClient, queryKeys } from '@/lib/api-client'
+import { Video } from '@/lib/videos'
+import { TranscriptCue } from '@/lib/parse-transcript'
+
+export interface PlayerData {
+  video: Video | undefined
+  cues: TranscriptCue[] | undefined
+  isLoading: boolean
+  error: Error | null
+}
+
+export function usePlayerData(id: string): PlayerData {
+  const client = useApiClient()
+
+  const [videoResult, transcriptResult] = useQueries({
+    queries: [
+      {
+        queryKey: queryKeys.video(id),
+        queryFn: () => client.getVideo(id),
+      },
+      {
+        queryKey: queryKeys.transcript(id),
+        queryFn: () => client.getTranscript(id),
+      },
+    ],
+  })
+
+  const isLoading = videoResult.isLoading || transcriptResult.isLoading
+  const error = (videoResult.error ?? transcriptResult.error) as Error | null
+
+  return {
+    video: videoResult.data,
+    cues: transcriptResult.data,
+    isLoading,
+    error,
+  }
+}

--- a/src/lib/__tests__/api-client.test.ts
+++ b/src/lib/__tests__/api-client.test.ts
@@ -1,0 +1,158 @@
+import { FetchApiClient, queryKeys } from '../api-client'
+
+const mockVideo = {
+  id: 'video-1',
+  title: 'Test Video',
+  author_name: 'Author',
+  thumbnail_url: '',
+  transcript_path: 'transcripts/video-1.srt',
+  transcript_format: 'srt',
+  tags: ['french'],
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+  source_type: 'local' as const,
+}
+
+function mockFetch(response: Partial<Response>) {
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    json: async () => ({}),
+    ...response,
+  })
+}
+
+afterEach(() => {
+  jest.resetAllMocks()
+})
+
+describe('queryKeys', () => {
+  it('videos() returns stable key', () => {
+    expect(queryKeys.videos()).toEqual(['videos'])
+  })
+
+  it('video(id) returns scoped key', () => {
+    expect(queryKeys.video('abc')).toEqual(['videos', 'abc'])
+  })
+
+  it('transcript(id) returns scoped key', () => {
+    expect(queryKeys.transcript('abc')).toEqual(['transcript', 'abc'])
+  })
+})
+
+describe('FetchApiClient', () => {
+  let client: FetchApiClient
+
+  beforeEach(() => {
+    client = new FetchApiClient()
+  })
+
+  describe('listVideos()', () => {
+    it('calls GET /api/videos', async () => {
+      mockFetch({ json: async () => [mockVideo] })
+      const result = await client.listVideos()
+      expect(global.fetch).toHaveBeenCalledWith('/api/videos')
+      expect(result).toEqual([mockVideo])
+    })
+
+    it('throws on non-ok response', async () => {
+      mockFetch({ ok: false, status: 500 })
+      await expect(client.listVideos()).rejects.toThrow('Failed to fetch videos')
+    })
+  })
+
+  describe('getVideo(id)', () => {
+    it('calls GET /api/videos/:id', async () => {
+      mockFetch({ json: async () => mockVideo })
+      const result = await client.getVideo('video-1')
+      expect(global.fetch).toHaveBeenCalledWith('/api/videos/video-1')
+      expect(result).toEqual(mockVideo)
+    })
+
+    it('throws "Video not found" on 404', async () => {
+      mockFetch({ ok: false, status: 404 })
+      await expect(client.getVideo('missing')).rejects.toThrow('Video not found: missing')
+    })
+
+    it('throws on other non-ok responses', async () => {
+      mockFetch({ ok: false, status: 500 })
+      await expect(client.getVideo('video-1')).rejects.toThrow('Failed to fetch video: video-1')
+    })
+  })
+
+  describe('getTranscript(id)', () => {
+    it('calls GET /api/videos/:id/transcript and unwraps cues', async () => {
+      const cues = [{ index: 1, startTime: '00:00:00,000', endTime: '00:00:02,000', text: 'Hello' }]
+      mockFetch({ json: async () => ({ cues }) })
+      const result = await client.getTranscript('video-1')
+      expect(global.fetch).toHaveBeenCalledWith('/api/videos/video-1/transcript')
+      expect(result).toEqual(cues)
+    })
+
+    it('returns empty array when cues is missing', async () => {
+      mockFetch({ json: async () => ({}) })
+      const result = await client.getTranscript('video-1')
+      expect(result).toEqual([])
+    })
+
+    it('throws on non-ok response', async () => {
+      mockFetch({ ok: false, status: 500 })
+      await expect(client.getTranscript('video-1')).rejects.toThrow(
+        'Failed to fetch transcript for: video-1'
+      )
+    })
+  })
+
+  describe('importVideo(form)', () => {
+    it('calls POST /api/videos/import with FormData', async () => {
+      mockFetch({ json: async () => mockVideo })
+      const form = new FormData()
+      form.append('title', 'Test')
+      const result = await client.importVideo(form)
+      expect(global.fetch).toHaveBeenCalledWith('/api/videos/import', {
+        method: 'POST',
+        body: form,
+      })
+      expect(result).toEqual(mockVideo)
+    })
+
+    it('throws on non-ok response', async () => {
+      mockFetch({ ok: false, status: 400 })
+      await expect(client.importVideo(new FormData())).rejects.toThrow('Failed to import video')
+    })
+  })
+
+  describe('updateVideo(id, form)', () => {
+    it('calls PATCH /api/videos/:id with FormData', async () => {
+      mockFetch({ json: async () => mockVideo })
+      const form = new FormData()
+      form.append('tags', '["french"]')
+      const result = await client.updateVideo('video-1', form)
+      expect(global.fetch).toHaveBeenCalledWith('/api/videos/video-1', {
+        method: 'PATCH',
+        body: form,
+      })
+      expect(result).toEqual(mockVideo)
+    })
+
+    it('throws on non-ok response', async () => {
+      mockFetch({ ok: false, status: 404 })
+      await expect(client.updateVideo('missing', new FormData())).rejects.toThrow(
+        'Failed to update video: missing'
+      )
+    })
+  })
+
+  describe('deleteVideo(id)', () => {
+    it('calls DELETE /api/videos/:id', async () => {
+      mockFetch({ ok: true })
+      await client.deleteVideo('video-1')
+      expect(global.fetch).toHaveBeenCalledWith('/api/videos/video-1', { method: 'DELETE' })
+    })
+
+    it('throws on non-ok response', async () => {
+      mockFetch({ ok: false, status: 404 })
+      await expect(client.deleteVideo('missing')).rejects.toThrow('Failed to delete video: missing')
+    })
+  })
+})

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -1,0 +1,78 @@
+'use client'
+
+import React, { createContext, useContext, useState } from 'react'
+import { Video } from '@/lib/videos'
+import { TranscriptCue } from '@/lib/parse-transcript'
+
+export interface ApiClient {
+  listVideos(): Promise<Video[]>
+  getVideo(id: string): Promise<Video>
+  getTranscript(id: string): Promise<TranscriptCue[]>
+  importVideo(form: FormData): Promise<Video>
+  updateVideo(id: string, form: FormData): Promise<Video>
+  deleteVideo(id: string): Promise<void>
+}
+
+export const queryKeys = {
+  videos: () => ['videos'] as const,
+  video: (id: string) => ['videos', id] as const,
+  transcript: (id: string) => ['transcript', id] as const,
+}
+
+export class FetchApiClient implements ApiClient {
+  async listVideos(): Promise<Video[]> {
+    const res = await fetch('/api/videos')
+    if (!res.ok) throw new Error('Failed to fetch videos')
+    return res.json()
+  }
+
+  async getVideo(id: string): Promise<Video> {
+    const res = await fetch(`/api/videos/${id}`)
+    if (res.status === 404) throw new Error(`Video not found: ${id}`)
+    if (!res.ok) throw new Error(`Failed to fetch video: ${id}`)
+    return res.json()
+  }
+
+  async getTranscript(id: string): Promise<TranscriptCue[]> {
+    const res = await fetch(`/api/videos/${id}/transcript`)
+    if (!res.ok) throw new Error(`Failed to fetch transcript for: ${id}`)
+    const data = await res.json()
+    return data.cues ?? []
+  }
+
+  async importVideo(form: FormData): Promise<Video> {
+    const res = await fetch('/api/videos/import', { method: 'POST', body: form })
+    if (!res.ok) throw new Error('Failed to import video')
+    return res.json()
+  }
+
+  async updateVideo(id: string, form: FormData): Promise<Video> {
+    const res = await fetch(`/api/videos/${id}`, { method: 'PATCH', body: form })
+    if (!res.ok) throw new Error(`Failed to update video: ${id}`)
+    return res.json()
+  }
+
+  async deleteVideo(id: string): Promise<void> {
+    const res = await fetch(`/api/videos/${id}`, { method: 'DELETE' })
+    if (!res.ok) throw new Error(`Failed to delete video: ${id}`)
+  }
+}
+
+const ApiClientContext = createContext<ApiClient | null>(null)
+
+export function ApiClientProvider({
+  client,
+  children,
+}: {
+  client?: ApiClient
+  children: React.ReactNode
+}) {
+  const [defaultClient] = useState<ApiClient>(() => new FetchApiClient())
+  return React.createElement(ApiClientContext.Provider, { value: client ?? defaultClient }, children)
+}
+
+export function useApiClient(): ApiClient {
+  const client = useContext(ApiClientContext)
+  if (!client) throw new Error('useApiClient must be used within ApiClientProvider')
+  return client
+}


### PR DESCRIPTION
## Summary

Implements #167 — RFC: Unified data-fetching layer with FetchApiClient + usePlayerData.

## Changes

### New files
- `src/lib/api-client.ts` — `ApiClient` interface, `queryKeys` registry, `FetchApiClient` class, `ApiClientContext`/`ApiClientProvider`/`useApiClient()` hook
- `src/hooks/usePlayerData.ts` — fires `getVideo` + `getTranscript` in parallel via `useQueries`, returns `{ video, cues, isLoading, error }`
- `src/lib/__tests__/api-client.test.ts` — 14 tests: URL construction and error propagation for all 6 methods
- `src/hooks/__tests__/usePlayerData.test.ts` — 6 tests: loading, parallel-fetch, error, cache-hit states

### Modified files
- `src/components/Providers.tsx` — wrap with `ApiClientProvider` so all client components have access
- `src/components/PlayerLoader.tsx` — replaced raw `fetch` + `useEffect` + manual state with `usePlayerData(id)`
- `src/components/PlayerClient.tsx` — added optional `cues` prop; skips self-fetch when cues provided by PlayerLoader
- `src/components/__tests__/PlayerClient.test.tsx` — pass `cues` prop; replace raw-fetch assertions with cues-prop tests

## Test results

- **294 tests pass** (all pre-existing + 20 new)
- **Build passes** (TypeScript + Next.js production build)