### PR TITLE
fix: improve mini-player seek control distinguishability (#178)

### DIFF
--- a/docs/api-docs.md
+++ b/docs/api-docs.md
@@ -298,26 +298,38 @@ CREATE TABLE IF NOT EXISTS videos (
 
 ## Dependency Injection / Composition Root
 
-**Never** instantiate services directly in route handlers. Always import from the composition root:
+**Never** instantiate services directly in route handlers. Use `getContainer()` from the composition root — called **inside** handler bodies, never at module scope:
 
 ```ts
-import { videoStore, videoService } from '@/lib/server/composition'
+import { getContainer } from '@/lib/server/composition'
+
+export async function GET(_req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
+  const { videoStore } = getContainer()
+  // ...
+}
 ```
 
-`videoStore` → `SqliteVideoStore`  
-`videoService` → `VideoService` (wraps store + transcript I/O + video file I/O)
+### `Container` interface
+
+```ts
+interface Container {
+  videoStore: SqliteVideoStore
+  videoService: VideoService
+  vocabStore: SqliteVocabStore
+}
+```
+
+`createContainer(dataDir)` builds a fresh container for tests; `':memory:'` uses in-memory SQLite.
 
 ### `VideoService` Methods
 
 ```ts
 class VideoService {
-  // Import a local video file + transcript
+  registerPostImportTask(task: PostImportTask): this
+  async drainPostImportTasks(video: Video): Promise<void>
   async importLocalVideo(params: ImportLocalVideoParams): Promise<Video>
-
-  // Update tags and/or replace transcript
   async updateVideo(id: string, params: UpdateVideoServiceParams): Promise<Video | undefined>
-
-  // Delete video record, transcript file, video file, and thumbnail
   async deleteVideo(id: string): Promise<boolean>
 }
 ```
@@ -389,6 +401,22 @@ const refreshVideos = () => queryClient.invalidateQueries({ queryKey: ['videos']
 | Key | Data |
 |---|---|
 | `['videos']` | All videos (`Video[]`) |
+| `['vocabulary']` | `Map<string, VocabEntry>` |
+| `['videos', id]` | Single `Video` (via `queryKeys.video(id)`) |
+| `['transcript', id]` | `TranscriptCue[]` (via `queryKeys.transcript(id)`) |
+
+### `useQueries` (parallel fetch)
+
+```ts
+import { useQueries } from '@tanstack/react-query'
+
+const [videoResult, transcriptResult] = useQueries({
+  queries: [
+    { queryKey: queryKeys.video(id),      queryFn: () => apiClient.getVideo(id) },
+    { queryKey: queryKeys.transcript(id), queryFn: () => apiClient.getTranscript(id) },
+  ],
+})
+```
 
 ---
 
@@ -413,7 +441,7 @@ refreshVideos()                                    // manual cache invalidate
 
 ### `useImportVideoForm()` — `src/hooks/useImportVideoForm.ts`
 
-Form state manager for the import modal. Handles validation, file detection, and `POST /api/videos/import` submission.
+Form state manager for the import modal. Uses `useReducer` internally. Handles validation, file detection, and `POST /api/videos/import` submission.
 
 ```ts
 const {
@@ -429,6 +457,38 @@ const {
   handleSubmit,
   canSubmit,
 } = useImportVideoForm({ onSuccess, onClose })
+```
+
+The underlying reducer is exported for unit testing:
+```ts
+import { importFormReducer, initialImportFormState } from '@/hooks/useImportVideoForm'
+// Test the pure reducer directly without mounting a component
+const next = importFormReducer(initialImportFormState, { type: 'SET_TITLE', payload: 'Hello' })
+```
+
+### `usePlayerData()` — `src/hooks/usePlayerData.ts`
+
+```ts
+const { video, cues, isLoading, error } = usePlayerData(id)
+// Parallel-fetches video + transcript via useQueries
+// Returns: { video: Video | undefined, cues: TranscriptCue[] | undefined, isLoading, error }
+```
+
+### `useVocabulary()` — `src/hooks/useVocabulary.ts`
+
+```ts
+const { data: vocabMap = new Map() } = useVocabulary()
+// Returns UseQueryResult<Map<string, VocabEntry>, Error>
+// Fetches GET /api/vocabulary; keyed by word.toLowerCase()
+```
+
+### `useUpdateWordStatus()` — `src/hooks/useVocabulary.ts`
+
+```ts
+const mutation = useUpdateWordStatus()
+mutation.mutate({ word: 'resilient', status: 'mastered' })
+// PATCH /api/vocabulary/:word + invalidate ['vocabulary']
+// Returns UseMutationResult<VocabEntry, Error, { word, status }>
 ```
 
 ---
@@ -491,9 +551,95 @@ Default `jsdom` lacks global `Request`/`Response`.
 
 ```ts
 jest.mock('@/lib/server/composition', () => ({
-  videoStore: { list: jest.fn(), getById: jest.fn(), ... },
-  videoService: { importLocalVideo: jest.fn(), deleteVideo: jest.fn(), ... },
+  getContainer: jest.fn().mockReturnValue({
+    videoStore: { list: jest.fn(), getById: jest.fn(), insert: jest.fn(), update: jest.fn(), delete: jest.fn() },
+    videoService: { importLocalVideo: jest.fn(), updateVideo: jest.fn(), deleteVideo: jest.fn() },
+    vocabStore: { getAll: jest.fn(), getByWord: jest.fn(), upsert: jest.fn() },
+  }),
 }))
+```
+
+### In-memory Integration Tests
+
+```ts
+import { createContainer } from '@/lib/server/composition'
+import * as composition from '@/lib/server/composition'
+
+jest.spyOn(composition, 'getContainer').mockReturnValue(createContainer(':memory:'))
+// ':memory:' → no filesystem I/O; ThumbnailTask not registered
+```
+
+### Component Tests — React Testing Library
+
+Components are tested with `render` / `screen` / `fireEvent` / `waitFor` from `@testing-library/react`.
+
+```ts
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
+import MyComponent from '../MyComponent'
+
+// Render and query
+render(<MyComponent prop="value" />)
+screen.getByText('Expected text')          // throws if not found
+screen.queryByText('Optional')             // returns null if absent
+screen.getByTestId('some-id')
+screen.getByRole('button', { name: 'Play video' })
+
+// Events
+fireEvent.click(screen.getByTestId('play-button'))
+fireEvent.change(screen.getByRole('textbox'), { target: { value: 'new text' } })
+
+// Async — wait for state updates / effects
+await waitFor(() => expect(screen.getByText('Loaded')).toBeInTheDocument())
+await act(async () => { fireEvent.click(button) })
+
+// Assertions (jest-dom)
+expect(element).toBeInTheDocument()
+expect(element).toBeVisible()
+expect(element).toHaveAttribute('src', '/api/videos/x/thumbnail')
+expect(element).toHaveClass('rounded-full')
+expect(element.className).toMatch(/rounded-full/)
+expect(element).toHaveTextContent('Hello')
+```
+
+### Mocking React Hooks
+
+```ts
+jest.mock('@/hooks/useVocabulary', () => ({
+  useVocabulary: () => ({ data: new Map(), isLoading: false }),
+  useUpdateWordStatus: () => ({ mutate: jest.fn(), isPending: false }),
+}))
+```
+
+### Mocking Child Components
+
+```ts
+// Variable MUST start with "mock" to satisfy babel-jest hoisting rules
+let mockCapturedOnClose: (() => void) | undefined
+
+jest.mock('@/components/LocalVideoPlayer', () => ({
+  __esModule: true,
+  default: ({ onClose }: { onClose: () => void }) => {
+    mockCapturedOnClose = onClose
+    return <div data-testid="mini-player"><button onClick={onClose}>Close</button></div>
+  },
+}))
+```
+
+### Mocking `fetch`
+
+```ts
+beforeEach(() => {
+  global.fetch = jest.fn()
+})
+afterEach(() => {
+  jest.resetAllMocks()
+})
+
+// Mock a successful response
+;(global.fetch as jest.Mock).mockResolvedValueOnce({
+  json: async () => ({ cues: [] }),
+  ok: true,
+} as Response)
 ```
 
 ### Allowed Transcript Formats
@@ -509,6 +655,283 @@ import { ALLOWED_TRANSCRIPT_FORMATS } from '@/lib/api-schemas'
 import { ALLOWED_VIDEO_MIME_TYPES, MAX_VIDEO_SIZE_BYTES } from '@/lib/api-schemas'
 // ['video/mp4', 'video/webm', 'video/quicktime']
 // 524_288_000 (500 MB)
+```
+
+---
+
+## React 19 Component Patterns
+
+### Server vs Client Components
+
+```ts
+// Server component (default in App Router) — no directive needed
+export default async function PlayerPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
+  return <PlayerLoader id={id} />
+}
+
+// Client component — must opt in with directive at top of file
+'use client'
+import { useState } from 'react'
+
+export default function DashboardPage() {
+  const [open, setOpen] = useState(false)
+  // ...
+}
+```
+
+### Rules for Client Components
+
+- Must have `'use client'` as the **first line** (before any imports)
+- Can use hooks (`useState`, `useEffect`, `useReducer`, `useRef`, etc.)
+- Can handle browser events
+- Can import other client components freely
+- Can import server-side utilities only if they don't use Node.js-only APIs
+
+### Rules for Server Components
+
+- Default in App Router (no directive needed)
+- Cannot use React hooks
+- Cannot handle browser events
+- Can `async/await` directly (e.g., `await params`, DB calls via service layer)
+- Pass data down to client components as props
+
+### `useEffect` for Data Fetching (client-local state)
+
+When data is component-local and not in React Query cache, use raw `fetch` + `useEffect`:
+
+```ts
+'use client'
+import { useEffect, useState } from 'react'
+
+function PlayerClient({ videoId }: { videoId: string }) {
+  const [cues, setCues] = useState<TranscriptCue[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    fetch(`/api/videos/${videoId}/transcript`)
+      .then((r) => r.json())
+      .then((data) => setCues(data.cues ?? []))
+      .catch(() => setCues([]))
+      .finally(() => setLoading(false))
+  }, [videoId])
+  // ...
+}
+```
+
+### `useRef` for Imperative DOM / Media APIs
+
+```ts
+const videoRef = useRef<HTMLVideoElement>(null)
+
+// In event handler or effect:
+videoRef.current?.play()
+videoRef.current?.pause()
+if (videoRef.current) {
+  videoRef.current.currentTime = seekTime
+  videoRef.current.playbackRate = 1.5
+}
+
+// In JSX:
+<video ref={videoRef} src={`/api/videos/${id}/stream`} autoPlay />
+```
+
+### `useReducer` Form State Pattern
+
+Used by `useImportVideoForm` for complex form state with multiple fields:
+
+```ts
+type Action =
+  | { type: 'SET_TITLE'; payload: string }
+  | { type: 'SUBMIT_START' }
+  | { type: 'SUBMIT_SUCCESS' }
+  | { type: 'SUBMIT_ERROR'; payload: string }
+  | { type: 'RESET' }
+
+function reducer(state: State, action: Action): State {
+  switch (action.type) {
+    case 'SET_TITLE': return { ...state, title: action.payload }
+    case 'SUBMIT_START': return { ...state, isSubmitting: true, submitError: null }
+    case 'SUBMIT_SUCCESS': return { ...initialState }
+    case 'SUBMIT_ERROR': return { ...state, isSubmitting: false, submitError: action.payload }
+    default: return state
+  }
+}
+
+function useMyForm() {
+  const [state, dispatch] = useReducer(reducer, initialState)
+  const setTitle = useCallback((t: string) => dispatch({ type: 'SET_TITLE', payload: t }), [])
+  // ...
+}
+```
+
+---
+
+## Tailwind CSS Design System
+
+LingoFlow uses a **Material Design 3-inspired color system** with custom Tailwind tokens. All colors are defined in `tailwind.config.ts`.
+
+### Primary Palette
+
+| Token | Hex | Usage |
+|---|---|---|
+| `primary` | `#006071` | Buttons, links, active states, tag text |
+| `on-primary` | `#ffffff` | Text/icons on primary background |
+| `primary-container` | `#007b8f` | Elevated primary surface |
+| `on-primary-container` | `#e3f9ff` | Text on primary container |
+| `inverse-primary` | `#7ad3e9` | Dark mode primary |
+
+### Surface Palette
+
+| Token | Usage |
+|---|---|
+| `surface` | Page background (`#f7f9fb`) |
+| `surface-container-low` | Slightly elevated panels |
+| `surface-container` | Cards, modals |
+| `surface-container-high` | Thumbnails, input backgrounds |
+| `surface-variant` | Borders, dividers |
+
+### Content / Text Tokens
+
+| Token | Usage |
+|---|---|
+| `on-surface` | Primary text on surface (`#191c1e`) |
+| `on-surface-variant` | Secondary / muted text (`#3e484b`) |
+| `outline` | Default borders (`#6e797c`) |
+| `outline-variant` | Subtle borders (`#bec8cc`) |
+| `error` | Error states (`#ba1a1a`) |
+| `on-error-container` | Error text (`#93000a`) |
+
+### Dark Mode
+
+Dark mode uses `class` strategy. Apply dark variants with `dark:` prefix:
+
+```tsx
+<div className="bg-surface dark:bg-slate-900 text-on-surface dark:text-slate-100">
+  <p className="text-on-surface-variant dark:text-slate-400">Muted text</p>
+</div>
+```
+
+### Typography Tokens
+
+| Token | Font | Usage |
+|---|---|---|
+| `font-headline` | Manrope | Headings, hero text |
+| `font-body` | Inter | Body copy |
+| `font-label` | Inter | Labels, captions |
+
+### Common Layout Patterns
+
+```tsx
+// Card / panel
+<div className="rounded-2xl bg-surface-container-low border border-outline-variant/30 overflow-hidden">
+
+// Section max-width
+<section className="mx-auto w-full max-w-3xl px-4 py-8 md:px-8">
+
+// Tag chip
+<span className="text-[10px] font-bold uppercase tracking-wider text-primary">
+  {tag}
+</span>
+
+// Empty state
+<div className="flex flex-col items-center justify-center py-12 text-center gap-3">
+  <span className="text-3xl">📄</span>
+  <p className="text-on-surface font-semibold">No items</p>
+  <p className="text-sm text-on-surface-variant">Descriptive hint</p>
+</div>
+```
+
+### Media Control Button Patterns
+
+Inline SVG icons inside circular buttons — used by `LocalVideoPlayer`:
+
+```tsx
+{/* Icon control button — standard size */}
+<button
+  onClick={handleAction}
+  aria-label="Descriptive label"
+  data-testid="my-button"
+  className="flex items-center justify-center w-8 h-8 rounded-full hover:bg-white/10 text-white transition"
+>
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" className="w-5 h-5">
+    {/* SVG path */}
+  </svg>
+</button>
+
+{/* Play/pause button — larger primary control */}
+<button
+  onClick={handlePlayPause}
+  aria-label={isPlaying ? 'Pause' : 'Play'}
+  data-testid="mini-player-play-pause"
+  className="flex items-center justify-center w-10 h-10 rounded-full bg-white/10 hover:bg-white/20 text-white transition"
+>
+  {isPlaying ? (
+    <svg viewBox="0 0 24 24" fill="currentColor" className="w-5 h-5">
+      <path d="M6 19h4V5H6v14zm8-14v14h4V5h-4z"/> {/* Pause */}
+    </svg>
+  ) : (
+    <svg viewBox="0 0 24 24" fill="currentColor" className="w-5 h-5">
+      <path d="M8 5v14l11-7z"/> {/* Play */}
+    </svg>
+  )}
+</button>
+
+{/* Close button — floating overlay */}
+<button
+  onClick={handleClose}
+  aria-label="Close"
+  className="absolute top-2 right-2 flex items-center justify-center w-7 h-7 rounded-full bg-black/60 hover:bg-black/80 text-white text-sm transition"
+>
+  ✕
+</button>
+
+{/* Compact play button — white circle on dark thumbnail */}
+<div className="w-12 h-12 bg-white/90 rounded-full flex items-center justify-center text-primary shadow-xl">▶</div>
+
+{/* Speed selector */}
+<select
+  aria-label="Playback speed"
+  className="text-white bg-gray-800 border border-gray-600 rounded px-1 py-0.5 text-xs focus:outline-none focus:ring-1 focus:ring-white/30"
+>
+  {[0.5, 0.75, 1, 1.25, 1.5, 2].map((s) => (
+    <option key={s} value={s}>{s}×</option>
+  ))}
+</select>
+```
+
+### Hover / Group Patterns
+
+```tsx
+{/* group-hover shows overlay + action buttons on card */}
+<div className="group cursor-pointer">
+  <div className="relative rounded-xl overflow-hidden transition-all group-hover:-translate-y-1">
+    {/* hover overlay */}
+    <div className="absolute inset-0 bg-primary/20 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center">
+      ...
+    </div>
+    {/* action buttons only visible on hover */}
+    <div className="absolute top-2 right-2 flex gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+      ...
+    </div>
+  </div>
+</div>
+```
+
+### Mini-Player Layout
+
+The mini-player floats bottom-right on mobile, top-right on desktop:
+
+```tsx
+<div className="fixed bottom-4 right-4 z-50 w-80 shadow-2xl rounded-xl overflow-hidden bg-black md:bottom-auto md:top-20">
+  <div className="relative aspect-video">
+    <video ... />
+  </div>
+  {/* Transport controls bar */}
+  <div className="flex items-center justify-between gap-1 px-3 py-2 bg-gray-900">
+    {/* rewind / play-pause / fast-forward / speed */}
+  </div>
+</div>
 ```
 
 ---
@@ -539,6 +962,20 @@ type UpdateVideoParams = { tags?: string[]; transcript_path?: string; transcript
 // src/lib/parse-transcript.ts
 interface TranscriptCue { index: number; startTime: string; endTime: string; text: string }
 
-// src/lib/vocabulary.ts
+// src/lib/tokenize-transcript.ts
+interface WordToken  { type: 'word';  value: string }
+interface PunctToken { type: 'punct'; value: string }
+type TranscriptToken = WordToken | PunctToken
+// tokenizeCueText(text: string): TranscriptToken[]
+
+// src/lib/vocab-store.ts
+interface VocabEntry {
+  word: string
+  status: 'new' | 'learning' | 'mastered'
+  level?: string      // CEFR e.g. 'B2'
+  definition?: string
+}
+
+// src/lib/vocabulary.ts (mock data type)
 type VocabWord = { id: string; word: string; level: 'A1'|'A2'|'B1'|'B2'|'C1'|'C2'; definition: string; contextQuote: string; source: string; status: 'new'|'learning'|'mastered' }
 ```

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,721 @@
+# LingoFlow — API Documentation
+
+> Canonical API reference generated from source. Covers all REST endpoints, TypeScript types, service interfaces, and key library patterns.
+>
+> Last updated: 2026-07 — Next.js 16.2.3, React 19, better-sqlite3 12, Zod 4.
+
+---
+
+## Detected Stack
+
+| Layer | Library | Version |
+|---|---|---|
+| Framework | Next.js (App Router) | 16.2.3 |
+| UI | React | 19.2.4 |
+| Language | TypeScript | ^5 (`strict: true`) |
+| Styling | Tailwind CSS | ^3.4.19 |
+| Data fetching | TanStack React Query | ^5.96.2 |
+| Database | better-sqlite3 | ^12.8.0 |
+| Validation | Zod | ^4.3.6 |
+| Video processing | fluent-ffmpeg | ^2.1.3 |
+| Unit tests | Jest + Testing Library | ^30.3.0 |
+| E2E tests | Playwright | ^1.59.1 |
+| Package manager | pnpm | — |
+| Node runtime | Node | 24 |
+
+---
+
+## REST API Endpoints
+
+> All routes export `export const runtime = 'nodejs'` — `better-sqlite3` is a native addon incompatible with the Edge runtime.
+
+### `GET /api/videos`
+
+List all videos ordered by `created_at DESC`.
+
+**Response** `200 Video[]`
+
+```json
+[{
+  "id": "uuid",
+  "title": "string",
+  "author_name": "string",
+  "thumbnail_url": "string",
+  "transcript_path": "string",
+  "transcript_format": "srt|vtt|txt",
+  "tags": ["string"],
+  "created_at": "ISO8601",
+  "updated_at": "ISO8601",
+  "source_type": "local",
+  "local_video_path": "string|null",
+  "local_video_filename": "string|null",
+  "thumbnail_path": "string|null"
+}]
+```
+
+**Error** `500 { "error": "Internal server error" }`
+
+---
+
+### `POST /api/videos/import`
+
+Import a local video file. Body is `multipart/form-data`.
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `video` | `File` | ✅ | MP4/WebM/MOV; max 500 MB |
+| `title` | `string` | ✅ | Min length 1 (trimmed) |
+| `author` | `string` | ❌ | Optional author name |
+| `transcript` | `File` | ✅ | `.srt`, `.vtt`, or `.txt` |
+| `tags` | `string` | ❌ | **Comma-separated**: `"french,beginner"` |
+
+**Response** `201 Video` on success
+
+**Errors**
+- `400 { "error": "Only local video upload is supported" }` — no video file
+- `400 { "error": "<zod message>" }` — validation failure
+- `500 { "error": "Internal server error" }`
+
+**Constants** (`src/lib/api-schemas.ts`)
+```ts
+ALLOWED_VIDEO_MIME_TYPES   = ['video/mp4', 'video/webm', 'video/quicktime']
+ALLOWED_TRANSCRIPT_FORMATS = ['srt', 'vtt', 'txt']
+MAX_VIDEO_SIZE_BYTES        = 524_288_000  // 500 MB
+```
+
+---
+
+### `GET /api/videos/[id]`
+
+Get a single video by ID.
+
+**Response**
+- `200 Video`
+- `404` plain text `"Not Found"`
+- `500 { "error": "Internal server error" }`
+
+---
+
+### `PATCH /api/videos/[id]`
+
+Update video metadata. Body is `multipart/form-data`.
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `tags` | `string` | ✅ | **JSON array string**: `'["french","beginner"]'` |
+| `transcript` | `File` | ❌ | Replacement transcript |
+
+**Response**
+- `200 Video`
+- `400 { "error": "<zod message>" }` — validation failure
+- `404 { "error": "Video not found" }`
+- `500 { "error": "Internal server error" }`
+
+> ⚠️ **Tags format differs between routes:**
+> - `POST /api/videos/import` → comma-separated: `"french,beginner"`
+> - `PATCH /api/videos/[id]` → JSON array string: `'["french","beginner"]'`
+
+---
+
+### `DELETE /api/videos/[id]`
+
+Deletes the video record plus all associated files (transcript, video, thumbnail).
+
+**Response**
+- `204` (no body)
+- `404` plain text `"Not Found"`
+- `500` plain text `"Internal Server Error"`
+
+---
+
+### `GET /api/videos/[id]/transcript`
+
+Return parsed transcript cues.
+
+**Response** `200`
+```json
+{ "cues": [{ "index": 1, "startTime": "00:00:01,000", "endTime": "00:00:03,500", "text": "Hello" }] }
+```
+Returns `{ "cues": [] }` if video has no transcript.
+`404` plain text if video does not exist.
+
+---
+
+### `GET /api/videos/[id]/stream`
+
+Stream the local video file. Supports HTTP range requests.
+
+| Header | Example | Notes |
+|---|---|---|
+| `Range` | `bytes=0-1048575` | Optional; triggers 206 |
+
+**Response**
+- `200` full file — `Content-Type`, `Content-Length`, `Accept-Ranges: bytes`
+- `206` partial — `Content-Range: bytes start-end/total`
+- `404` plain text — file missing
+- `500` plain text
+
+---
+
+### `GET /api/videos/[id]/thumbnail`
+
+Return JPEG thumbnail.
+
+**Response**
+- `200 image/jpeg` with `Cache-Control: public, max-age=31536000, immutable`
+- `404` (no body)
+
+---
+
+### `GET /api/vocabulary`
+
+List all vocabulary entries ordered by `word ASC`.
+
+**Response** `200 VocabEntry[]`
+```json
+[{ "word": "string", "status": "new|learning|mastered", "level": "B2", "definition": "string" }]
+```
+
+**Error** `500 { "error": "Internal server error" }`
+
+---
+
+### `PATCH /api/vocabulary/[word]`
+
+Upsert a vocabulary word's status. `word` is URL-decoded and lowercased server-side.
+
+**Request** `Content-Type: application/json`
+```json
+{ "status": "new|learning|mastered" }
+```
+
+**Response**
+- `200 VocabEntry`
+- `400 { "error": "<zod message>" }` — invalid status value
+- `500 { "error": "Internal server error" }`
+
+---
+
+## TypeScript Types
+
+### `Video` — `src/lib/videos.ts`
+
+```ts
+type Video = {
+  id: string
+  title: string
+  author_name: string
+  thumbnail_url: string          // empty string for local-only videos
+  transcript_path: string
+  transcript_format: string      // 'srt' | 'vtt' | 'txt'
+  tags: string[]
+  created_at: string             // ISO 8601
+  updated_at: string             // ISO 8601
+  source_type: 'local'
+  local_video_path: string | null
+  local_video_filename: string | null
+  thumbnail_path: string | null
+}
+
+type InsertVideoParams = Omit<Video, 'created_at' | 'updated_at'>
+type UpdateVideoParams = {
+  tags?: string[]
+  transcript_path?: string
+  transcript_format?: string
+  thumbnail_path?: string | null
+}
+```
+
+### `TranscriptCue` — `src/lib/parse-transcript.ts`
+
+```ts
+interface TranscriptCue {
+  index: number
+  startTime: string   // e.g. "00:00:01,000"
+  endTime: string
+  text: string
+}
+```
+
+### `TranscriptToken` — `src/lib/tokenize-transcript.ts`
+
+```ts
+interface WordToken  { type: 'word';  value: string }
+interface PunctToken { type: 'punct'; value: string }
+type TranscriptToken = WordToken | PunctToken
+
+tokenizeCueText(text: string): TranscriptToken[]
+```
+
+### `VocabEntry` — `src/lib/vocab-store.ts`
+
+```ts
+interface VocabEntry {
+  word: string
+  status: 'new' | 'learning' | 'mastered'
+  level?: string      // CEFR e.g. 'B2'
+  definition?: string
+}
+```
+
+### `VocabWord` — `src/lib/vocabulary.ts` (mock data)
+
+```ts
+type VocabWord = {
+  id: string
+  word: string
+  level: 'A1' | 'A2' | 'B1' | 'B2' | 'C1' | 'C2'
+  definition: string
+  contextQuote: string
+  source: string
+  status: 'new' | 'learning' | 'mastered'
+}
+```
+
+---
+
+## Database Schema
+
+Managed by `initializeSchema(db)` in `src/lib/db.ts`. New columns added via `addColumnIfMissing`.
+
+### `videos` table
+
+```sql
+CREATE TABLE IF NOT EXISTS videos (
+  id                   TEXT PRIMARY KEY,
+  title                TEXT NOT NULL,
+  author_name          TEXT NOT NULL,
+  thumbnail_url        TEXT NOT NULL,
+  transcript_path      TEXT NOT NULL,
+  transcript_format    TEXT NOT NULL,
+  tags                 TEXT NOT NULL DEFAULT '[]',   -- JSON array string
+  created_at           TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at           TEXT NOT NULL DEFAULT (datetime('now')),
+  source_type          TEXT,
+  local_video_path     TEXT,
+  local_video_filename TEXT,
+  thumbnail_path       TEXT
+)
+```
+
+### `vocabulary` table
+
+```sql
+CREATE TABLE IF NOT EXISTS vocabulary (
+  word       TEXT PRIMARY KEY,
+  status     TEXT NOT NULL CHECK(status IN ('new','learning','mastered')),
+  level      TEXT,
+  definition TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+)
+```
+
+**Tags serialization:** `tags` stores `JSON.stringify(string[])`. `rowToVideo()` deserializes on read. Never serialize manually in callers.
+
+---
+
+## Service & Store Interfaces
+
+### `VideoStore` — `src/lib/video-store.ts`
+
+```ts
+interface VideoStore {
+  list(): Video[]
+  getById(id: string): Video | undefined
+  insert(params: InsertVideoParams): Video
+  update(id: string, params: UpdateVideoParams): Video | undefined
+  delete(id: string): boolean
+}
+```
+
+Implementation: `SqliteVideoStore`. All calls are synchronous.
+
+### `VideoService` — `src/lib/video-service.ts`
+
+```ts
+class VideoService {
+  registerPostImportTask(task: PostImportTask): this
+  async drainPostImportTasks(video: Video): Promise<void>
+  async importLocalVideo(params: ImportLocalVideoParams): Promise<Video>
+  async updateVideo(id: string, params: UpdateVideoServiceParams): Promise<Video | undefined>
+  async deleteVideo(id: string): Promise<boolean>
+}
+
+interface PostImportTask {
+  run(video: Video): Promise<Partial<UpdateVideoParams>>
+}
+```
+
+`ThumbnailTask` (registered in production) extracts JPEG via ffmpeg.
+
+### `ImportLocalVideoParams`
+
+```ts
+interface ImportLocalVideoParams {
+  id: string
+  title: string
+  author_name: string
+  video_buffer: Buffer
+  video_ext: string       // 'mp4' | 'webm' | 'mov'
+  video_filename: string
+  transcript_buffer: Buffer
+  transcript_ext: string  // 'srt' | 'vtt' | 'txt'
+  tags: string[]
+  source_type: 'local'
+}
+```
+
+### `VocabStore` — `src/lib/vocab-store.ts`
+
+```ts
+interface VocabStore {
+  getAll(): VocabEntry[]
+  getByWord(word: string): VocabEntry | null
+  upsert(word: string, status: VocabEntry['status'], level?: string, definition?: string): VocabEntry
+}
+```
+
+Implementation: `SqliteVocabStore`. All calls synchronous.
+
+---
+
+## Dependency Injection — Composition Root
+
+`src/lib/server/composition.ts` is the DI root. **Never** instantiate services directly in route handlers.
+
+```ts
+import { getContainer } from '@/lib/server/composition'
+
+// Inside a route handler (not at module scope):
+const { videoStore, videoService, vocabStore } = getContainer()
+```
+
+### `Container` interface
+
+```ts
+interface Container {
+  videoStore: SqliteVideoStore
+  videoService: VideoService
+  vocabStore: SqliteVocabStore
+}
+```
+
+### `createContainer(dataDir)` — for tests
+
+```ts
+import { createContainer } from '@/lib/server/composition'
+
+// In tests — uses in-memory SQLite:
+jest.spyOn(composition, 'getContainer').mockReturnValue(createContainer(':memory:'))
+```
+
+When `dataDir === ':memory:'`:
+- Uses `new Database(':memory:')` (no filesystem I/O)
+- Transcript/video writes return virtual paths (`:memory:/transcripts/<id>.<ext>`)
+- `ThumbnailTask` is **not** registered (avoids loading ffmpeg)
+
+### `getContainer()` — production singleton
+
+Lazily initialised on first call. Uses `LINGOFLOW_DATA_DIR` env var or `.lingoflow-data/`.
+
+---
+
+## ApiClient — `src/lib/api-client.ts`
+
+```ts
+interface ApiClient {
+  listVideos(): Promise<Video[]>
+  getVideo(id: string): Promise<Video>
+  getTranscript(id: string): Promise<TranscriptCue[]>
+  importVideo(form: FormData): Promise<Video>
+  updateVideo(id: string, form: FormData): Promise<Video>
+  deleteVideo(id: string): Promise<void>
+}
+
+// React context provider
+<ApiClientProvider client={new FetchApiClient()}>...</ApiClientProvider>
+
+// Hook to consume it
+const apiClient = useApiClient()
+```
+
+### Query keys
+
+```ts
+import { queryKeys } from '@/lib/api-client'
+
+queryKeys.videos()         // ['videos']
+queryKeys.video(id)        // ['videos', id]
+queryKeys.transcript(id)   // ['transcript', id]
+```
+
+---
+
+## Custom Hooks
+
+### `useVideos()` — `src/hooks/useVideos.ts`
+
+```ts
+const { data: videos = [], isLoading, error } = useVideos()
+// UseQueryResult<Video[], Error> — fetches GET /api/videos
+```
+
+### `useVideoMutations()` — `src/hooks/useVideoMutations.ts`
+
+```ts
+const { deleteVideo, refreshVideos } = useVideoMutations()
+
+deleteVideo.mutate(id)
+deleteVideo.mutate(id, { onSuccess: () => ... })
+refreshVideos()  // invalidateQueries({ queryKey: ['videos'] })
+```
+
+### `useImportVideoForm()` — `src/hooks/useImportVideoForm.ts`
+
+```ts
+const {
+  videoFile, setVideoFile,
+  title, setTitle,
+  author, setAuthor,
+  transcriptFile, setTranscriptFile,
+  transcriptMode, setTranscriptMode,   // 'upload' | 'paste'
+  pastedTranscript, setPastedTranscript,
+  tags, setTags,
+  isSubmitting,
+  submitError,
+  handleSubmit,
+  canSubmit,
+} = useImportVideoForm({ onSuccess, onClose })
+```
+
+### `usePlayerData()` — `src/hooks/usePlayerData.ts`
+
+```ts
+const { video, transcript, isLoading, error } = usePlayerData(id)
+// Parallel-fetches video + transcript via useQueries
+```
+
+### `useVocabulary()` — `src/hooks/useVocabulary.ts`
+
+```ts
+const { data: vocabMap } = useVocabulary()
+// UseQueryResult<Map<string, VocabEntry>, Error>
+// Fetches GET /api/vocabulary; keyed by word.toLowerCase()
+
+const mutation = useUpdateWordStatus()
+mutation.mutate({ word: 'resilient', status: 'mastered' })
+// PATCH /api/vocabulary/:word + invalidate ['vocabulary']
+```
+
+---
+
+## Zod v4 Patterns
+
+> ⚠️ **Breaking change from v3:** `.error.errors` renamed to `.error.issues`.
+
+```ts
+import { z } from 'zod'
+
+const result = schema.safeParse(input)
+if (!result.success) {
+  return NextResponse.json({ error: result.error.issues[0].message }, { status: 400 })
+}
+const data = result.data
+```
+
+### Schemas in codebase
+
+| Schema | File | Used by |
+|---|---|---|
+| `ImportLocalVideoRequestSchema` | `src/lib/api-schemas.ts` | `POST /api/videos/import` |
+| `UpdateVideoRequestSchema` | `src/lib/api-schemas.ts` | `PATCH /api/videos/[id]` |
+| `UpdateVocabRequestSchema` | `src/lib/api-schemas.ts` | `PATCH /api/vocabulary/[word]` |
+| `VideoSchema` | `src/lib/videos.ts` | DB row → `Video` |
+| `InsertVideoParamsSchema` | `src/lib/videos.ts` | Store insert |
+| `UpdateVideoParamsSchema` | `src/lib/videos.ts` | Store update |
+
+---
+
+## better-sqlite3 Patterns
+
+All calls are **synchronous** (no `await`):
+
+```ts
+import Database from 'better-sqlite3'
+
+const db = new Database(dbPath)
+db.pragma('journal_mode = WAL')  // always set WAL mode
+
+const rows = db.prepare('SELECT * FROM videos ORDER BY created_at DESC').all()
+const row  = db.prepare('SELECT * FROM videos WHERE id = ?').get(id)
+db.prepare('INSERT INTO videos (...) VALUES (...)').run(...values)
+db.prepare('UPDATE videos SET tags = ? WHERE id = ?').run(JSON.stringify(tags), id)
+db.prepare('DELETE FROM videos WHERE id = ?').run(id)
+```
+
+### Additive migration
+
+```ts
+const addColumnIfMissing = (column: string, definition: string) => {
+  try {
+    db.exec(`ALTER TABLE videos ADD COLUMN ${column} ${definition}`)
+  } catch { /* already exists — ignore */ }
+}
+```
+
+---
+
+## TanStack React Query v5
+
+### Provider
+
+```tsx
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { useState } from 'react'
+
+export default function Providers({ children }: { children: React.ReactNode }) {
+  const [queryClient] = useState(() => new QueryClient())
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+}
+```
+
+Wrapped in `src/app/layout.tsx`.
+
+### `useMutation` + cache invalidation
+
+```ts
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+const queryClient = useQueryClient()
+
+const deleteVideo = useMutation<void, Error, string>({
+  mutationFn: async (id) => {
+    const res = await fetch(`/api/videos/${id}`, { method: 'DELETE' })
+    if (!res.ok) throw new Error('Failed to delete video')
+  },
+  onSuccess: () => queryClient.invalidateQueries({ queryKey: ['videos'] }),
+})
+```
+
+### `useQueries` (parallel fetch)
+
+```ts
+import { useQueries } from '@tanstack/react-query'
+
+const [videoResult, transcriptResult] = useQueries({
+  queries: [
+    { queryKey: queryKeys.video(id),       queryFn: () => apiClient.getVideo(id) },
+    { queryKey: queryKeys.transcript(id),  queryFn: () => apiClient.getTranscript(id) },
+  ]
+})
+```
+
+---
+
+## Next.js App Router Patterns
+
+### Dynamic route params must be awaited
+
+```ts
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params
+  // ...
+}
+```
+
+### Response patterns
+
+```ts
+import { NextResponse } from 'next/server'
+
+NextResponse.json(data)                              // 200
+NextResponse.json(data, { status: 201 })             // 201
+NextResponse.json({ error: 'msg' }, { status: 400 }) // 400
+new NextResponse(null, { status: 204 })              // 204 No Content
+new NextResponse('Not Found', { status: 404 })       // 404 plain text
+new Response(buffer, { headers: { 'Content-Type': 'image/jpeg' } }) // binary
+```
+
+---
+
+## Transcript Utilities
+
+### `parseTranscript` — `src/lib/parse-transcript.ts`
+
+```ts
+const cues: TranscriptCue[] = parseTranscript(fileContent, 'srt')
+// formats: 'srt' | 'vtt' | 'txt'
+```
+
+### `detectPastedTranscriptFormat` — `src/lib/detect-transcript-format.ts`
+
+```ts
+const ext = detectPastedTranscriptFormat(text)  // 'vtt' | 'srt' | 'txt'
+```
+
+### `tokenizeCueText` — `src/lib/tokenize-transcript.ts`
+
+```ts
+import { tokenizeCueText } from '@/lib/tokenize-transcript'
+
+const tokens: TranscriptToken[] = tokenizeCueText('Hello, world!')
+// [{ type: 'word', value: 'Hello' }, { type: 'punct', value: ',' }, ...]
+```
+
+### File I/O — `src/lib/transcripts.ts`
+
+```ts
+writeTranscript(videoId, ext, buffer): string   // writes to getTranscriptsDir(); returns path
+deleteTranscript(filePath): void                 // ENOENT silently ignored
+```
+
+---
+
+## Data Directory — `src/lib/data-dir.ts`
+
+```ts
+getDataDir(): string        // LINGOFLOW_DATA_DIR ?? cwd()/.lingoflow-data
+getTranscriptsDir(): string // <dataDir>/transcripts
+getVideosDir(): string      // <dataDir>/videos
+getThumbnailsDir(): string  // <dataDir>/thumbnails
+getDbPath(): string         // <dataDir>/lingoflow.db
+```
+
+Override root via `LINGOFLOW_DATA_DIR` env var.
+
+---
+
+## Testing Patterns
+
+### API route tests require node environment
+
+```ts
+// @jest-environment node
+```
+
+Default `jsdom` lacks `Request`/`Response` globals.
+
+### Mocking the composition root
+
+```ts
+jest.mock('@/lib/server/composition', () => ({
+  getContainer: jest.fn().mockReturnValue({
+    videoStore: { list: jest.fn(), getById: jest.fn(), insert: jest.fn(), update: jest.fn(), delete: jest.fn() },
+    videoService: { importLocalVideo: jest.fn(), updateVideo: jest.fn(), deleteVideo: jest.fn() },
+    vocabStore: { getAll: jest.fn(), getByWord: jest.fn(), upsert: jest.fn() },
+  }),
+}))
+```
+
+### In-memory container for integration tests
+
+```ts
+import { createContainer } from '@/lib/server/composition'
+import * as composition from '@/lib/server/composition'
+
+jest.spyOn(composition, 'getContainer').mockReturnValue(createContainer(':memory:'))
+```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -175,12 +175,11 @@ return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider
 
 **Query hooks** use `useQuery`; **mutation hooks** use `useMutation` + `queryClient.invalidateQueries`.
 
-### Raw `fetch` in `useEffect` — component-local state
+### Raw `fetch` in `useEffect` — component-local state (PlayerClient fallback only)
 
-`PlayerLoader` and `PlayerClient` fetch data via raw `fetch` inside `useEffect`. This data is not cached in React Query — it is component-local state only.
+`PlayerClient` contains a `useEffect` fallback that fetches `GET /api/videos/:id/transcript` **only** when the `cues` prop is `undefined`. In the normal render path `PlayerLoader` passes `cues` from `usePlayerData`, so the fetch is not triggered.
 
-- `PlayerLoader`: fetches `GET /api/videos/:id` on mount to resolve a `Video` object.
-- `PlayerClient`: fetches `GET /api/videos/:id/transcript` on mount to load `TranscriptCue[]`.
+`PlayerLoader` does **not** use raw `fetch`. It delegates entirely to `usePlayerData` (React Query via `useQueries`).
 
 ---
 
@@ -213,17 +212,32 @@ DashboardPage  [client component, 'use client']
 ### Player (`/player/[id]`)
 
 ```
-PlayerPage  [server component]           ← awaits params.id
-  └─ PlayerLoader  [client component]    ← fetches Video via raw fetch/useEffect
-       └─ PlayerClient  [client component]
-            ├─ useVocabulary()            ← React Query: GET /api/vocabulary
+PlayerPage  [server component]           ← awaits params.id; renders <PlayerLoader id={id} />
+  └─ PlayerLoader  [client component]    ← usePlayerData(id): parallel React Query fetch
+       │   usePlayerData → useQueries([video, transcript])
+       └─ PlayerClient  [client component]   receives video + cues props
+            ├─ useVocabulary()            ← React Query: GET /api/vocabulary → Map<string,VocabEntry>
             ├─ useUpdateWordStatus()      ← React Query mutation: PATCH /api/vocabulary/:word
-            ├─ LessonHero                 ← title, author, tags, Play button
-            ├─ PlaybackProgress           ← progress bar (shown only when mini-player open)
-            ├─ CueText[]                  ← tokenized transcript cues; word-click support
-            ├─ LocalVideoPlayer           ← floating <video> mini-player (conditional)
-            └─ WordSidebar                ← slide-over word detail panel (conditional)
+            ├─ LessonHero                 ← title, author, tags, Play button (data-testid="play-button")
+            ├─ PlaybackProgress           ← display-only progress bar (shown when mini-player is open)
+            ├─ CueText[]                  ← tokenized transcript cues; word-click → WordSidebar
+            ├─ LocalVideoPlayer           ← floating <video> mini-player (conditional on isMiniPlayerOpen)
+            └─ WordSidebar                ← slide-over word detail panel (conditional on selectedWord)
 ```
+
+**State in `PlayerClient`**:
+
+| State variable | Type | Purpose |
+|---|---|---|
+| `cues` | `TranscriptCue[]` | Transcript cues (from prop, or fetched as fallback) |
+| `loadingTranscript` | `boolean` | True while fallback fetch is pending |
+| `activeCueIndex` | `number` | Selected cue (manual click navigation) |
+| `isMiniPlayerOpen` | `boolean` | Controls visibility of `LocalVideoPlayer` |
+| `playbackTime` | `{ current: number, duration: number }` | Updated from `LocalVideoPlayer` polling |
+| `requestedSeekTime` | `number \| null` | One-shot seek request; cleared by `onSeekApplied` |
+| `selectedWord` | `{ word, contextSentence } \| null` | Controls visibility of `WordSidebar` |
+
+**Seek flow**: cue click → `setRequestedSeekTime(startTime)` → `seekToTime` prop on `LocalVideoPlayer` → `useEffect` sets `videoRef.current.currentTime` → `onSeekApplied()` clears `requestedSeekTime`.
 
 ### Vocabulary (`/vocabulary`)
 
@@ -241,6 +255,7 @@ VocabularyPage  [client component, 'use client']
 |---|---|---|---|
 | `useVideos` | `hooks/useVideos.ts` | `useQuery` | Fetches `Video[]` from `GET /api/videos`; query key `['videos']` |
 | `useVideoMutations` | `hooks/useVideoMutations.ts` | `useMutation` + `invalidateQueries` | `deleteVideo(id)` mutation; `refreshVideos()` cache invalidation |
+| `usePlayerData` | `hooks/usePlayerData.ts` | `useQueries` | Parallel-fetches `Video` + `TranscriptCue[]` for player; returns `{ video, cues, isLoading, error }` |
 | `useImportVideoForm` | `hooks/useImportVideoForm.ts` | `useReducer` + `useCallback` | Full import form state machine; submits to `POST /api/videos/import` |
 | `useVocabulary` | `hooks/useVocabulary.ts` | `useQuery` | Fetches `VocabEntry[]`; returns `Map<string, VocabEntry>`; query key `['vocabulary']` |
 | `useUpdateWordStatus` | `hooks/useVocabulary.ts` | `useMutation` + `invalidateQueries` | `PATCH /api/vocabulary/:word`; invalidates `['vocabulary']` on success |

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,8 +9,10 @@
 | File | Contents |
 |---|---|
 | [`architecture.md`](./architecture.md) | **Architecture reference** — App Router layout, DI/composition root, data flow, component hierarchy, hook inventory, testing conventions |
+| [`player-architecture.md`](./player-architecture.md) | **Player & mini-player reference** — component tree, seek flow, transport controls, `data-testid` map, test patterns |
 | [`api-reference.md`](./api-reference.md) | **Canonical API reference** — all REST endpoints, types, service interfaces, DB schema, library patterns |
-| [`api-docs.md`](./api-docs.md) | Extended API patterns, hooks, and issue-specific notes |
+| [`api.md`](./api.md) | Extended API reference — includes `ApiClient`, `usePlayerData`, `VocabStore`, vocabulary endpoints |
+| [`api-docs.md`](./api-docs.md) | Patterns for UI development — React 19, Tailwind design system, hooks, testing, media controls |
 | [`e2e-testing.md`](./e2e-testing.md) | Playwright config, Page Object Model, fixtures, `data-testid` reference |
 | [`project-docs.md`](./project-docs.md) | Architecture, directory layout, build/test commands, design decisions |
 
@@ -18,39 +20,23 @@
 
 ## api-docs.md — Sections
 
-| Section | Relevant Issue(s) |
+| Section | Notes |
 |---|---|
-| Tech Stack Summary | — |
-| Next.js App Router Patterns | all |
-| REST API Endpoints | all |
-| Tags API Contract | — |
-| Zod v4 Patterns | — |
-| better-sqlite3 / SQLite Patterns | #166 |
-| Dependency Injection / Composition Root | #166 |
-| TanStack React Query v5 Patterns | #167 |
-| Custom Hooks | #163, #167 |
-| Transcript Utilities | — |
-| File & Data Layout | #165 |
-| Testing Patterns | #163, #166 |
-| **Data Directory Module** | **#165** |
-| **React useReducer Pattern** | **#163** |
-| **PostImportTask Plugin System** | **#164** |
-| **DI Containers — createContainer / getContainer** | **#166** |
-| **React Query — useQueries (Parallel Fetching)** | **#167** |
-| **ApiClient Context Pattern** | **#167** |
-| TypeScript Types Quick Reference | — |
-
----
-
-## Open Issues Addressed
-
-| Issue | Title | Key API Patterns |
-|---|---|---|
-| #163 | Replace useState with useReducer in useImportVideoForm | `useReducer`, discriminated union actions, pure reducer testing |
-| #164 | PostImportTask plugin system on VideoService | `PostImportTask` interface, `registerPostImportTask`, `drainPostImportTasks` |
-| #165 | Extract getDataDir() to data-dir.ts | `getDataDir`, `getTranscriptsDir`, `getVideosDir`, `getThumbnailsDir`, `getDbPath` |
-| #166 | Export createContainer/getContainer for per-test DI | `createContainer`, `getContainer`, `Database(':memory:')`, `jest.spyOn` |
-| #167 | FetchApiClient + usePlayerData unified data-fetching | `useQueries`, `ApiClient` interface, `ApiClientProvider`, `usePlayerData` |
+| Tech Stack Summary | All versions |
+| Next.js App Router Patterns | params awaiting, response helpers |
+| REST API Endpoints | All routes |
+| Tags API Contract | ⚠️ format differs between import/update |
+| Zod v4 Patterns | `.issues` not `.errors` |
+| better-sqlite3 / SQLite Patterns | Sync calls, WAL, migration |
+| Dependency Injection / Composition Root | `getContainer()`, `createContainer(':memory:')` |
+| TanStack React Query v5 Patterns | `useQuery`, `useMutation`, `useQueries` |
+| Custom Hooks | `useVideos`, `useVideoMutations`, `useImportVideoForm`, `usePlayerData`, `useVocabulary`, `useUpdateWordStatus` |
+| Transcript Utilities | parse, detect, tokenize, file I/O |
+| File & Data Layout | `.lingoflow-data/` structure |
+| Testing Patterns | API routes, component tests, mocking, `fetch` |
+| React 19 Component Patterns | Server/client directive, hooks, `useRef`, `useReducer` |
+| Tailwind CSS Design System | Color tokens, typography, media controls, mini-player layout |
+| TypeScript Types Quick Reference | `Video`, `TranscriptCue`, `TranscriptToken`, `VocabEntry` |
 
 ---
 

--- a/docs/player-architecture.md
+++ b/docs/player-architecture.md
@@ -1,0 +1,311 @@
+# LingoFlow — Player & Mini-Player Architecture
+
+> **Purpose**: Detailed reference for the player page, mini-player (LocalVideoPlayer), transport controls, seek flow, and test patterns.
+> **Last updated**: 2026-07, HEAD: main.
+
+---
+
+## 1. Component Tree
+
+```
+PlayerPage  [server component]  src/app/(app)/player/[id]/page.tsx
+  └─ PlayerLoader  [client]     src/components/PlayerLoader.tsx
+       │   usePlayerData(id)  ← parallel React Query fetch (video + transcript)
+       └─ PlayerClient  [client]  src/components/PlayerClient.tsx
+            ├─ LessonHero           ← hero section: title, author, tags, Play button
+            ├─ PlaybackProgress     ← display-only progress bar (while mini-player open)
+            ├─ CueText[]            ← tokenised transcript lines; word-click → WordSidebar
+            ├─ LocalVideoPlayer     ← floating <video> mini-player (conditional)
+            └─ WordSidebar          ← slide-over word detail panel (conditional)
+```
+
+---
+
+## 2. Data-Fetching Strategy
+
+### PlayerLoader
+
+Uses `usePlayerData(id)` — a React Query `useQueries` hook — to **parallel-fetch** the video record and its transcript cues:
+
+```ts
+// src/hooks/usePlayerData.ts
+const [videoResult, transcriptResult] = useQueries({
+  queries: [
+    { queryKey: queryKeys.video(id),      queryFn: () => client.getVideo(id) },
+    { queryKey: queryKeys.transcript(id), queryFn: () => client.getTranscript(id) },
+  ],
+})
+```
+
+Returns `{ video, cues, isLoading, error }`.  
+Both results are cached by React Query under keys `['videos', id]` and `['transcript', id]`.
+
+### PlayerClient — transcript fallback
+
+`PlayerClient` accepts a `cues?: TranscriptCue[]` prop. When `cues` is `undefined` (not passed), it fires a **one-shot `useEffect` fetch** to `GET /api/videos/:id/transcript`. In the normal render path `PlayerLoader` supplies `cues`, so this fallback is not triggered.
+
+```ts
+useEffect(() => {
+  if (propCues !== undefined) return  // skip if cues provided
+  fetch(`/api/videos/${video.id}/transcript`)
+    .then(r => r.json())
+    .then(data => setCues(data.cues ?? []))
+    .catch(() => setCues([]))
+    .finally(() => setLoadingTranscript(false))
+}, [video.id])
+```
+
+---
+
+## 3. PlayerClient State
+
+| Variable | Type | Purpose |
+|---|---|---|
+| `cues` | `TranscriptCue[]` | Transcript cues (from prop or fallback fetch) |
+| `loadingTranscript` | `boolean` | True while fallback fetch in progress |
+| `activeCueIndex` | `number` | Manually-selected cue index (cue-click navigation) |
+| `isMiniPlayerOpen` | `boolean` | Whether `LocalVideoPlayer` is rendered |
+| `playbackTime` | `{ current: number, duration: number }` | Updated by mini-player polling at 250 ms |
+| `requestedSeekTime` | `number \| null` | One-shot seek target in seconds; `null` after applied |
+| `selectedWord` | `{ word: string, contextSentence: string } \| null` | Drives `WordSidebar` visibility |
+
+### Active-cue resolution
+
+```
+playbackCueIndex  = cues.findIndex(cue => now >= start && now < end)   // -1 when paused
+highlightedCueIndex = playbackCueIndex >= 0 ? playbackCueIndex : activeCueIndex
+```
+
+Auto-scroll runs on `highlightedCueIndex` change via `element.scrollIntoView({ block: 'center', behavior: 'smooth' })`.
+
+---
+
+## 4. Seek Flow
+
+```
+Cue div onClick
+  → setActiveCueIndex(i)
+  → setRequestedSeekTime(parseTimeToSeconds(cue.startTime))
+        ↓  prop: seekToTime
+LocalVideoPlayer useEffect [seekToTime]
+  → videoRef.current.currentTime = seekToTime
+  → onSeekApplied?.()           ← prop callback
+        ↓
+PlayerClient: setRequestedSeekTime(null)
+```
+
+`requestedSeekTime` is cleared immediately after the seek is applied, preventing the seek from re-applying on re-render.
+
+---
+
+## 5. LocalVideoPlayer (Mini-Player)
+
+**File**: `src/components/LocalVideoPlayer.tsx`  
+**Appearance**: fixed bottom-right (mobile), fixed top-right (desktop ≥ `md`):
+
+```
+fixed bottom-4 right-4 z-50 w-80 shadow-2xl rounded-xl overflow-hidden bg-black
+md:bottom-auto md:top-20
+```
+
+### Props
+
+```ts
+interface LocalVideoPlayerProps {
+  videoId: string               // used to build src="/api/videos/{videoId}/stream"
+  title: string
+  onClose: () => void           // called by close button; PlayerClient resets all state
+  onTimeUpdate?: (currentTime: number, duration: number) => void
+  seekToTime?: number | null    // triggers currentTime assignment on change
+  onSeekApplied?: () => void    // callback after seek applied
+}
+```
+
+### Internal state
+
+| Variable | Type | Initial | Purpose |
+|---|---|---|---|
+| `isPlaying` | `boolean` | `true` | Tracks play/pause; updated by video `play`/`pause`/`ended` events |
+| `speed` | `SpeedOption` | `1` | Current playback rate |
+
+`SpeedOption` = `0.5 | 0.75 | 1 | 1.25 | 1.5 | 2`
+
+### Time polling
+
+When playing, a `setInterval` at **250 ms** calls `onTimeUpdate(el.currentTime, el.duration)`. Polling starts on `onPlay` event, stops on `onPause` / `onEnded` / component unmount.
+
+```ts
+const pollIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
+
+function startPolling() {
+  if (pollIntervalRef.current) return
+  pollIntervalRef.current = setInterval(() => {
+    if (el && el.duration > 0) onTimeUpdate?.(el.currentTime, el.duration)
+  }, 250)
+}
+```
+
+---
+
+## 6. Transport Controls
+
+All controls live in the dark bar below the video (`bg-gray-900`):
+
+```
+[ Rewind 10s ] [ Play/Pause ] [ Fast-forward 10s ]    [ Speed ▾ ]
+```
+
+### Rewind (`mini-player-rewind`)
+
+```ts
+function handleRewind() {
+  el.currentTime = Math.max(0, el.currentTime - 10)
+}
+```
+
+Icon: circular-arrow SVG (counter-clockwise) with embedded `<text>10</text>` at `fontSize="6"`.
+
+### Play / Pause (`mini-player-play-pause`)
+
+```ts
+function handlePlayPause() {
+  el.paused ? el.play() : el.pause()
+}
+```
+
+`aria-label` toggles between `"Pause"` (when playing) and `"Play"` (when paused).
+
+Icons:
+- **Playing**: two-bar pause SVG — `<path d="M6 19h4V5H6v14zm8-14v14h4V5h-4z"/>`
+- **Paused**: triangle play SVG — `<path d="M8 5v14l11-7z"/>`
+
+### Fast-forward (`mini-player-fastforward`)
+
+```ts
+function handleFastForward() {
+  el.currentTime = Math.min(el.duration || 0, el.currentTime + 10)
+}
+```
+
+Icon: circular-arrow SVG (clockwise) with embedded `<text>10</text>` at `fontSize="6"`.
+
+### Speed selector (`mini-player-speed`)
+
+```tsx
+<select value={speed} onChange={handleSpeedChange}>
+  {[0.5, 0.75, 1, 1.25, 1.5, 2].map(s => <option value={s}>{s}×</option>)}
+</select>
+```
+
+On change: sets `speed` state and `videoRef.current.playbackRate`.
+
+### Close button (`mini-player-close`)
+
+Floating overlay (absolute top-right of the video area). Calls `videoRef.current.pause()` then `onClose()`.
+
+---
+
+## 7. PlaybackProgress
+
+**File**: `src/components/PlaybackProgress.tsx`  
+**Display only** — no click-to-seek. Receives `currentTime` and `duration` (seconds) as props from `PlayerClient`.
+
+```
+[ ████░░░░░░░░░░░░░░░ ]
+  1:30                5:00
+```
+
+| `data-testid` | Element |
+|---|---|
+| `playback-progress` | container |
+| `progress-bar-fill` | filled bar (`width: ${pct}%`) |
+| `current-time` | elapsed time label |
+| `duration` | total duration label |
+
+Time format: `M:SS` (no hours) — `formatTime(seconds)` → `${m}:${s.padStart(2,'0')}`.
+
+---
+
+## 8. Component `data-testid` Reference
+
+| Component | `data-testid` | Element |
+|---|---|---|
+| `PlayerClient` | `player-client` | root `<div>` |
+| `LessonHero` | `lesson-hero` | root `<div>` |
+| `LessonHero` | `play-button` | Play `<button>` |
+| `LocalVideoPlayer` | `mini-player` | root container |
+| `LocalVideoPlayer` | `local-video` | `<video>` element |
+| `LocalVideoPlayer` | `mini-player-close` | close overlay button |
+| `LocalVideoPlayer` | `mini-player-rewind` | Rewind 10s button |
+| `LocalVideoPlayer` | `mini-player-play-pause` | Play/Pause toggle button |
+| `LocalVideoPlayer` | `mini-player-fastforward` | Fast-forward 10s button |
+| `LocalVideoPlayer` | `mini-player-speed` | Speed `<select>` |
+| `PlaybackProgress` | `playback-progress` | container |
+| `PlaybackProgress` | `progress-bar-fill` | fill bar |
+| `PlaybackProgress` | `current-time` | elapsed time `<span>` |
+| `PlaybackProgress` | `duration` | total duration `<span>` |
+| `CueText` | `cue-{i}` | per-cue `<div>` (on parent in `PlayerClient`) |
+| `CueText` | `word-{normalized}` | per-word `<span>` |
+| `WordSidebar` | `word-sidebar` | panel `<div>` |
+| `WordSidebar` | `word-sidebar-close` | close button |
+| `WordSidebar` | `sidebar-word` | word display `<span>` |
+| `WordSidebar` | `sidebar-context` | context sentence `<p>` |
+| `WordSidebar` | `status-toggle` | mastered/unknown toggle button |
+
+---
+
+## 9. Test Patterns
+
+### LocalVideoPlayer
+
+File: `src/components/__tests__/LocalVideoPlayer.test.tsx`
+
+- **Environment**: `jsdom` (default — no `@jest-environment` override needed)
+- **Video mock**: `HTMLVideoElement.prototype.play` / `pause` overridden with `jest.fn()`; `currentTime` / `duration` set via `Object.defineProperty`
+- **Polling test**: `jest.useFakeTimers()` + `jest.advanceTimersByTime(300)` to assert `onTimeUpdate` called
+- **Seek test**: rerender with new `seekToTime` prop; assert `video.currentTime` set and `onSeekApplied` called
+
+```ts
+it('applies seekToTime when prop changes', () => {
+  const { rerender } = render(<LocalVideoPlayer {...defaultProps} seekToTime={null} />)
+  const onSeekApplied = jest.fn()
+  rerender(<LocalVideoPlayer {...defaultProps} seekToTime={30} onSeekApplied={onSeekApplied} />)
+  expect(video.currentTime).toBe(30)
+  expect(onSeekApplied).toHaveBeenCalledTimes(1)
+})
+```
+
+### PlayerClient
+
+File: `src/components/__tests__/PlayerClient.test.tsx`
+
+- **Hooks mocked**: `@/hooks/useVocabulary` — both `useVocabulary` and `useUpdateWordStatus`
+- **LocalVideoPlayer mocked**: exposes `onTimeUpdate` via module-level `let mockCapturedOnTimeUpdate`
+- **Variable naming rule**: mock-capture vars must start with `mock` (babel-jest hoisting)
+- **`act()`** required when calling captured callbacks that trigger state updates
+
+```ts
+let mockCapturedOnTimeUpdate: ((c: number, d: number) => void) | undefined
+
+jest.mock('@/components/LocalVideoPlayer', () => ({
+  __esModule: true,
+  default: ({ onClose, onTimeUpdate }: ...) => {
+    mockCapturedOnTimeUpdate = onTimeUpdate
+    return <div data-testid="mini-player"><button data-testid="mini-player-close" onClick={onClose}>Close</button></div>
+  },
+}))
+
+// Driving time update from test:
+act(() => { mockCapturedOnTimeUpdate?.(90, 300) })
+expect(screen.getByTestId('current-time')).toHaveTextContent('1:30')
+```
+
+### PlaybackProgress
+
+File: `src/components/__tests__/PlaybackProgress.test.tsx`
+
+Pure display component — tests verify rendered text and `style` on fill bar. No user interaction beyond confirming clicks do not change state.
+
+### MiniPlayer.test.tsx
+
+`src/components/__tests__/MiniPlayer.test.tsx` is a **placeholder** — the original YouTube-only `MiniPlayer` component was removed. The file contains a single no-op test to keep the test runner from erroring on an empty suite.

--- a/src/components/LocalVideoPlayer.tsx
+++ b/src/components/LocalVideoPlayer.tsx
@@ -129,12 +129,12 @@ export default function LocalVideoPlayer({
         <button
           onClick={handleRewind}
           aria-label="Rewind 10 seconds"
-          data-testid="mini-player-rewind"
+          data-testid="rewind-button"
           className="flex items-center justify-center w-8 h-8 rounded-full hover:bg-white/10 text-white transition"
         >
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" className="w-5 h-5">
-            <path d="M11.99 5V1l-5 5 5 5V7c3.31 0 6 2.69 6 6s-2.69 6-6 6-6-2.69-6-6h-2c0 4.42 3.58 8 8 8s8-3.58 8-8-3.58-8-8-8z"/>
-            <text x="12" y="14" textAnchor="middle" fontSize="6" fill="currentColor">10</text>
+          {/* Double left-chevron — clearly distinct from forward */}
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" className="w-5 h-5" aria-hidden="true">
+            <path d="M18 6l-6 6 6 6V6zM11 6l-6 6 6 6V6z"/>
           </svg>
         </button>
 
@@ -157,13 +157,13 @@ export default function LocalVideoPlayer({
 
         <button
           onClick={handleFastForward}
-          aria-label="Fast forward 10 seconds"
-          data-testid="mini-player-fastforward"
+          aria-label="Fast-forward 10 seconds"
+          data-testid="fastforward-button"
           className="flex items-center justify-center w-8 h-8 rounded-full hover:bg-white/10 text-white transition"
         >
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" className="w-5 h-5">
-            <path d="M12.01 5V1l5 5-5 5V7c-3.31 0-6 2.69-6 6s2.69 6 6 6 6-2.69 6-6h2c0 4.42-3.58 8-8 8s-8-3.58-8-8 3.58-8 8-8z"/>
-            <text x="12" y="14" textAnchor="middle" fontSize="6" fill="currentColor">10</text>
+          {/* Double right-chevron — clearly distinct from rewind */}
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" className="w-5 h-5" aria-hidden="true">
+            <path d="M6 18l6-6-6-6v12zM13 18l6-6-6-6v12z"/>
           </svg>
         </button>
 

--- a/src/components/__tests__/LocalVideoPlayer.test.tsx
+++ b/src/components/__tests__/LocalVideoPlayer.test.tsx
@@ -58,8 +58,8 @@ describe('LocalVideoPlayer', () => {
   it('renders play/pause, rewind, and fast-forward buttons', () => {
     render(<LocalVideoPlayer {...defaultProps} />)
     expect(screen.getByTestId('mini-player-play-pause')).toBeInTheDocument()
-    expect(screen.getByTestId('mini-player-rewind')).toBeInTheDocument()
-    expect(screen.getByTestId('mini-player-fastforward')).toBeInTheDocument()
+    expect(screen.getByTestId('rewind-button')).toBeInTheDocument()
+    expect(screen.getByTestId('fastforward-button')).toBeInTheDocument()
   })
 
   it('renders speed selector with all speed options', () => {
@@ -127,5 +127,94 @@ describe('LocalVideoPlayer', () => {
     expect(onTimeUpdate).toHaveBeenCalled()
 
     jest.useRealTimers()
+  })
+})
+
+describe('LocalVideoPlayer seek behavior', () => {
+  beforeEach(() => {
+    setupVideoMock()
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('rewind button seeks backward by 10 seconds', () => {
+    render(<LocalVideoPlayer {...defaultProps} />)
+    const video = screen.getByTestId('local-video') as HTMLVideoElement
+    Object.defineProperty(video, 'duration', { configurable: true, value: 120 })
+    video.currentTime = 30
+    fireEvent.click(screen.getByTestId('rewind-button'))
+    expect(video.currentTime).toBe(20)
+  })
+
+  it('rewind clamps to 0 when currentTime is less than seek interval', () => {
+    render(<LocalVideoPlayer {...defaultProps} />)
+    const video = screen.getByTestId('local-video') as HTMLVideoElement
+    Object.defineProperty(video, 'duration', { configurable: true, value: 120 })
+    video.currentTime = 5
+    fireEvent.click(screen.getByTestId('rewind-button'))
+    expect(video.currentTime).toBe(0)
+  })
+
+  it('fast-forward button seeks forward by 10 seconds', () => {
+    render(<LocalVideoPlayer {...defaultProps} />)
+    const video = screen.getByTestId('local-video') as HTMLVideoElement
+    Object.defineProperty(video, 'duration', { configurable: true, value: 120 })
+    video.currentTime = 30
+    fireEvent.click(screen.getByTestId('fastforward-button'))
+    expect(video.currentTime).toBe(40)
+  })
+
+  it('fast-forward clamps to duration when near end', () => {
+    render(<LocalVideoPlayer {...defaultProps} />)
+    const video = screen.getByTestId('local-video') as HTMLVideoElement
+    Object.defineProperty(video, 'duration', { configurable: true, value: 120 })
+    video.currentTime = 115
+    fireEvent.click(screen.getByTestId('fastforward-button'))
+    expect(video.currentTime).toBe(120)
+  })
+})
+
+describe('LocalVideoPlayer seek controls accessibility', () => {
+  beforeEach(() => {
+    setupVideoMock()
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('rewind button has accessible name "Rewind 10 seconds"', () => {
+    render(<LocalVideoPlayer {...defaultProps} />)
+    expect(screen.getByRole('button', { name: 'Rewind 10 seconds' })).toBeInTheDocument()
+  })
+
+  it('fast-forward button has accessible name "Fast-forward 10 seconds"', () => {
+    render(<LocalVideoPlayer {...defaultProps} />)
+    expect(screen.getByRole('button', { name: 'Fast-forward 10 seconds' })).toBeInTheDocument()
+  })
+
+  it('rewind and fast-forward buttons have different aria-labels', () => {
+    render(<LocalVideoPlayer {...defaultProps} />)
+    const rewind = screen.getByTestId('rewind-button')
+    const fastforward = screen.getByTestId('fastforward-button')
+    expect(rewind.getAttribute('aria-label')).not.toBe(fastforward.getAttribute('aria-label'))
+  })
+
+  it('both seek controls are keyboard-operable buttons', () => {
+    render(<LocalVideoPlayer {...defaultProps} />)
+    expect(screen.getByRole('button', { name: 'Rewind 10 seconds' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Fast-forward 10 seconds' })).toBeInTheDocument()
+  })
+
+  it('rewind button has data-testid "rewind-button"', () => {
+    render(<LocalVideoPlayer {...defaultProps} />)
+    expect(screen.getByTestId('rewind-button')).toBeInTheDocument()
+  })
+
+  it('fast-forward button has data-testid "fastforward-button"', () => {
+    render(<LocalVideoPlayer {...defaultProps} />)
+    expect(screen.getByTestId('fastforward-button')).toBeInTheDocument()
   })
 })

--- a/tests/e2e/player.spec.ts
+++ b/tests/e2e/player.spec.ts
@@ -98,4 +98,33 @@ test.describe('Player + mini-player workflow', () => {
     expect(consoleErrors).toEqual([])
     expect(pageErrors).toEqual([])
   })
+
+  test('seek controls are visible, distinct, and clickable in mini-player', async ({ page }) => {
+    test.setTimeout(60_000)
+
+    await mockPlayerRoutes(page)
+
+    const player = new PlayerPage(page)
+    await player.navigateTo(MOCK_VIDEO.id)
+    await player.assertLoaded()
+
+    await player.clickPlay()
+    await player.assertMiniPlayerOpen()
+
+    const rewindBtn = page.getByTestId('rewind-button')
+    const fastforwardBtn = page.getByTestId('fastforward-button')
+
+    await expect(rewindBtn).toBeVisible()
+    await expect(fastforwardBtn).toBeVisible()
+
+    const rewindLabel = await rewindBtn.getAttribute('aria-label')
+    const fastforwardLabel = await fastforwardBtn.getAttribute('aria-label')
+
+    expect(rewindLabel).not.toBe(fastforwardLabel)
+    expect(rewindLabel).toBeTruthy()
+    expect(fastforwardLabel).toBeTruthy()
+
+    await rewindBtn.click()
+    await fastforwardBtn.click()
+  })
 })


### PR DESCRIPTION
Closes #178

## Changes

- **Distinct icons**: Replaced near-identical circular-arrow SVGs with clearly distinguishable double-chevron icons:
  - Rewind: double left-chevron (⏪-style, two left-pointing triangles)
  - Fast-forward: double right-chevron (⏩-style, two right-pointing triangles)
- **Stable test ids**: `data-testid="rewind-button"` and `data-testid="fastforward-button"`
- **Unambiguous labels**: `aria-label="Rewind 10 seconds"` and `aria-label="Fast-forward 10 seconds"`
- **Seek behaviour**: Rewind clamps to 0, fast-forward clamps to duration

## Acceptance criteria

- [x] Rewind control is clearly distinguishable from fast-forward (opposite double-chevrons)
- [x] Rewind seeks backward 10 s with lower-bound clamping to 0
- [x] Fast-forward seeks forward 10 s with upper-bound clamping to duration
- [x] Both controls retain unambiguous accessible names and keyboard operability (`<button>`)
- [x] New unit tests covering seek behaviour and distinguishability pass (20 tests total)
- [x] New E2E test validates both controls visible, distinct labels, and clickable
- [x] All existing tests still pass

## Test coverage added

- `LocalVideoPlayer seek behavior` — 4 tests (backward seek, forward seek, both boundary clamps)
- `LocalVideoPlayer seek controls accessibility` — 6 tests (aria-labels, role=button, distinct labels, testids)
- `player.spec.ts` — E2E regression: seek controls visible + clickable in mini-player