### PR TITLE
feat: Word Definition Overwrite Warning (closes #193)

### DIFF
--- a/src/components/ConfirmationModal.tsx
+++ b/src/components/ConfirmationModal.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+interface ConfirmationModalProps {
+  isOpen: boolean;
+  word: string;
+  onCancel: () => void;
+  onConfirm: () => void;
+  isConfirming: boolean;
+}
+
+export default function ConfirmationModal({
+  isOpen,
+  word,
+  onCancel,
+  onConfirm,
+  isConfirming,
+}: ConfirmationModalProps) {
+  if (!isOpen) return null;
+
+  return (
+    <div
+      data-testid="confirmation-modal"
+      className="fixed inset-0 bg-black/40 backdrop-blur-[6px] z-50 flex items-center justify-center"
+      onClick={onCancel}
+    >
+      <div
+        className="bg-surface-container-lowest/90 dark:bg-slate-900/90 backdrop-blur-[24px] rounded-xl shadow-2xl border border-outline-variant/20 dark:border-slate-700/30 w-full max-w-md p-8 transition-all duration-300"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center gap-4 mb-4">
+          <div className="w-10 h-10 rounded-full bg-yellow-100 dark:bg-yellow-900 flex items-center justify-center flex-shrink-0">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              className="h-5 w-5 text-yellow-600 dark:text-yellow-400"
+              viewBox="0 0 20 20"
+              fill="currentColor"
+            >
+              <path
+                fillRule="evenodd"
+                d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z"
+                clipRule="evenodd"
+              />
+            </svg>
+          </div>
+          <h2 className="font-headline text-2xl font-extrabold text-on-surface dark:text-slate-100">
+            Overwrite Definition?
+          </h2>
+        </div>
+
+        <p className="text-on-surface-variant dark:text-slate-400 mb-6">
+          &quot;{word}&quot; already has a saved definition. Do you want to
+          replace it with a new AI-generated one?
+        </p>
+
+        <div className="flex justify-end gap-3">
+          <button
+            data-testid="confirmation-cancel"
+            onClick={onCancel}
+            className="px-6 py-3 bg-surface-container-high dark:bg-slate-800 text-on-surface-variant dark:text-slate-400 rounded-xl font-bold hover:bg-surface-container-highest dark:hover:bg-slate-700 transition-colors"
+          >
+            Keep Current
+          </button>
+          <button
+            data-testid="confirmation-confirm"
+            onClick={onConfirm}
+            disabled={isConfirming}
+            className="bg-gradient-to-br from-blue-600 to-blue-500 text-white rounded-xl font-bold px-6 py-3 hover:scale-[1.02] transition-transform disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:scale-100"
+          >
+            {isConfirming ? "Generating..." : "Generate New"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/WordSidebar.tsx
+++ b/src/components/WordSidebar.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState } from "react";
 import { VocabInfo } from "@/lib/vocabulary";
 import { useUpdateWordDefinition } from "@/hooks/useVocabulary";
+import ConfirmationModal from "./ConfirmationModal";
 
 interface WordSidebarProps {
   word: string;
@@ -53,6 +54,8 @@ export default function WordSidebar({
   const [isLoadingDefinition, setIsLoadingDefinition] = useState(false);
   const [definitionError, setDefinitionError] = useState<string | null>(null);
   const [isSavingDefinition, setIsSavingDefinition] = useState(false);
+  const [showOverwriteConfirm, setShowOverwriteConfirm] = useState(false);
+  const [isConfirmingOverwrite, setIsConfirmingOverwrite] = useState(false);
 
   // Derived state: reset when the selected word changes
   if (word !== lastWord) {
@@ -80,9 +83,33 @@ export default function WordSidebar({
     onStatusChange(word, nextStatus);
   }
 
+  function handleClickGenerateDefinition() {
+    // Check if word already has a saved definition
+    if (vocabEntry?.definition) {
+      setShowOverwriteConfirm(true);
+    } else {
+      handleGenerateDefinition();
+    }
+  }
+
+  function handleCancelOverwrite() {
+    setShowOverwriteConfirm(false);
+  }
+
+  async function handleConfirmOverwrite() {
+    setIsConfirmingOverwrite(true);
+    try {
+      await handleGenerateDefinition();
+    } finally {
+      setIsConfirmingOverwrite(false);
+      setShowOverwriteConfirm(false);
+    }
+  }
+
   async function handleGenerateDefinition() {
     setIsLoadingDefinition(true);
     setDefinitionError(null);
+    setGeneratedDefinition(null);
     try {
       const body: Record<string, unknown> = { word, contextSentence };
       if (transcriptContext) {
@@ -237,7 +264,7 @@ export default function WordSidebar({
           {/* AI Definition Section */}
           <div className="flex flex-col gap-3">
             <button
-              onClick={handleGenerateDefinition}
+              onClick={handleClickGenerateDefinition}
               disabled={isLoadingDefinition}
               data-testid="generate-definition-btn"
               className="w-full py-2 rounded-xl text-sm font-bold transition-opacity bg-blue-100 text-blue-700 hover:bg-blue-200 disabled:opacity-50"
@@ -301,6 +328,15 @@ export default function WordSidebar({
           </div>
         </div>
       </div>
+
+      {/* Overwrite Confirmation Modal */}
+      <ConfirmationModal
+        isOpen={showOverwriteConfirm}
+        word={word}
+        onCancel={handleCancelOverwrite}
+        onConfirm={handleConfirmOverwrite}
+        isConfirming={isConfirmingOverwrite}
+      />
     </>
   );
 }

--- a/src/components/__tests__/ConfirmationModal.test.tsx
+++ b/src/components/__tests__/ConfirmationModal.test.tsx
@@ -1,0 +1,140 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import ConfirmationModal from "../ConfirmationModal";
+
+describe("ConfirmationModal", () => {
+  it("does not render when isOpen is false", () => {
+    const { container } = render(
+      <ConfirmationModal
+        isOpen={false}
+        word="serendipity"
+        onCancel={jest.fn()}
+        onConfirm={jest.fn()}
+        isConfirming={false}
+      />
+    );
+    expect(
+      container.querySelector('[data-testid="confirmation-modal"]')
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders when isOpen is true", () => {
+    render(
+      <ConfirmationModal
+        isOpen={true}
+        word="serendipity"
+        onCancel={jest.fn()}
+        onConfirm={jest.fn()}
+        isConfirming={false}
+      />
+    );
+    expect(screen.getByTestId("confirmation-modal")).toBeInTheDocument();
+  });
+
+  it("displays the word in the confirmation message", () => {
+    render(
+      <ConfirmationModal
+        isOpen={true}
+        word="serendipity"
+        onCancel={jest.fn()}
+        onConfirm={jest.fn()}
+        isConfirming={false}
+      />
+    );
+    expect(
+      screen.getByText(/serendipity.*already has a saved definition/)
+    ).toBeInTheDocument();
+  });
+
+  it("calls onCancel when cancel button is clicked", () => {
+    const onCancel = jest.fn();
+    render(
+      <ConfirmationModal
+        isOpen={true}
+        word="serendipity"
+        onCancel={onCancel}
+        onConfirm={jest.fn()}
+        isConfirming={false}
+      />
+    );
+    fireEvent.click(screen.getByTestId("confirmation-cancel"));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onConfirm when confirm button is clicked", () => {
+    const onConfirm = jest.fn();
+    render(
+      <ConfirmationModal
+        isOpen={true}
+        word="serendipity"
+        onCancel={jest.fn()}
+        onConfirm={onConfirm}
+        isConfirming={false}
+      />
+    );
+    fireEvent.click(screen.getByTestId("confirmation-confirm"));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onCancel when backdrop is clicked", () => {
+    const onCancel = jest.fn();
+    render(
+      <ConfirmationModal
+        isOpen={true}
+        word="serendipity"
+        onCancel={onCancel}
+        onConfirm={jest.fn()}
+        isConfirming={false}
+      />
+    );
+    fireEvent.click(screen.getByTestId("confirmation-modal"));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables confirm button when isConfirming is true", () => {
+    render(
+      <ConfirmationModal
+        isOpen={true}
+        word="serendipity"
+        onCancel={jest.fn()}
+        onConfirm={jest.fn()}
+        isConfirming={true}
+      />
+    );
+    const confirmBtn = screen.getByTestId("confirmation-confirm");
+    expect(confirmBtn).toBeDisabled();
+    expect(confirmBtn).toHaveTextContent("Generating...");
+  });
+
+  it('shows "Generate New" when not confirming', () => {
+    render(
+      <ConfirmationModal
+        isOpen={true}
+        word="serendipity"
+        onCancel={jest.fn()}
+        onConfirm={jest.fn()}
+        isConfirming={false}
+      />
+    );
+    expect(screen.getByTestId("confirmation-confirm")).toHaveTextContent(
+      "Generate New"
+    );
+  });
+
+  it("prevents event bubbling when inner content is clicked", () => {
+    const onCancel = jest.fn();
+    const { container } = render(
+      <ConfirmationModal
+        isOpen={true}
+        word="serendipity"
+        onCancel={onCancel}
+        onConfirm={jest.fn()}
+        isConfirming={false}
+      />
+    );
+    const innerDiv = container.querySelector(".bg-surface-container-lowest");
+    if (innerDiv) {
+      fireEvent.click(innerDiv);
+    }
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/__tests__/WordSidebar.test.tsx
+++ b/src/components/__tests__/WordSidebar.test.tsx
@@ -1,4 +1,10 @@
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  cleanup,
+} from "@testing-library/react";
 import WordSidebar from "../WordSidebar";
 import { VocabInfo } from "@/lib/vocabulary";
 import { useUpdateWordDefinition } from "@/hooks/useVocabulary";
@@ -26,6 +32,14 @@ const mockVocabEntry: VocabInfo = {
 global.fetch = jest.fn();
 
 describe("WordSidebar", () => {
+  beforeEach(() => {
+    (global.fetch as jest.Mock).mockClear();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
   it("renders the selected word", () => {
     render(
       <WordSidebar
@@ -229,7 +243,7 @@ describe("WordSidebar", () => {
       <WordSidebar
         word="serendipity"
         contextSentence="It was pure serendipity that we met"
-        vocabEntry={mockVocabEntry}
+        vocabEntry={undefined}
         onClose={jest.fn()}
       />
     );
@@ -260,7 +274,7 @@ describe("WordSidebar", () => {
       <WordSidebar
         word="serendipity"
         contextSentence="It was pure serendipity that we met"
-        vocabEntry={mockVocabEntry}
+        vocabEntry={undefined}
         onClose={jest.fn()}
       />
     );
@@ -285,7 +299,7 @@ describe("WordSidebar", () => {
       <WordSidebar
         word="serendipity"
         contextSentence="It was pure serendipity that we met"
-        vocabEntry={mockVocabEntry}
+        vocabEntry={undefined}
         onClose={jest.fn()}
       />
     );
@@ -319,7 +333,7 @@ describe("WordSidebar", () => {
       <WordSidebar
         word="serendipity"
         contextSentence="It was pure serendipity that we met"
-        vocabEntry={mockVocabEntry}
+        vocabEntry={undefined}
         onClose={jest.fn()}
       />
     );
@@ -356,7 +370,7 @@ describe("WordSidebar", () => {
           "It was pure serendipity that we met",
           "Fate brought us together.",
         ]}
-        vocabEntry={mockVocabEntry}
+        vocabEntry={undefined}
         onClose={jest.fn()}
       />
     );
@@ -431,6 +445,12 @@ describe("WordSidebar", () => {
     fireEvent.click(screen.getByTestId("generate-definition-btn"));
 
     await waitFor(() => {
+      expect(screen.getByTestId("confirmation-modal")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId("confirmation-confirm"));
+
+    await waitFor(() => {
       expect(screen.getByTestId("save-definition-btn")).toBeInTheDocument();
     });
 
@@ -456,5 +476,129 @@ describe("WordSidebar", () => {
 
     expect(screen.getByTestId("generated-definition")).toBeInTheDocument();
     expect(screen.getByTestId("save-definition-btn")).toBeInTheDocument();
+  });
+
+  it("shows overwrite confirmation modal when clicking Generate with existing definition", async () => {
+    render(
+      <WordSidebar
+        word="serendipity"
+        contextSentence="It was pure serendipity that we met"
+        vocabEntry={mockVocabEntry}
+        onClose={jest.fn()}
+      />
+    );
+
+    expect(screen.queryByTestId("confirmation-modal")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("generate-definition-btn"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("confirmation-modal")).toBeInTheDocument();
+    });
+  });
+
+  it("does not show confirmation modal when clicking Generate with no existing definition", async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        definition: "First AI definition",
+      }),
+    });
+
+    render(
+      <WordSidebar
+        word="hello"
+        contextSentence="Hello there"
+        vocabEntry={undefined}
+        onClose={jest.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId("generate-definition-btn"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("generated-definition")).toBeInTheDocument();
+    });
+
+    expect(screen.queryByTestId("confirmation-modal")).not.toBeInTheDocument();
+  });
+
+  it("closes confirmation modal when cancel button is clicked", async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        definition: "Should not be used",
+      }),
+    });
+
+    render(
+      <WordSidebar
+        word="serendipity"
+        contextSentence="It was pure serendipity that we met"
+        vocabEntry={mockVocabEntry}
+        onClose={jest.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId("generate-definition-btn"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("confirmation-modal")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId("confirmation-cancel"));
+
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId("confirmation-modal")
+      ).not.toBeInTheDocument();
+    });
+
+    // Verify generation did not start
+    expect(
+      (global.fetch as jest.Mock).mock.calls.filter(
+        (call: unknown[]) => (call as string[])[0] === "/api/dictionary/define"
+      )
+    ).toHaveLength(0);
+  });
+
+  it("generates new definition when confirming overwrite", async () => {
+    (global.fetch as jest.Mock).mockReset();
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        definition: "New AI definition replacing old one",
+        partOfSpeech: "noun",
+      }),
+    });
+
+    render(
+      <WordSidebar
+        word="serendipity"
+        contextSentence="It was pure serendipity that we met"
+        vocabEntry={mockVocabEntry}
+        onClose={jest.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId("generate-definition-btn"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("confirmation-modal")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId("confirmation-confirm"));
+
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId("confirmation-modal")
+      ).not.toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("New AI definition replacing old one")
+      ).toBeInTheDocument();
+    });
   });
 });


### PR DESCRIPTION
## Summary
Adds professional overwrite protection to the word definition feature. When a user attempts to generate a new AI definition for a word that already has a saved definition, a confirmation modal appears asking whether they want to keep the current definition or proceed with generating a new one.

## Changes
- **ConfirmationModal** (new component): Centered modal with warning icon, friendly message, and cancel/confirm buttons
- **WordSidebar** (updated): Checks for existing definition before generation; shows modal if definition exists
- **Logic**: Only proceeds with generation after user confirmation; cancel dismisses modal without changes

## Behaviors
- ✅ Word sidebar correctly checks for existing definition before clicking 'Generate'
- ✅ Overwrite warning modal appears with word name in message
- ✅ User can cancel to keep their old definition
- ✅ User can confirm to proceed with new AI generation
- ✅ Properly handles async state during generation

## Testing
- 9 new ConfirmationModal tests (all passing)
- 4 new WordSidebar integration tests for overwrite flow (all passing)
- Updated 5 existing WordSidebar tests to accommodate new modal behavior
- All 353 tests in full suite passing
- Production build succeeds

Closes #193